### PR TITLE
Add /forget command and hyperspell_forget tool for memory deletion

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -234,6 +234,24 @@ export class HyperspellClient {
     return raw
   }
 
+  async deleteMemory(
+    resourceId: string,
+    source: HyperspellSource,
+  ): Promise<{ success: boolean; chunksDeleted: number }> {
+    log.debugRequest("memories.delete", { resourceId, source })
+
+    const response = await this.client.memories.delete(resourceId, { source })
+
+    log.debugResponse("memories.delete", {
+      success: response.success,
+      chunksDeleted: response.chunks_deleted,
+    })
+    return {
+      success: response.success,
+      chunksDeleted: response.chunks_deleted,
+    }
+  }
+
   async listConnections(): Promise<Connection[]> {
     log.debugRequest("connections.list", {})
 

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -1,119 +1,188 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { getWorkspaceDir } from "../config.ts"
-import { log } from "../logger.ts"
-import { syncAllMemoryFiles } from "../sync/markdown.ts"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig, HyperspellSource } from "../config.ts";
+import { getWorkspaceDir } from "../config.ts";
+import { log } from "../logger.ts";
+import { deleteLocalMemoryFile, syncAllMemoryFiles } from "../sync/markdown.ts";
 
 function truncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text
-  return `${text.slice(0, maxLength)}…`
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength)}…`;
 }
 
 function formatScore(score: number | null): string {
-  if (score === null) return ""
-  return ` (${Math.round(score * 100)}%)`
+	if (score === null) return "";
+	return ` (${Math.round(score * 100)}%)`;
 }
 
 export function registerCommands(
-  api: OpenClawPluginApi,
-  client: HyperspellClient,
-  _cfg: HyperspellConfig,
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
 ): void {
-  // /getcontext <query> - Search memories and show summaries
-  api.registerCommand({
-    name: "getcontext",
-    description: "Search your memories for relevant context",
-    acceptsArgs: true,
-    requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
-      const query = ctx.args?.trim()
-      if (!query) {
-        return { text: "Usage: /getcontext <search query>" }
-      }
+	// /getcontext <query> - Search memories and show summaries
+	api.registerCommand({
+		name: "getcontext",
+		description: "Search your memories for relevant context",
+		acceptsArgs: true,
+		requireAuth: true,
+		handler: async (ctx: { args?: string }) => {
+			const query = ctx.args?.trim();
+			if (!query) {
+				return { text: "Usage: /getcontext <search query>" };
+			}
 
-      log.debug(`/getcontext command: "${query}"`)
+			log.debug(`/getcontext command: "${query}"`);
 
-      try {
-        const results = await client.search(query, { limit: 5 })
+			try {
+				const results = await client.search(query, { limit: 5 });
 
-        if (results.length === 0) {
-          return { text: `No memories found for: "${query}"` }
-        }
+				if (results.length === 0) {
+					return { text: `No memories found for: "${query}"` };
+				}
 
-        const lines = results.map((r, i) => {
-          const title = r.title ? truncate(r.title, 60) : `[${r.source}]`
-          const score = formatScore(r.score)
-          return `${i + 1}. ${title}${score}`
-        })
+				const lines = results.map((r, i) => {
+					const title = r.title ? truncate(r.title, 60) : `[${r.source}]`;
+					const score = formatScore(r.score);
+					return `${i + 1}. ${title}${score}`;
+				});
 
-        return {
-          text: `Found ${results.length} memories:\n\n${lines.join("\n")}`,
-        }
-      } catch (err) {
-        log.error("/getcontext failed", err)
-        return { text: "Failed to search memories. Check logs for details." }
-      }
-    },
-  })
+				return {
+					text: `Found ${results.length} memories:\n\n${lines.join("\n")}`,
+				};
+			} catch (err) {
+				log.error("/getcontext failed", err);
+				return { text: "Failed to search memories. Check logs for details." };
+			}
+		},
+	});
 
-  // /remember <text> - Add a new memory
-  api.registerCommand({
-    name: "remember",
-    description: "Save something to memory",
-    acceptsArgs: true,
-    requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
-      const text = ctx.args?.trim()
-      if (!text) {
-        return { text: "Usage: /remember <text to remember>" }
-      }
+	// /remember <text> - Add a new memory
+	api.registerCommand({
+		name: "remember",
+		description: "Save something to memory",
+		acceptsArgs: true,
+		requireAuth: true,
+		handler: async (ctx: { args?: string }) => {
+			const text = ctx.args?.trim();
+			if (!text) {
+				return { text: "Usage: /remember <text to remember>" };
+			}
 
-      log.debug(`/remember command: "${truncate(text, 50)}"`)
+			log.debug(`/remember command: "${truncate(text, 50)}"`);
 
-      try {
-        await client.addMemory(text, {
-          metadata: { source: "openclaw_command" },
-        })
+			try {
+				await client.addMemory(text, {
+					metadata: { source: "openclaw_command" },
+				});
 
-        const preview = truncate(text, 60)
-        return { text: `Remembered: "${preview}"` }
-      } catch (err) {
-        log.error("/remember failed", err)
-        return { text: "Failed to save memory. Check logs for details." }
-      }
-    },
-  })
+				const preview = truncate(text, 60);
+				return { text: `Remembered: "${preview}"` };
+			} catch (err) {
+				log.error("/remember failed", err);
+				return { text: "Failed to save memory. Check logs for details." };
+			}
+		},
+	});
 
-  // /sync - Manually sync memory files
-  api.registerCommand({
-    name: "sync",
-    description: "Sync memory/*.md files with Hyperspell",
-    acceptsArgs: false,
-    requireAuth: true,
-    handler: async () => {
-      log.debug("/sync command")
+	// /forget <query> - Search and delete matching memories
+	api.registerCommand({
+		name: "forget",
+		description: "Find and delete memories matching a query",
+		acceptsArgs: true,
+		requireAuth: true,
+		handler: async (ctx: { args?: string }) => {
+			const query = ctx.args?.trim();
+			if (!query) {
+				return { text: "Usage: /forget <search query>" };
+			}
 
-      try {
-        const workspaceDir = getWorkspaceDir()
-        const result = await syncAllMemoryFiles(client, workspaceDir)
+			log.debug(`/forget command: "${query}"`);
 
-        if (result.synced === 0 && result.failed === 0) {
-          return { text: "No memory files found in memory/ directory." }
-        }
+			try {
+				const response = await client.searchRaw(query, { limit: 5 });
+				const documents = (response.documents ?? []) as Array<{
+					source: string;
+					resource_id: string;
+					score?: number;
+					title?: string;
+				}>;
 
-        if (result.failed > 0) {
-          const errors = result.errors.map((e) => `  • ${e}`).join("\n")
-          return {
-            text: `Synced ${result.synced} files, ${result.failed} failed:\n${errors}`,
-          }
-        }
+				if (documents.length === 0) {
+					return { text: `No memories found matching: "${query}"` };
+				}
 
-        return { text: `Synced ${result.synced} memory file(s) to Hyperspell.` }
-      } catch (err) {
-        log.error("/sync failed", err)
-        return { text: "Failed to sync memory files. Check logs for details." }
-      }
-    },
-  })
+				const workspaceDir = getWorkspaceDir();
+				const results: string[] = [];
+				let deleted = 0;
+
+				for (const doc of documents) {
+					try {
+						await client.deleteMemory(
+							doc.resource_id,
+							doc.source as HyperspellSource,
+						);
+
+						const localDeleted = deleteLocalMemoryFile(
+							workspaceDir,
+							doc.resource_id,
+						);
+						const localNote = localDeleted ? " + local file" : "";
+						const title = doc.title
+							? truncate(doc.title, 50)
+							: `[${doc.source}]`;
+						results.push(`  Deleted: ${title}${localNote}`);
+						deleted++;
+					} catch (err) {
+						const title = doc.title
+							? truncate(doc.title, 50)
+							: `[${doc.source}]`;
+						const msg = err instanceof Error ? err.message : String(err);
+						results.push(`  Failed: ${title} - ${msg}`);
+					}
+				}
+
+				return {
+					text: `Forgot ${deleted}/${documents.length} memories:\n${results.join("\n")}`,
+				};
+			} catch (err) {
+				log.error("/forget failed", err);
+				return { text: "Failed to delete memories. Check logs for details." };
+			}
+		},
+	});
+
+	// /sync - Manually sync memory files
+	api.registerCommand({
+		name: "sync",
+		description: "Sync memory/*.md files with Hyperspell",
+		acceptsArgs: false,
+		requireAuth: true,
+		handler: async () => {
+			log.debug("/sync command");
+
+			try {
+				const workspaceDir = getWorkspaceDir();
+				const result = await syncAllMemoryFiles(client, workspaceDir);
+
+				if (result.synced === 0 && result.failed === 0) {
+					return { text: "No memory files found in memory/ directory." };
+				}
+
+				if (result.failed > 0) {
+					const errors = result.errors.map((e) => `  • ${e}`).join("\n");
+					return {
+						text: `Synced ${result.synced} files, ${result.failed} failed:\n${errors}`,
+					};
+				}
+
+				return {
+					text: `Synced ${result.synced} memory file(s) to Hyperspell.`,
+				};
+			} catch (err) {
+				log.error("/sync failed", err);
+				return { text: "Failed to sync memory files. Check logs for details." };
+			}
+		},
+	});
 }

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -118,10 +118,18 @@ export function registerCommands(
 
 				for (const doc of documents) {
 					try {
-						await client.deleteMemory(
+						const deleteResult = await client.deleteMemory(
 							doc.resource_id,
 							doc.source as HyperspellSource,
 						);
+
+						if (!deleteResult.success) {
+							const title = doc.title
+								? truncate(doc.title, 50)
+								: `[${doc.source}]`;
+							results.push(`  Failed: ${title} - API returned success: false`);
+							continue;
+						}
 
 						const localDeleted = deleteLocalMemoryFile(
 							workspaceDir,

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -27,7 +27,11 @@ export function buildFileSyncHandler(client: HyperspellClient, _cfg: HyperspellC
     try {
       const result = await syncMarkdownFile(client, filePath)
       if (result.success) {
-        log.info(`Synced ${fileName} -> ${result.resourceId}`)
+        if (result.warning) {
+          log.warn(`Synced with warning: ${fileName} — ${result.warning}`)
+        } else {
+          log.info(`Synced ${fileName} -> ${result.resourceId}`)
+        }
       } else {
         log.error(`Failed to sync ${fileName}: ${result.error}`)
       }

--- a/index.ts
+++ b/index.ts
@@ -130,8 +130,14 @@ export default {
 
 				// Sync memories on startup if enabled
 				if (cfg.syncMemories) {
-					const workspaceDir = getWorkspaceDir();
-					await syncMemoriesOnStartup(client, workspaceDir);
+					try {
+						const workspaceDir = getWorkspaceDir();
+						await syncMemoriesOnStartup(client, workspaceDir);
+					} catch (err) {
+						api.logger.warn(
+							`hyperspell: memory sync on startup failed: ${err instanceof Error ? err.message : String(err)}`,
+						);
+					}
 				}
 			},
 			stop: () => {

--- a/index.ts
+++ b/index.ts
@@ -1,113 +1,142 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import { HyperspellClient } from "./client.ts"
-import { registerCommands } from "./commands/slash.ts"
-import { registerCliCommands } from "./commands/setup.ts"
-import { parseConfig, hyperspellConfigSchema, getWorkspaceDir } from "./config.ts"
-import { buildAutoContextHandler } from "./hooks/auto-context.ts"
-import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
-import { initLogger } from "./logger.ts"
-import { registerRememberTool } from "./tools/remember.ts"
-import { registerSearchTool } from "./tools/search.ts"
-import { registerNetworkTools } from "./graph/index.ts"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { HyperspellClient } from "./client.ts";
+import { registerCliCommands } from "./commands/setup.ts";
+import { registerCommands } from "./commands/slash.ts";
+import {
+	getWorkspaceDir,
+	hyperspellConfigSchema,
+	parseConfig,
+} from "./config.ts";
+import { registerNetworkTools } from "./graph/index.ts";
+import { buildAutoContextHandler } from "./hooks/auto-context.ts";
+import {
+	buildFileSyncHandler,
+	syncMemoriesOnStartup,
+} from "./hooks/memory-sync.ts";
+import { initLogger } from "./logger.ts";
+import { registerForgetTool } from "./tools/forget.ts";
+import { registerRememberTool } from "./tools/remember.ts";
+import { registerSearchTool } from "./tools/search.ts";
 
 export default {
-  id: "openclaw-hyperspell",
-  name: "Hyperspell",
-  description: "Hyperspell gives your Molty context and memory from all your existing data",
-  kind: "memory" as const,
-  configSchema: hyperspellConfigSchema,
+	id: "openclaw-hyperspell",
+	name: "Hyperspell",
+	description:
+		"Hyperspell gives your Molty context and memory from all your existing data",
+	kind: "memory" as const,
+	configSchema: hyperspellConfigSchema,
 
-  register(api: OpenClawPluginApi) {
-    // Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
-    api.registerCli(
-      (ctx) => {
-        registerCliCommands(ctx.program, api.pluginConfig)
-      },
-      { commands: ["openclaw-hyperspell"] },
-    )
+	register(api: OpenClawPluginApi) {
+		// Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
+		api.registerCli(
+			(ctx) => {
+				registerCliCommands(ctx.program, api.pluginConfig);
+			},
+			{ commands: ["openclaw-hyperspell"] },
+		);
 
-    // Check if configured
-    const rawConfig = api.pluginConfig as Record<string, unknown> | undefined
-    const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY
+		// Check if configured
+		const rawConfig = api.pluginConfig as Record<string, unknown> | undefined;
+		const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY;
 
-    if (!hasConfig) {
-      api.logger.info("hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'")
-      // Still register slash commands so they show up, but they'll return an error
-      api.registerCommand({
-        name: "getcontext",
-        description: "Search your memories for relevant context",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "remember",
-        description: "Save something to memory",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "sync",
-        description: "Sync memory/*.md files with Hyperspell",
-        acceptsArgs: false,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      return
-    }
+		if (!hasConfig) {
+			api.logger.info(
+				"hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'",
+			);
+			// Still register slash commands so they show up, but they'll return an error
+			api.registerCommand({
+				name: "getcontext",
+				description: "Search your memories for relevant context",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			api.registerCommand({
+				name: "remember",
+				description: "Save something to memory",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			api.registerCommand({
+				name: "forget",
+				description: "Find and delete memories matching a query",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			api.registerCommand({
+				name: "sync",
+				description: "Sync memory/*.md files with Hyperspell",
+				acceptsArgs: false,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			return;
+		}
 
-    const cfg = parseConfig(api.pluginConfig)
+		const cfg = parseConfig(api.pluginConfig);
 
-    initLogger(api.logger, cfg.debug)
+		initLogger(api.logger, cfg.debug);
 
-    const client = new HyperspellClient(cfg)
+		const client = new HyperspellClient(cfg);
 
-    // Register AI tools
-    registerSearchTool(api, client, cfg)
-    registerRememberTool(api, client, cfg)
+		// Register AI tools
+		registerSearchTool(api, client, cfg);
+		registerRememberTool(api, client, cfg);
+		registerForgetTool(api, client, cfg);
 
-    // Register auto-context hook
-    if (cfg.autoContext) {
-      const autoContextHandler = buildAutoContextHandler(client, cfg)
-      api.on("before_agent_start", autoContextHandler)
-    }
+		// Register auto-context hook
+		if (cfg.autoContext) {
+			const autoContextHandler = buildAutoContextHandler(client, cfg);
+			api.on("before_agent_start", autoContextHandler);
+		}
 
-    // Register memory sync hook
-    if (cfg.syncMemories) {
-      const fileSyncHandler = buildFileSyncHandler(client, cfg)
-      api.on("file_changed", fileSyncHandler)
-    }
+		// Register memory sync hook
+		if (cfg.syncMemories) {
+			const fileSyncHandler = buildFileSyncHandler(client, cfg);
+			api.on("file_changed", fileSyncHandler);
+		}
 
-    // Register memory network tools
-    if (cfg.knowledgeGraph.enabled) {
-      registerNetworkTools(api, client, cfg)
-    }
+		// Register memory network tools
+		if (cfg.knowledgeGraph.enabled) {
+			registerNetworkTools(api, client, cfg);
+		}
 
-    // Register slash commands
-    registerCommands(api, client, cfg)
+		// Register slash commands
+		registerCommands(api, client, cfg);
 
-    // Register service for lifecycle management
-    api.registerService({
-      id: "openclaw-hyperspell",
-      start: async () => {
-        api.logger.info("hyperspell: connected")
+		// Register service for lifecycle management
+		api.registerService({
+			id: "openclaw-hyperspell",
+			start: async () => {
+				api.logger.info("hyperspell: connected");
 
-        // Sync memories on startup if enabled
-        if (cfg.syncMemories) {
-          const workspaceDir = getWorkspaceDir()
-          await syncMemoriesOnStartup(client, workspaceDir)
-        }
-      },
-      stop: () => {
-        api.logger.info("hyperspell: stopped")
-      },
-    })
-  },
-}
+				// Sync memories on startup if enabled
+				if (cfg.syncMemories) {
+					const workspaceDir = getWorkspaceDir();
+					await syncMemoriesOnStartup(client, workspaceDir);
+				}
+			},
+			stop: () => {
+				api.logger.info("hyperspell: stopped");
+			},
+		});
+	},
+};

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -56,9 +56,10 @@ function parseFrontmatter(content: string): {
  * in Knowledge Graph entity files (source_memories, relationships).
  */
 function serializeFrontmatter(frontmatter: Record<string, string>): string {
-	const lines = Object.entries(frontmatter).map(
-		([key, value]) => `${key}: ${value}`,
-	);
+	const lines = Object.entries(frontmatter).map(([key, value]) => {
+		const safe = value.replace(/\n/g, " ").replace(/\r/g, "");
+		return `${key}: ${safe}`;
+	});
 	return `---\n${lines.join("\n")}\n---\n`;
 }
 
@@ -167,7 +168,7 @@ export async function syncMarkdownFile(
 			log.warn(
 				`Sync of ${filePath} succeeded but API returned no resourceId — file is not linked to a remote resource`,
 			);
-			return { success: false, error: "No resourceId returned from API" };
+			return { success: true };
 		}
 
 		if (result.resourceId !== file.hyperspellId) {

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -142,7 +142,12 @@ export function getMemoryFiles(workspaceDir: string): string[] {
 export async function syncMarkdownFile(
 	client: HyperspellClient,
 	filePath: string,
-): Promise<{ success: boolean; resourceId?: string; error?: string }> {
+): Promise<{
+	success: boolean;
+	resourceId?: string;
+	error?: string;
+	warning?: string;
+}> {
 	const file = readMarkdownFile(filePath);
 	if (!file) {
 		return { success: false, error: "Failed to read file" };
@@ -168,7 +173,10 @@ export async function syncMarkdownFile(
 			log.warn(
 				`Sync of ${filePath} succeeded but API returned no resourceId — file is not linked to a remote resource`,
 			);
-			return { success: true };
+			return {
+				success: true,
+				warning: "No resourceId returned — file is not linked to remote resource",
+			};
 		}
 
 		if (result.resourceId !== file.hyperspellId) {
@@ -238,7 +246,11 @@ export async function syncAllMemoryFiles(
 		const result = await syncMarkdownFile(client, filePath);
 		if (result.success) {
 			synced++;
-			log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`);
+			if (result.warning) {
+				log.warn(`Synced with warning: ${path.basename(filePath)} — ${result.warning}`);
+			} else {
+				log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`);
+			}
 		} else {
 			failed++;
 			errors.push(`${path.basename(filePath)}: ${result.error}`);

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -1,183 +1,218 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import type { HyperspellClient } from "../client.ts"
-import { log } from "../logger.ts"
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { HyperspellClient } from "../client.ts";
+import { log } from "../logger.ts";
 
-const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/;
 
 interface MarkdownFile {
-  filePath: string
-  title: string
-  content: string
-  hyperspellId: string | null
+	filePath: string;
+	title: string;
+	content: string;
+	hyperspellId: string | null;
 }
 
 /**
  * Parse frontmatter from markdown content
  */
-function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
-  const match = content.match(FRONTMATTER_REGEX)
-  if (!match) {
-    return { frontmatter: {}, body: content }
-  }
+function parseFrontmatter(content: string): {
+	frontmatter: Record<string, string>;
+	body: string;
+} {
+	const match = content.match(FRONTMATTER_REGEX);
+	if (!match) {
+		return { frontmatter: {}, body: content };
+	}
 
-  const frontmatterText = match[1]
-  const body = content.slice(match[0].length)
-  const frontmatter: Record<string, string> = {}
+	const frontmatterText = match[1];
+	const body = content.slice(match[0].length);
+	const frontmatter: Record<string, string> = {};
 
-  for (const line of frontmatterText.split("\n")) {
-    const colonIndex = line.indexOf(":")
-    if (colonIndex > 0) {
-      const key = line.slice(0, colonIndex).trim()
-      const value = line.slice(colonIndex + 1).trim()
-      frontmatter[key] = value
-    }
-  }
+	for (const line of frontmatterText.split("\n")) {
+		const colonIndex = line.indexOf(":");
+		if (colonIndex > 0) {
+			const key = line.slice(0, colonIndex).trim();
+			const value = line.slice(colonIndex + 1).trim();
+			frontmatter[key] = value;
+		}
+	}
 
-  return { frontmatter, body }
+	return { frontmatter, body };
 }
 
 /**
  * Serialize frontmatter back to string
  */
 function serializeFrontmatter(frontmatter: Record<string, string>): string {
-  const lines = Object.entries(frontmatter).map(([key, value]) => `${key}: ${value}`)
-  return `---\n${lines.join("\n")}\n---\n`
+	const lines = Object.entries(frontmatter).map(
+		([key, value]) => `${key}: ${value}`,
+	);
+	return `---\n${lines.join("\n")}\n---\n`;
 }
 
 /**
  * Read a markdown file and parse its content
  */
 function readMarkdownFile(filePath: string): MarkdownFile | null {
-  try {
-    const content = fs.readFileSync(filePath, "utf-8")
-    const { frontmatter, body } = parseFrontmatter(content)
-    const title = frontmatter.title || path.basename(filePath, ".md")
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		const { frontmatter, body } = parseFrontmatter(content);
+		const title = frontmatter.title || path.basename(filePath, ".md");
 
-    return {
-      filePath,
-      title,
-      content: body.trim(),
-      hyperspellId: frontmatter.hyperspell_id || null,
-    }
-  } catch (err) {
-    log.error(`Failed to read markdown file: ${filePath}`, err)
-    return null
-  }
+		return {
+			filePath,
+			title,
+			content: body.trim(),
+			hyperspellId: frontmatter.hyperspell_id || null,
+		};
+	} catch (err) {
+		log.error(`Failed to read markdown file: ${filePath}`, err);
+		return null;
+	}
 }
 
 /**
  * Update the hyperspell_id in the frontmatter of a markdown file
  */
 function updateFrontmatterId(filePath: string, hyperspellId: string): void {
-  try {
-    const content = fs.readFileSync(filePath, "utf-8")
-    const { frontmatter, body } = parseFrontmatter(content)
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		const { frontmatter, body } = parseFrontmatter(content);
 
-    frontmatter.hyperspell_id = hyperspellId
+		frontmatter.hyperspell_id = hyperspellId;
 
-    const newContent = serializeFrontmatter(frontmatter) + body
-    fs.writeFileSync(filePath, newContent)
+		const newContent = serializeFrontmatter(frontmatter) + body;
+		fs.writeFileSync(filePath, newContent);
 
-    log.debug(`Updated frontmatter in ${filePath} with hyperspell_id: ${hyperspellId}`)
-  } catch (err) {
-    log.error(`Failed to update frontmatter in ${filePath}`, err)
-  }
+		log.debug(
+			`Updated frontmatter in ${filePath} with hyperspell_id: ${hyperspellId}`,
+		);
+	} catch (err) {
+		log.error(`Failed to update frontmatter in ${filePath}`, err);
+	}
 }
 
 /**
  * Get all markdown files from the memory directory, including subdirectories
  */
 export function getMemoryFiles(workspaceDir: string): string[] {
-  const memoryDir = path.join(workspaceDir, "memory")
+	const memoryDir = path.join(workspaceDir, "memory");
 
-  if (!fs.existsSync(memoryDir)) {
-    return []
-  }
+	if (!fs.existsSync(memoryDir)) {
+		return [];
+	}
 
-  const results: string[] = []
+	const results: string[] = [];
 
-  function walk(dir: string): void {
-    try {
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = path.join(dir, entry.name)
-        if (entry.isDirectory()) {
-          walk(fullPath)
-        } else if (entry.name.endsWith(".md")) {
-          results.push(fullPath)
-        }
-      }
-    } catch (err) {
-      log.error(`Failed to read directory: ${dir}`, err)
-    }
-  }
+	function walk(dir: string): void {
+		try {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const fullPath = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(fullPath);
+				} else if (entry.name.endsWith(".md")) {
+					results.push(fullPath);
+				}
+			}
+		} catch (err) {
+			log.error(`Failed to read directory: ${dir}`, err);
+		}
+	}
 
-  walk(memoryDir)
-  return results
+	walk(memoryDir);
+	return results;
 }
 
 /**
  * Sync a single markdown file to Hyperspell
  */
 export async function syncMarkdownFile(
-  client: HyperspellClient,
-  filePath: string,
+	client: HyperspellClient,
+	filePath: string,
 ): Promise<{ success: boolean; resourceId?: string; error?: string }> {
-  const file = readMarkdownFile(filePath)
-  if (!file) {
-    return { success: false, error: "Failed to read file" }
-  }
+	const file = readMarkdownFile(filePath);
+	if (!file) {
+		return { success: false, error: "Failed to read file" };
+	}
 
-  if (!file.content) {
-    return { success: false, error: "File has no content" }
-  }
+	if (!file.content) {
+		return { success: false, error: "File has no content" };
+	}
 
-  try {
-    const result = await client.addMemory(file.content, {
-      title: file.title,
-      resourceId: file.hyperspellId || undefined,
-      collection: "openclaw",
-      metadata: {
-        openclaw_source: "memory_sync",
-        file_path: filePath,
-      },
-    })
+	try {
+		const result = await client.addMemory(file.content, {
+			title: file.title,
+			resourceId: file.hyperspellId || undefined,
+			collection: "openclaw",
+			metadata: {
+				openclaw_source: "memory_sync",
+				file_path: filePath,
+			},
+		});
 
-    // Update frontmatter with new resource ID if it changed or was newly created
-    if (result.resourceId !== file.hyperspellId) {
-      updateFrontmatterId(filePath, result.resourceId)
-    }
+		// Update frontmatter with new resource ID if it changed or was newly created
+		if (result.resourceId !== file.hyperspellId) {
+			updateFrontmatterId(filePath, result.resourceId);
+		}
 
-    return { success: true, resourceId: result.resourceId }
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
-    log.error(`Failed to sync ${filePath}`, err)
-    return { success: false, error: errorMsg }
-  }
+		return { success: true, resourceId: result.resourceId };
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		log.error(`Failed to sync ${filePath}`, err);
+		return { success: false, error: errorMsg };
+	}
+}
+
+/**
+ * Find and delete a local markdown file by its hyperspell_id.
+ * Returns true if a file was found and deleted.
+ */
+export function deleteLocalMemoryFile(
+	workspaceDir: string,
+	hyperspellId: string,
+): boolean {
+	const files = getMemoryFiles(workspaceDir);
+
+	for (const filePath of files) {
+		try {
+			const content = fs.readFileSync(filePath, "utf-8");
+			const { frontmatter } = parseFrontmatter(content);
+
+			if (frontmatter.hyperspell_id === hyperspellId) {
+				fs.unlinkSync(filePath);
+				log.info(`Deleted local memory file: ${filePath}`);
+				return true;
+			}
+		} catch (err) {
+			log.error(`Failed to check file ${filePath}`, err);
+		}
+	}
+
+	return false;
 }
 
 /**
  * Sync all markdown files in the memory directory
  */
 export async function syncAllMemoryFiles(
-  client: HyperspellClient,
-  workspaceDir: string,
+	client: HyperspellClient,
+	workspaceDir: string,
 ): Promise<{ synced: number; failed: number; errors: string[] }> {
-  const files = getMemoryFiles(workspaceDir)
-  let synced = 0
-  let failed = 0
-  const errors: string[] = []
+	const files = getMemoryFiles(workspaceDir);
+	let synced = 0;
+	let failed = 0;
+	const errors: string[] = [];
 
-  for (const filePath of files) {
-    const result = await syncMarkdownFile(client, filePath)
-    if (result.success) {
-      synced++
-      log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`)
-    } else {
-      failed++
-      errors.push(`${path.basename(filePath)}: ${result.error}`)
-    }
-  }
+	for (const filePath of files) {
+		const result = await syncMarkdownFile(client, filePath);
+		if (result.success) {
+			synced++;
+			log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`);
+		} else {
+			failed++;
+			errors.push(`${path.basename(filePath)}: ${result.error}`);
+		}
+	}
 
-  return { synced, failed, errors }
+	return { synced, failed, errors };
 }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -32,7 +32,13 @@ function parseFrontmatter(content: string): {
 		const colonIndex = line.indexOf(":");
 		if (colonIndex > 0) {
 			const key = line.slice(0, colonIndex).trim();
-			const value = line.slice(colonIndex + 1).trim();
+			let value = line.slice(colonIndex + 1).trim();
+			if (
+				(value.startsWith('"') && value.endsWith('"')) ||
+				(value.startsWith("'") && value.endsWith("'"))
+			) {
+				value = value.slice(1, -1);
+			}
 			frontmatter[key] = value;
 		}
 	}
@@ -151,7 +157,7 @@ export async function syncMarkdownFile(
 		});
 
 		// Update frontmatter with new resource ID if it changed or was newly created
-		if (result.resourceId !== file.hyperspellId) {
+		if (result.resourceId && result.resourceId !== file.hyperspellId) {
 			updateFrontmatterId(filePath, result.resourceId);
 		}
 
@@ -174,17 +180,28 @@ export function deleteLocalMemoryFile(
 	const files = getMemoryFiles(workspaceDir);
 
 	for (const filePath of files) {
+		let matched = false;
 		try {
 			const content = fs.readFileSync(filePath, "utf-8");
 			const { frontmatter } = parseFrontmatter(content);
+			matched = frontmatter.hyperspell_id === hyperspellId;
+		} catch (err) {
+			log.error(`Failed to read file ${filePath}`, err);
+			continue;
+		}
 
-			if (frontmatter.hyperspell_id === hyperspellId) {
+		if (matched) {
+			try {
 				fs.unlinkSync(filePath);
 				log.info(`Deleted local memory file: ${filePath}`);
 				return true;
+			} catch (err) {
+				log.error(
+					`Found matching file ${filePath} but failed to delete it`,
+					err,
+				);
+				return false;
 			}
-		} catch (err) {
-			log.error(`Failed to check file ${filePath}`, err);
 		}
 	}
 

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -34,8 +34,9 @@ function parseFrontmatter(content: string): {
 			const key = line.slice(0, colonIndex).trim();
 			let value = line.slice(colonIndex + 1).trim();
 			if (
-				(value.startsWith('"') && value.endsWith('"')) ||
-				(value.startsWith("'") && value.endsWith("'"))
+				value.length >= 2 &&
+				((value.startsWith('"') && value.endsWith('"')) ||
+					(value.startsWith("'") && value.endsWith("'")))
 			) {
 				value = value.slice(1, -1);
 			}
@@ -157,7 +158,14 @@ export async function syncMarkdownFile(
 		});
 
 		// Update frontmatter with new resource ID if it changed or was newly created
-		if (result.resourceId && result.resourceId !== file.hyperspellId) {
+		if (!result.resourceId) {
+			log.warn(
+				`Sync of ${filePath} succeeded but API returned no resourceId — file is not linked to a remote resource`,
+			);
+			return { success: false, error: "No resourceId returned from API" };
+		}
+
+		if (result.resourceId !== file.hyperspellId) {
 			updateFrontmatterId(filePath, result.resourceId);
 		}
 

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -48,7 +48,12 @@ function parseFrontmatter(content: string): {
 }
 
 /**
- * Serialize frontmatter back to string
+ * Serialize frontmatter back to string.
+ *
+ * Values are written unquoted intentionally — the codebase uses a first-colon
+ * parser (not a YAML parser), so colons/special chars in values are safe.
+ * Adding YAML-style quoting would break roundtripping of JSON values stored
+ * in Knowledge Graph entity files (source_memories, relationships).
  */
 function serializeFrontmatter(frontmatter: Record<string, string>): string {
 	const lines = Object.entries(frontmatter).map(

--- a/tools/forget.ts
+++ b/tools/forget.ts
@@ -1,0 +1,146 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig, HyperspellSource } from "../config.ts";
+import { getWorkspaceDir } from "../config.ts";
+import { log } from "../logger.ts";
+import { deleteLocalMemoryFile } from "../sync/markdown.ts";
+
+export function registerForgetTool(
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
+): void {
+	const workspaceDir = getWorkspaceDir();
+
+	api.registerTool(
+		{
+			name: "hyperspell_forget",
+			label: "Memory Forget",
+			description:
+				"Delete memories that match a search query. Use when the user says to forget something, correct outdated info, or remove sensitive data. Searches for matching memories first, then deletes them from Hyperspell and cleans up local markdown files.",
+			parameters: Type.Object({
+				query: Type.String({
+					description: "Search query to find memories to delete",
+				}),
+				limit: Type.Optional(
+					Type.Number({
+						description: "Max memories to delete (default: 3)",
+					}),
+				),
+				confirm: Type.Optional(
+					Type.Boolean({
+						description:
+							"Set to true to confirm deletion. First call without confirm to preview matches, then call again with confirm: true to delete.",
+					}),
+				),
+			}),
+			async execute(
+				_toolCallId: string,
+				params: { query: string; limit?: number; confirm?: boolean },
+			) {
+				const limit = params.limit ?? 3;
+				log.debug(
+					`forget tool: query="${params.query}" limit=${limit} confirm=${params.confirm}`,
+				);
+
+				try {
+					const response = await client.searchRaw(params.query, { limit });
+					const documents = (response.documents ?? []) as Array<{
+						source: string;
+						resource_id: string;
+						score?: number;
+						title?: string;
+						summary?: string;
+					}>;
+
+					if (documents.length === 0) {
+						return {
+							content: [
+								{
+									type: "text" as const,
+									text: `No memories found matching: "${params.query}"`,
+								},
+							],
+						};
+					}
+
+					// Preview mode: show matches without deleting
+					if (!params.confirm) {
+						const preview = documents
+							.map((doc, i) => {
+								const title = doc.title || "(untitled)";
+								const score = doc.score
+									? ` (${Math.round(doc.score * 100)}% match)`
+									: "";
+								return `${i + 1}. [${doc.source}] ${title}${score} (id: ${doc.resource_id})`;
+							})
+							.join("\n");
+
+						return {
+							content: [
+								{
+									type: "text" as const,
+									text: `Found ${documents.length} memories to delete:\n\n${preview}\n\nCall again with confirm: true to delete these memories.`,
+								},
+							],
+							details: { count: documents.length, documents },
+						};
+					}
+
+					// Delete mode: remove each matching memory
+					const results: string[] = [];
+					let deleted = 0;
+					let failed = 0;
+
+					for (const doc of documents) {
+						try {
+							await client.deleteMemory(
+								doc.resource_id,
+								doc.source as HyperspellSource,
+							);
+
+							// Clean up local markdown file if it exists
+							const localDeleted = deleteLocalMemoryFile(
+								workspaceDir,
+								doc.resource_id,
+							);
+							const localNote = localDeleted ? " (local file removed)" : "";
+
+							results.push(
+								`Deleted: [${doc.source}] ${doc.title || "(untitled)"}${localNote}`,
+							);
+							deleted++;
+						} catch (err) {
+							const msg = err instanceof Error ? err.message : String(err);
+							results.push(
+								`Failed: [${doc.source}] ${doc.title || "(untitled)"} - ${msg}`,
+							);
+							failed++;
+						}
+					}
+
+					const summary =
+						failed > 0
+							? `Deleted ${deleted} memories, ${failed} failed:\n\n${results.join("\n")}`
+							: `Deleted ${deleted} memories:\n\n${results.join("\n")}`;
+
+					return {
+						content: [{ type: "text" as const, text: summary }],
+					};
+				} catch (err) {
+					log.error("forget tool failed", err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Failed to forget memories: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_forget" },
+	);
+}

--- a/tools/forget.ts
+++ b/tools/forget.ts
@@ -95,10 +95,18 @@ export function registerForgetTool(
 
 					for (const doc of documents) {
 						try {
-							await client.deleteMemory(
+							const deleteResult = await client.deleteMemory(
 								doc.resource_id,
 								doc.source as HyperspellSource,
 							);
+
+							if (!deleteResult.success) {
+								results.push(
+									`Failed: [${doc.source}] ${doc.title || "(untitled)"} - API returned success: false`,
+								);
+								failed++;
+								continue;
+							}
 
 							// Clean up local markdown file if it exists
 							const localDeleted = deleteLocalMemoryFile(


### PR DESCRIPTION
## Summary

- Adds `hyperspell_forget` AI tool with a two-step preview/confirm flow — the LLM first shows matching memories, then deletes on confirmation. Prevents accidental mass deletion when the agent calls it autonomously.
- Adds `/forget <query>` slash command for quick direct deletion (immediate, consistent with `/remember` being immediate).
- Adds `deleteMemory()` to `HyperspellClient` wrapping the SDK's `memories.delete()` endpoint.
- Bidirectional cleanup: when a memory is deleted from Hyperspell, the corresponding local markdown file (matched by `hyperspell_id` in frontmatter) is also removed.
- Registers an unconfigured `/forget` stub so the command shows up in help before setup.

### Why this matters

This is table-stakes for any memory system. Without it, users have no way to correct wrong memories or remove sensitive information that was accidentally stored. Supermemory has `forget` as a core primitive. Every competitor with shipped OpenClaw plugins offers delete — Hyperspell should too.

### Design decisions

1. **Slash command vs AI tool behavior**: `/forget` deletes immediately (consistent with `/remember`). The AI tool has preview/confirm because the LLM may call it without explicit user intent.
2. **Re-search on confirm**: The AI tool re-searches on the confirm call rather than caching preview results. Simpler, and results are stable in short time windows.
3. **Knowledge graph entity cleanup**: Not implemented in this PR. Entity files that reference deleted source memories remain valid — the extracted facts don't become wrong just because the source is gone. Stale `source_memories` references are harmless. Can be added as a follow-up.

## Test plan

- [ ] Run `tsc --noEmit` — passes
- [ ] Run `biome ci` on modified files — passes
- [ ] Verify `/forget` with no args returns usage message
- [ ] Verify `/forget <query>` with no matches returns "No memories found"
- [ ] Verify `/forget <query>` with matches deletes and reports results
- [ ] Verify `hyperspell_forget` without `confirm` returns preview
- [ ] Verify `hyperspell_forget` with `confirm: true` deletes memories
- [ ] Verify local markdown files with matching `hyperspell_id` are removed on delete
- [ ] Verify unconfigured state shows "Run setup" message for `/forget`