### PR TITLE
feat: Multi-user support with per-sender context isolation

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -82,29 +82,52 @@ export class HyperspellClient {
 		return headers;
 	}
 
+	private requestOptions(userId?: string) {
+		if (!userId) return undefined;
+		return { headers: { "X-As-User": userId } };
+	}
+
 	async search(
 		query: string,
-		options?: { limit?: number; sources?: HyperspellSource[]; after?: string; before?: string },
+		options?: {
+			limit?: number;
+			sources?: HyperspellSource[];
+			after?: string;
+			before?: string;
+			userId?: string;
+		},
 	): Promise<SearchResult[]> {
 		const limit = options?.limit ?? this.config.maxResults;
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-		log.debugRequest("memories.search", { query, limit, sources, after: options?.after, before: options?.before });
-
-		const response = await this.client.memories.search({
+		log.debugRequest("memories.search", {
 			query,
+			limit,
 			sources,
-			options: {
-				max_results: limit,
-				...(options?.after ? { after: options.after } : {}),
-				...(options?.before ? { before: options.before } : {}),
-			},
+			after: options?.after,
+			before: options?.before,
+			userId: options?.userId,
 		});
 
+		const response = await this.client.memories.search(
+			{
+				query,
+				sources,
+				options: {
+					max_results: limit,
+					...(options?.after ? { after: options.after } : {}),
+					...(options?.before ? { before: options.before } : {}),
+				},
+			},
+			this.requestOptions(options?.userId),
+		);
+
 		const results: SearchResult[] = response.documents.map((doc) => {
-			const raw = doc as typeof doc & { highlights?: Array<{ id: string; score: number; text: string }> };
+			const raw = doc as typeof doc & {
+				highlights?: Array<{ id: string; score: number; text: string }>;
+			};
 			return {
 				resourceId: doc.resource_id,
 				title: doc.title ?? null,
@@ -112,7 +135,11 @@ export class HyperspellClient {
 				score: doc.score ?? null,
 				url: (doc.metadata?.url as string | null) ?? null,
 				createdAt: (doc.metadata?.created_at as string | null) ?? null,
-				highlights: (raw.highlights ?? []).map((h) => ({ id: h.id, score: h.score, text: h.text })),
+				highlights: (raw.highlights ?? []).map((h) => ({
+					id: h.id,
+					score: h.score,
+					text: h.text,
+				})),
 			};
 		});
 
@@ -122,24 +149,40 @@ export class HyperspellClient {
 
 	async searchRaw(
 		query: string,
-		options?: { limit?: number; sources?: HyperspellSource[]; after?: string; before?: string },
+		options?: {
+			limit?: number;
+			sources?: HyperspellSource[];
+			after?: string;
+			before?: string;
+			userId?: string;
+		},
 	): Promise<Record<string, unknown>> {
 		const limit = options?.limit ?? this.config.maxResults;
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-		log.debugRequest("memories.search (raw)", { query, limit, sources, after: options?.after, before: options?.before });
-
-		const response = await this.client.memories.search({
+		log.debugRequest("memories.search (raw)", {
 			query,
+			limit,
 			sources,
-			options: {
-				max_results: limit,
-				...(options?.after ? { after: options.after } : {}),
-				...(options?.before ? { before: options.before } : {}),
-			},
+			after: options?.after,
+			before: options?.before,
+			userId: options?.userId,
 		});
+
+		const response = await this.client.memories.search(
+			{
+				query,
+				sources,
+				options: {
+					max_results: limit,
+					...(options?.after ? { after: options.after } : {}),
+					...(options?.before ? { before: options.before } : {}),
+				},
+			},
+			this.requestOptions(options?.userId),
+		);
 
 		log.debugResponse("memories.search (raw)", {
 			count: response.documents.length,
@@ -150,7 +193,11 @@ export class HyperspellClient {
 
 	async searchWithAnswer(
 		query: string,
-		options?: { limit?: number; sources?: HyperspellSource[] },
+		options?: {
+			limit?: number;
+			sources?: HyperspellSource[];
+			userId?: string;
+		},
 	): Promise<SearchWithAnswerResult> {
 		const limit = options?.limit ?? this.config.maxResults;
 		const sources =
@@ -161,16 +208,20 @@ export class HyperspellClient {
 			query,
 			limit,
 			sources,
+			userId: options?.userId,
 		});
 
-		const response = await this.client.memories.search({
-			query,
-			sources,
-			answer: true,
-			options: {
-				max_results: limit,
+		const response = await this.client.memories.search(
+			{
+				query,
+				sources,
+				answer: true,
+				options: {
+					max_results: limit,
+				},
 			},
-		});
+			this.requestOptions(options?.userId),
+		);
 
 		const documents: SearchResult[] = response.documents.map((doc) => ({
 			resourceId: doc.resource_id,
@@ -201,6 +252,7 @@ export class HyperspellClient {
 			collection?: string;
 			date?: string;
 			metadata?: Record<string, string | number | boolean>;
+			userId?: string;
 		},
 	): Promise<{ resourceId: string }> {
 		log.debugRequest("memories.add", {
@@ -209,19 +261,23 @@ export class HyperspellClient {
 			resourceId: options?.resourceId,
 			collection: options?.collection,
 			date: options?.date,
+			userId: options?.userId,
 		});
 
-		const result = await this.client.memories.add({
-			text,
-			title: options?.title,
-			resource_id: options?.resourceId,
-			collection: options?.collection,
-			date: options?.date,
-			metadata: {
-				...options?.metadata,
-				openclaw_source: "command",
+		const result = await this.client.memories.add(
+			{
+				text,
+				title: options?.title,
+				resource_id: options?.resourceId,
+				collection: options?.collection,
+				date: options?.date,
+				metadata: {
+					...options?.metadata,
+					openclaw_source: "command",
+				},
 			},
-		});
+			this.requestOptions(options?.userId),
+		);
 
 		log.debugResponse("memories.add", { resourceId: result.resource_id });
 		return { resourceId: result.resource_id };
@@ -245,10 +301,15 @@ export class HyperspellClient {
 
 	async getConnectUrl(
 		integrationId: string,
+		options?: { userId?: string },
 	): Promise<{ url: string; expiresAt: string }> {
 		log.debugRequest("integrations.connect", { integrationId });
 
-		const response = await this.client.integrations.connect(integrationId);
+		const response = await this.client.integrations.connect(
+			integrationId,
+			undefined,
+			this.requestOptions(options?.userId),
+		);
 
 		log.debugResponse("integrations.connect", { url: response.url });
 		return {
@@ -261,6 +322,7 @@ export class HyperspellClient {
 		source?: HyperspellSource;
 		collection?: string;
 		pageSize?: number;
+		userId?: string;
 	}): AsyncGenerator<{
 		resourceId: string;
 		source: HyperspellSource;
@@ -270,6 +332,7 @@ export class HyperspellClient {
 		log.debugRequest("memories.list", {
 			source: options?.source,
 			collection: options?.collection,
+			userId: options?.userId,
 		});
 
 		const params: Record<string, unknown> = {
@@ -278,7 +341,10 @@ export class HyperspellClient {
 		if (options?.source) params.source = options.source;
 		if (options?.collection) params.collection = options.collection;
 
-		for await (const memory of this.client.memories.list(params as any)) {
+		for await (const memory of this.client.memories.list(
+			params as any,
+			this.requestOptions(options?.userId),
+		)) {
 			yield {
 				resourceId: memory.resource_id,
 				source: memory.source as HyperspellSource,
@@ -291,10 +357,15 @@ export class HyperspellClient {
 	async getMemory(
 		resourceId: string,
 		source: HyperspellSource,
+		options?: { userId?: string },
 	): Promise<Record<string, unknown>> {
 		log.debugRequest("memories.get", { resourceId, source });
 
-		const response = await this.client.memories.get(resourceId, { source });
+		const response = await this.client.memories.get(
+			resourceId,
+			{ source },
+			this.requestOptions(options?.userId),
+		);
 		const raw = response as unknown as Record<string, unknown>;
 
 		log.debugResponse("memories.get", { resourceId, hasData: "data" in raw });
@@ -308,30 +379,35 @@ export class HyperspellClient {
 			title?: string;
 			extract?: Array<"procedure" | "memory" | "mood">;
 			metadata?: Record<string, string | number | boolean>;
+			userId?: string;
 		},
 	): Promise<{ resourceId: string; status: string }> {
 		log.debugRequest("sessions.add", {
 			historyLength: history.length,
 			sessionId: options?.sessionId,
 			extract: options?.extract,
+			userId: options?.userId,
 		});
 
-		const result = await this.client.sessions.add({
-			history,
-			session_id: options?.sessionId,
-			title: options?.title,
-			format: "openclaw",
-			// Cast: SDK 0.35 typing accepts only ["procedure" | "memory"], but the
-			// backend's mood extractor (hyperspell/hyperspell#581) accepts "mood".
-			// Remove this cast once the OpenAPI spec is updated.
-			extract: (options?.extract ?? ["procedure"]) as Array<
-				"procedure" | "memory"
-			>,
-			metadata: {
-				...options?.metadata,
-				openclaw_source: "agent_end",
+		const result = await this.client.sessions.add(
+			{
+				history,
+				session_id: options?.sessionId,
+				title: options?.title,
+				format: "openclaw",
+				// Cast: SDK 0.35 typing accepts only ["procedure" | "memory"], but the
+				// backend's mood extractor (hyperspell/hyperspell#581) accepts "mood".
+				// Remove this cast once the OpenAPI spec is updated.
+				extract: (options?.extract ?? ["procedure"]) as Array<
+					"procedure" | "memory"
+				>,
+				metadata: {
+					...options?.metadata,
+					openclaw_source: "agent_end",
+				},
 			},
-		});
+			this.requestOptions(options?.userId),
+		);
 
 		log.debugResponse("sessions.add", {
 			resourceId: result.resource_id,
@@ -340,10 +416,14 @@ export class HyperspellClient {
 		return { resourceId: result.resource_id, status: result.status };
 	}
 
-	async listConnections(): Promise<Connection[]> {
-		log.debugRequest("connections.list", {});
+	async listConnections(options?: {
+		userId?: string;
+	}): Promise<Connection[]> {
+		log.debugRequest("connections.list", { userId: options?.userId });
 
-		const response = await this.client.connections.list();
+		const response = await this.client.connections.list(
+			this.requestOptions(options?.userId),
+		);
 
 		const connections: Connection[] = response.connections.map((conn) => ({
 			id: conn.id,

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -2,6 +2,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
 import { getWorkspaceDir } from "../config.ts"
+import { resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 import { syncAllMemoryFiles } from "../sync/markdown.ts"
 
@@ -18,7 +19,7 @@ function formatScore(score: number | null): string {
 export function registerCommands(
   api: OpenClawPluginApi,
   client: HyperspellClient,
-  _cfg: HyperspellConfig,
+  cfg: HyperspellConfig,
 ): void {
   // /getcontext <query> - Search memories and show summaries
   api.registerCommand({
@@ -26,16 +27,18 @@ export function registerCommands(
     description: "Search your memories for relevant context",
     acceptsArgs: true,
     requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
+    handler: async (ctx: { args?: string; senderId?: string; channel?: string }) => {
       const query = ctx.args?.trim()
       if (!query) {
         return { text: "Usage: /getcontext <search query>" }
       }
 
-      log.debug(`/getcontext command: "${query}"`)
+      const resolved = resolveUser(ctx as Record<string, unknown>, cfg)
+      const userId = resolved?.userId
+      log.debug(`/getcontext command: "${query}" userId=${userId}`)
 
       try {
-        const results = await client.search(query, { limit: 5 })
+        const results = await client.search(query, { limit: 5, userId })
 
         if (results.length === 0) {
           return { text: `No memories found for: "${query}"` }
@@ -63,17 +66,20 @@ export function registerCommands(
     description: "Save something to memory",
     acceptsArgs: true,
     requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
+    handler: async (ctx: { args?: string; senderId?: string; channel?: string }) => {
       const text = ctx.args?.trim()
       if (!text) {
         return { text: "Usage: /remember <text to remember>" }
       }
 
-      log.debug(`/remember command: "${truncate(text, 50)}"`)
+      const resolved = resolveUser(ctx as Record<string, unknown>, cfg)
+      const userId = resolved?.userId
+      log.debug(`/remember command: "${truncate(text, 50)}" userId=${userId}`)
 
       try {
         await client.addMemory(text, {
           metadata: { source: "openclaw_command" },
+          userId,
         })
 
         const preview = truncate(text, 60)
@@ -96,7 +102,9 @@ export function registerCommands(
 
       try {
         const workspaceDir = getWorkspaceDir()
-        const result = await syncAllMemoryFiles(client, workspaceDir)
+        const result = await syncAllMemoryFiles(client, workspaceDir, {
+          userId: cfg.multiUser?.sharedUserId,
+        })
 
         if (result.synced === 0 && result.failed === 0) {
           return { text: "No memory files found in memory/ directory." }

--- a/config.ts
+++ b/config.ts
@@ -25,6 +25,18 @@ export type AutoTraceConfig = {
 	metadata?: Record<string, string | number | boolean>;
 };
 
+export type UserProfile = {
+	userId: string;
+	name: string;
+	context?: string;
+};
+
+export type MultiUserConfig = {
+	senderMap: Record<string, UserProfile>;
+	sharedUserId: string;
+	includeSharedInSearch: boolean;
+};
+
 export type HyperspellConfig = {
 	apiKey: string;
 	userId?: string;
@@ -38,6 +50,7 @@ export type HyperspellConfig = {
 	relevanceThreshold: number;
 	debug: boolean;
 	knowledgeGraph: KnowledgeGraphConfig;
+	multiUser?: MultiUserConfig;
 };
 
 const ALLOWED_KEYS = [
@@ -53,6 +66,7 @@ const ALLOWED_KEYS = [
 	"relevanceThreshold",
 	"debug",
 	"knowledgeGraph",
+	"multiUser",
 ];
 
 const VALID_SOURCES: HyperspellSource[] = [
@@ -135,6 +149,40 @@ function parseSources(raw: string | string[] | undefined): HyperspellSource[] {
 	return sources;
 }
 
+function parseMultiUser(raw: unknown): MultiUserConfig | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const mu = raw as Record<string, unknown>;
+
+	const senderMap: Record<string, UserProfile> = {};
+	const rawMap = mu.senderMap as Record<string, unknown> | undefined;
+	if (rawMap && typeof rawMap === "object") {
+		for (const [handle, profile] of Object.entries(rawMap)) {
+			if (profile && typeof profile === "object") {
+				const p = profile as Record<string, unknown>;
+				if (typeof p.userId === "string" && typeof p.name === "string") {
+					senderMap[handle] = {
+						userId: p.userId,
+						name: p.name,
+						context: typeof p.context === "string" ? p.context : undefined,
+					};
+				}
+			}
+		}
+	}
+
+	if (Object.keys(senderMap).length === 0) return undefined;
+
+	return {
+		senderMap,
+		sharedUserId:
+			typeof mu.sharedUserId === "string" ? mu.sharedUserId : "shared",
+		includeSharedInSearch:
+			typeof mu.includeSharedInSearch === "boolean"
+				? mu.includeSharedInSearch
+				: true,
+	};
+}
+
 export function parseConfig(raw: unknown): HyperspellConfig {
 	const cfg =
 		raw && typeof raw === "object" && !Array.isArray(raw)
@@ -184,6 +232,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			scanIntervalMinutes: (kgRaw.scanIntervalMinutes as number) ?? 60,
 			batchSize: (kgRaw.batchSize as number) ?? 20,
 		},
+		multiUser: parseMultiUser(cfg.multiUser),
 	};
 }
 

--- a/graph/ops.ts
+++ b/graph/ops.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import type { HyperspellClient } from "../client.ts"
+import type { HyperspellConfig } from "../config.ts"
+import { getAllUserIds } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 import { NetworkStateManager } from "./state.ts"
 
@@ -93,38 +95,42 @@ export async function scanMemories(
   client: HyperspellClient,
   stateManager: NetworkStateManager,
   batchSize: number,
+  cfg?: HyperspellConfig,
 ): Promise<ScannedMemory[]> {
   const unprocessed: ScannedMemory[] = []
+  const userIds = cfg ? getAllUserIds(cfg) : [undefined]
 
-  for await (const mem of client.listMemories()) {
-    if (stateManager.isProcessed(mem.resourceId)) continue
-    if (mem.metadata?.graph_entity === "true" || mem.metadata?.graph_entity === true) continue
-    if ((mem.metadata?.status as string) !== "completed") continue
+  outer: for (const userId of userIds) {
+    for await (const mem of client.listMemories({ userId })) {
+      if (stateManager.isProcessed(mem.resourceId)) continue
+      if (mem.metadata?.graph_entity === "true" || mem.metadata?.graph_entity === true) continue
+      if ((mem.metadata?.status as string) !== "completed") continue
 
-    let summary = ""
-    try {
-      const full = await client.getMemory(mem.resourceId, mem.source)
-      const data = full.data as unknown[] | undefined
+      let summary = ""
+      try {
+        const full = await client.getMemory(mem.resourceId, mem.source as import("../config.ts").HyperspellSource, { userId })
+        const data = full.data as unknown[] | undefined
 
-      const participants = full.participants as Array<{ name?: string; email?: string }> | undefined
-      const participantLine = participants?.length
-        ? `Participants: ${participants.map((p) => `${p.name || ""} <${p.email || ""}>`).join(", ")}`
-        : ""
+        const participants = full.participants as Array<{ name?: string; email?: string }> | undefined
+        const participantLine = participants?.length
+          ? `Participants: ${participants.map((p) => `${p.name || ""} <${p.email || ""}>`).join(", ")}`
+          : ""
 
-      const dataSummary = data ? summarizeMemoryData(data, mem.source) : ""
-      summary = [participantLine, dataSummary].filter(Boolean).join("\n\n")
-    } catch {
-      summary = "(content unavailable)"
+        const dataSummary = data ? summarizeMemoryData(data, mem.source) : ""
+        summary = [participantLine, dataSummary].filter(Boolean).join("\n\n")
+      } catch {
+        summary = "(content unavailable)"
+      }
+
+      unprocessed.push({
+        resourceId: mem.resourceId,
+        source: mem.source,
+        title: mem.title,
+        summary: summary.slice(0, 1000),
+      })
+
+      if (unprocessed.length >= batchSize) break outer
     }
-
-    unprocessed.push({
-      resourceId: mem.resourceId,
-      source: mem.source,
-      title: mem.title,
-      summary: summary.slice(0, 1000),
-    })
-
-    if (unprocessed.length >= batchSize) break
   }
 
   return unprocessed

--- a/graph/tools.ts
+++ b/graph/tools.ts
@@ -32,7 +32,7 @@ export function registerNetworkTools(
       async execute(_toolCallId: string, params: { batchSize?: number }) {
         const batchSize = params.batchSize ?? cfg.knowledgeGraph.batchSize
         try {
-          const memories = await scanMemories(client, stateManager, batchSize)
+          const memories = await scanMemories(client, stateManager, batchSize, cfg)
           const text = formatScanResults(memories, stateManager.getProcessedCount(), stateManager.getLastScanAt())
           return {
             content: [{ type: "text" as const, text }],

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -1,5 +1,6 @@
 import type { HyperspellClient, SearchResult } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
+import { resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
 function formatRelativeTime(isoTimestamp: string): string {
@@ -26,7 +27,15 @@ function formatRelativeTime(isoTimestamp: string): string {
   }
 }
 
-function formatContext(results: SearchResult[], maxResults: number, threshold: number): string | null {
+/**
+ * Format a list of search results as per-highlight bullets, filtered by relevance threshold.
+ * Returns null if nothing passes the threshold.
+ */
+function formatHighlightBullets(
+  results: SearchResult[],
+  maxResults: number,
+  threshold: number,
+): string | null {
   const sections: string[] = []
 
   for (const r of results.slice(0, maxResults)) {
@@ -44,39 +53,183 @@ function formatContext(results: SearchResult[], maxResults: number, threshold: n
   }
 
   if (sections.length === 0) return null
+  return sections.join("\n\n")
+}
 
-  const intro =
-    "The following is context from the user's connected sources. Reference it only when relevant to the conversation."
-  const disclaimer =
-    "Use this context naturally when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
+const INTRO =
+  "The following is context from the user's connected sources. Reference it only when relevant to the conversation."
+const DISCLAIMER =
+  "Use this context naturally when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
 
-  return `<hyperspell-context>\n${intro}\n\n${sections.join("\n\n")}\n\n${disclaimer}\n</hyperspell-context>`
+function wrapSingle(body: string): string {
+  return `<hyperspell-context>\n${INTRO}\n\n${body}\n\n${DISCLAIMER}\n</hyperspell-context>`
 }
 
 export function buildAutoContextHandler(
   client: HyperspellClient,
   cfg: HyperspellConfig,
 ) {
-  return async (event: Record<string, unknown>) => {
+  return async (
+    event: Record<string, unknown>,
+    ctx?: Record<string, unknown>,
+  ) => {
     const prompt = event.prompt as string | undefined
     if (!prompt || prompt.length < 5) return
 
+    // Multi-user path
+    if (cfg.multiUser) {
+      const resolved = resolveUser(ctx, cfg)
+      return multiUserSearch(client, cfg, prompt, resolved)
+    }
+
+    // Single-user path — preserves main's highlights + threshold behavior
     log.debug(`auto-context: searching for "${prompt.slice(0, 50)}..."`)
 
     try {
       const results = await client.search(prompt, { limit: cfg.maxResults })
-      const context = formatContext(results, cfg.maxResults, cfg.relevanceThreshold)
+      const formatted = formatHighlightBullets(
+        results,
+        cfg.maxResults,
+        cfg.relevanceThreshold,
+      )
 
-      if (!context) {
+      if (!formatted) {
         log.debug("auto-context: no relevant memories found")
         return
       }
 
       log.debug(`auto-context: injecting ${results.length} memories`)
-      return { prependContext: context }
+      return { prependContext: wrapSingle(formatted) }
     } catch (err) {
       log.error("auto-context failed", err)
       return
     }
+  }
+}
+
+async function multiUserSearch(
+  client: HyperspellClient,
+  cfg: HyperspellConfig,
+  prompt: string,
+  resolved:
+    | { userId: string; name: string; context?: string; resolved: boolean }
+    | undefined,
+) {
+  const multiUser = cfg.multiUser!
+  const isKnownSender = !!resolved?.resolved
+  const includeShared = multiUser.includeSharedInSearch
+
+  log.debug(
+    `auto-context: searching for "${prompt.slice(0, 50)}..." user=${resolved?.userId ?? "unknown"}`,
+  )
+
+  // Build parallel searches — personal (known senders only) + shared
+  const personalSearch = isKnownSender
+    ? client.search(prompt, {
+        limit: cfg.maxResults,
+        userId: resolved!.userId,
+      })
+    : null
+
+  // Always search shared for unknown senders, even if includeSharedInSearch is false
+  const sharedLimit = isKnownSender
+    ? Math.ceil(cfg.maxResults / 2)
+    : cfg.maxResults
+  const sharedSearch =
+    includeShared || !isKnownSender
+      ? client.search(prompt, {
+          limit: sharedLimit,
+          userId: multiUser.sharedUserId,
+        })
+      : null
+
+  const searches = [personalSearch, sharedSearch].filter(Boolean) as Promise<
+    SearchResult[]
+  >[]
+  const settled = await Promise.allSettled(searches)
+
+  let idx = 0
+  let personalResults: SearchResult[] = []
+  let sharedResults: SearchResult[] = []
+
+  if (personalSearch) {
+    const r = settled[idx++]
+    if (r.status === "fulfilled") {
+      personalResults = r.value
+    } else {
+      log.error("auto-context: personal search failed", r.reason)
+    }
+  }
+  if (sharedSearch) {
+    const r = settled[idx++]
+    if (r.status === "fulfilled") {
+      sharedResults = r.value
+    } else {
+      log.error("auto-context: shared search failed", r.reason)
+    }
+  }
+
+  const sections: string[] = []
+
+  // User identity preamble
+  if (isKnownSender && resolved) {
+    const contextLine = resolved.context ? ` ${resolved.context}` : ""
+    sections.push(`You are speaking with ${resolved.name}.${contextLine}`)
+  }
+
+  // Personal section (threshold-filtered per PR #11/#12 format)
+  if (isKnownSender && personalResults.length > 0 && resolved) {
+    const formatted = formatHighlightBullets(
+      personalResults,
+      cfg.maxResults,
+      cfg.relevanceThreshold,
+    )
+    if (formatted) {
+      sections.push(
+        `<personal-context>\nMemories from ${resolved.name}'s personal sources and history.\n\n${formatted}\n</personal-context>`,
+      )
+    }
+  }
+
+  // Shared section
+  if (sharedResults.length > 0) {
+    const sharedDisplayLimit = isKnownSender
+      ? Math.ceil(cfg.maxResults / 2)
+      : cfg.maxResults
+    const formatted = formatHighlightBullets(
+      sharedResults,
+      sharedDisplayLimit,
+      cfg.relevanceThreshold,
+    )
+    if (formatted) {
+      sections.push(
+        `<shared-context>\nShared memories available to all users.\n\n${formatted}\n</shared-context>`,
+      )
+    }
+  }
+
+  // If only the identity preamble is present (no memory sections), still inject identity
+  const haveMemorySections = sections.some(
+    (s) => s.startsWith("<personal-context>") || s.startsWith("<shared-context>"),
+  )
+
+  if (!haveMemorySections) {
+    log.debug("auto-context: no relevant memories found")
+    if (isKnownSender && resolved) {
+      const contextLine = resolved.context ? ` ${resolved.context}` : ""
+      return {
+        prependContext: `<hyperspell-context>\nYou are speaking with ${resolved.name}.${contextLine}\n</hyperspell-context>`,
+      }
+    }
+    return
+  }
+
+  const totalCount = personalResults.length + sharedResults.length
+  log.debug(
+    `auto-context: injecting ${totalCount} memories (${personalResults.length} personal, ${sharedResults.length} shared)`,
+  )
+
+  return {
+    prependContext: `<hyperspell-context>\n${sections.join("\n\n")}\n\n${DISCLAIMER}\n</hyperspell-context>`,
   }
 }

--- a/hooks/auto-trace.ts
+++ b/hooks/auto-trace.ts
@@ -1,5 +1,6 @@
 import type { HyperspellClient } from "../client.ts";
 import type { HyperspellConfig } from "../config.ts";
+import { resolveUser } from "../lib/sender.ts";
 import { log } from "../logger.ts";
 
 type Message = { role?: string; content?: string | unknown };
@@ -75,7 +76,10 @@ export function buildAutoTraceHandler(
 	client: HyperspellClient,
 	cfg: HyperspellConfig,
 ) {
-	return async (event: Record<string, unknown>) => {
+	return async (
+		event: Record<string, unknown>,
+		ctx?: Record<string, unknown>,
+	) => {
 		if (event.success === false) {
 			log.debug("auto-trace: skipping — agent ended with error");
 			return;
@@ -109,15 +113,21 @@ export function buildAutoTraceHandler(
 			? String(firstUser.content).slice(0, 80).replace(/\n/g, " ")
 			: undefined;
 
+		// Resolve sender → userId so traces land in the right user's space.
+		// Falls back to sharedUserId for unknown senders (or undefined in single-user mode).
+		const resolved = resolveUser(ctx, cfg);
+		const userId = resolved?.userId;
+
 		try {
 			const result = await client.sendTrace(history, {
 				sessionId,
 				title,
 				extract: cfg.autoTrace.extract,
 				metadata: cfg.autoTrace.metadata,
+				userId,
 			});
 			log.info(
-				`auto-trace: sent ${result.resourceId} (${messages.length} messages)`,
+				`auto-trace: sent ${result.resourceId} (${messages.length} messages${userId ? `, user=${userId}` : ""})`,
 			);
 		} catch (err) {
 			// Fire-and-forget — never break the session

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -8,9 +8,10 @@ import { syncMarkdownFile, syncAllMemoryFiles } from "../sync/markdown.ts"
 /**
  * Build a handler for file change events that syncs markdown files to Hyperspell
  */
-export function buildFileSyncHandler(client: HyperspellClient, _cfg: HyperspellConfig) {
+export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellConfig) {
   const workspaceDir = getWorkspaceDir()
   const memoryDir = path.join(workspaceDir, "memory")
+  const syncUserId = cfg.multiUser?.sharedUserId
 
   return async (event: Record<string, unknown>) => {
     const filePath = event.file_path as string | undefined
@@ -25,7 +26,7 @@ export function buildFileSyncHandler(client: HyperspellClient, _cfg: HyperspellC
     log.info(`Memory file changed: ${fileName}`)
 
     try {
-      const result = await syncMarkdownFile(client, filePath)
+      const result = await syncMarkdownFile(client, filePath, { userId: syncUserId })
       if (result.success) {
         log.info(`Synced ${fileName} -> ${result.resourceId}`)
       } else {
@@ -43,10 +44,11 @@ export function buildFileSyncHandler(client: HyperspellClient, _cfg: HyperspellC
 export async function syncMemoriesOnStartup(
   client: HyperspellClient,
   workspaceDir: string,
+  options?: { userId?: string },
 ): Promise<void> {
   log.info("Syncing existing memory files...")
 
-  const result = await syncAllMemoryFiles(client, workspaceDir)
+  const result = await syncAllMemoryFiles(client, workspaceDir, { userId: options?.userId })
 
   if (result.synced > 0) {
     log.info(`Synced ${result.synced} memory files`)

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,8 @@ import { buildAutoTraceHandler } from "./hooks/auto-trace.ts"
 import { buildEmotionalStateFetchHandler, buildEmotionalStateStoreHandler } from "./hooks/emotional-state.ts"
 import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
 import { initLogger } from "./logger.ts"
-import { registerRememberTool } from "./tools/remember.ts"
-import { registerSearchTool } from "./tools/search.ts"
+import { createRememberToolFactory } from "./tools/remember.ts"
+import { createSearchToolFactory } from "./tools/search.ts"
 import { registerNetworkTools } from "./graph/index.ts"
 
 export default {
@@ -80,9 +80,13 @@ export default {
 
 		const client = new HyperspellClient(cfg);
 
-		// Register AI tools
-		registerSearchTool(api, client, cfg);
-		registerRememberTool(api, client, cfg);
+		// Register AI tools (factory pattern for sender context)
+		api.registerTool(createSearchToolFactory(client, cfg), {
+			name: "hyperspell_search",
+		});
+		api.registerTool(createRememberToolFactory(client, cfg), {
+			name: "hyperspell_remember",
+		});
 
 		// Register emotional context hooks (fetch on start, store on end)
 		if (cfg.emotionalContext) {
@@ -124,7 +128,9 @@ export default {
 				// Sync memories on startup if enabled
 				if (cfg.syncMemories) {
 					const workspaceDir = getWorkspaceDir();
-					await syncMemoriesOnStartup(client, workspaceDir);
+					await syncMemoriesOnStartup(client, workspaceDir, {
+						userId: cfg.multiUser?.sharedUserId,
+					});
 				}
 			},
 			stop: () => {

--- a/lib/sender.ts
+++ b/lib/sender.ts
@@ -1,0 +1,76 @@
+import type { HyperspellConfig } from "../config.ts"
+import { log } from "../logger.ts"
+
+export interface ResolvedUser {
+  userId: string
+  name: string
+  context?: string
+  /** True if the sender was matched in senderMap; false if falling back to sharedUserId */
+  resolved: boolean
+}
+
+/**
+ * Resolve the sender's Hyperspell user from hook or tool context.
+ *
+ * Matches sender handles in the multiUser.senderMap against the sessionKey
+ * using substring matching. Handles are sorted longest-first to prevent
+ * partial matches (e.g., Discord ID "123" matching inside "1234567").
+ *
+ * Falls back to sharedUserId for unrecognized senders.
+ */
+export function resolveUser(
+  ctx: Record<string, unknown> | undefined,
+  cfg: HyperspellConfig,
+): ResolvedUser | undefined {
+  const multiUser = cfg.multiUser
+  if (!multiUser) {
+    // Single-user mode: return config.userId if set
+    return cfg.userId ? { userId: cfg.userId, name: cfg.userId, resolved: true } : undefined
+  }
+
+  // Try direct senderId lookup (available in slash command contexts;
+  // tool factory contexts do NOT include senderId — they have sessionKey instead)
+  const senderId = (ctx?.senderId as string) ?? (ctx?.requesterSenderId as string) ?? undefined
+  if (senderId && multiUser.senderMap[senderId]) {
+    const profile = multiUser.senderMap[senderId]
+    log.debug(`sender resolved via senderId: ${senderId} -> ${profile.userId}`)
+    return { ...profile, resolved: true }
+  }
+
+  // Try sessionKey substring matching (works in both hook and tool factory contexts)
+  const sessionKey = ctx?.sessionKey as string | undefined
+  if (sessionKey) {
+    const sortedEntries = Object.entries(multiUser.senderMap)
+      .sort(([a], [b]) => b.length - a.length)
+    for (const [handle, profile] of sortedEntries) {
+      if (sessionKey.includes(handle)) {
+        log.debug(`sender resolved via sessionKey: ${handle} -> ${profile.userId}`)
+        return { ...profile, resolved: true }
+      }
+    }
+  }
+
+  // Fallback: use sharedUserId for unknown senders
+  log.debug("sender unresolved, falling back to sharedUserId")
+  return {
+    userId: multiUser.sharedUserId,
+    name: multiUser.sharedUserId,
+    resolved: false,
+  }
+}
+
+/**
+ * Get all unique userIds from the multiUser config (for knowledge graph scanning).
+ */
+export function getAllUserIds(cfg: HyperspellConfig): string[] {
+  if (!cfg.multiUser) {
+    return cfg.userId ? [cfg.userId] : []
+  }
+
+  const userIds = new Set<string>()
+  for (const profile of Object.values(cfg.multiUser.senderMap)) {
+    userIds.add(profile.userId)
+  }
+  userIds.add(cfg.multiUser.sharedUserId)
+  return [...userIds]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -122,6 +122,7 @@ export function getMemoryFiles(workspaceDir: string): string[] {
 export async function syncMarkdownFile(
   client: HyperspellClient,
   filePath: string,
+  options?: { userId?: string },
 ): Promise<{ success: boolean; resourceId?: string; error?: string }> {
   const file = readMarkdownFile(filePath)
   if (!file) {
@@ -141,6 +142,7 @@ export async function syncMarkdownFile(
         openclaw_source: "memory_sync",
         file_path: filePath,
       },
+      userId: options?.userId,
     })
 
     // Update frontmatter with new resource ID if it changed or was newly created
@@ -162,6 +164,7 @@ export async function syncMarkdownFile(
 export async function syncAllMemoryFiles(
   client: HyperspellClient,
   workspaceDir: string,
+  options?: { userId?: string },
 ): Promise<{ synced: number; failed: number; errors: string[] }> {
   const files = getMemoryFiles(workspaceDir)
   let synced = 0
@@ -169,7 +172,7 @@ export async function syncAllMemoryFiles(
   const errors: string[] = []
 
   for (const filePath of files) {
-    const result = await syncMarkdownFile(client, filePath)
+    const result = await syncMarkdownFile(client, filePath, { userId: options?.userId })
     if (result.success) {
       synced++
       log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`)

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -1,60 +1,68 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
+import { resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
-export function registerRememberTool(
-  api: OpenClawPluginApi,
+export function createRememberToolFactory(
   client: HyperspellClient,
-  _cfg: HyperspellConfig,
-): void {
-  api.registerTool(
-    {
-      name: "hyperspell_remember",
-      label: "Memory Store",
-      description: "Save important information to the user's memory.",
-      parameters: Type.Object({
-        text: Type.String({ description: "Information to remember" }),
-        title: Type.Optional(
-          Type.String({ description: "Optional title for the memory" }),
-        ),
-        date: Type.Optional(
-          Type.String({ description: "Date of the memory (ISO 8601 or YYYY-MM-DD). Helps ranking and enables date-range filtering. Defaults to now if omitted." }),
-        ),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { text: string; title?: string; date?: string },
-      ) {
-        log.debug(`remember tool: "${params.text.slice(0, 50)}..." date=${params.date ?? "now"}`)
+  cfg: HyperspellConfig,
+) {
+  return (ctx: Record<string, unknown>) => ({
+    name: "hyperspell_remember",
+    label: "Memory Store",
+    description: "Save important information to the user's memory.",
+    parameters: Type.Object({
+      text: Type.String({ description: "Information to remember" }),
+      title: Type.Optional(
+        Type.String({ description: "Optional title for the memory" }),
+      ),
+      date: Type.Optional(
+        Type.String({ description: "Date of the memory (ISO 8601 or YYYY-MM-DD). Helps ranking and enables date-range filtering. Defaults to now if omitted." }),
+      ),
+      userId: Type.Optional(
+        Type.String({
+          description:
+            "Store for a specific user or 'shared' for everyone. Omit to store for current sender.",
+        }),
+      ),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { text: string; title?: string; date?: string; userId?: string },
+    ) {
+      // Resolve userId: explicit param > sender resolution > config default
+      const resolved = resolveUser(ctx, cfg)
+      const userId = params.userId ?? resolved?.userId
+      log.debug(
+        `remember tool: "${params.text.slice(0, 50)}..." date=${params.date ?? "now"} userId=${userId}`,
+      )
 
-        try {
-          await client.addMemory(params.text, {
-            title: params.title,
-            date: params.date,
-            metadata: { source: "openclaw_tool" },
-          })
+      try {
+        await client.addMemory(params.text, {
+          title: params.title,
+          date: params.date,
+          metadata: { source: "openclaw_tool" },
+          userId,
+        })
 
-          const preview =
-            params.text.length > 80 ? `${params.text.slice(0, 80)}…` : params.text
+        const preview =
+          params.text.length > 80 ? `${params.text.slice(0, 80)}…` : params.text
 
-          return {
-            content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
-          }
-        } catch (err) {
-          log.error("remember tool failed", err)
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Failed to store memory: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-          }
+        return {
+          content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
         }
-      },
+      } catch (err) {
+        log.error("remember tool failed", err)
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to store memory: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        }
+      }
     },
-    { name: "hyperspell_remember" },
-  )
+  })
 }

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -1,98 +1,102 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
+import { resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
-export function registerSearchTool(
-  api: OpenClawPluginApi,
+export function createSearchToolFactory(
   client: HyperspellClient,
-  _cfg: HyperspellConfig,
-): void {
-  api.registerTool(
-    {
-      name: "hyperspell_search",
-      label: "Memory Search",
-      description:
-        "Search through the user's connected sources (Notion, Slack, Gmail, Google Drive, etc.) for relevant information.",
-      parameters: Type.Object({
-        query: Type.String({ description: "Search query" }),
-        limit: Type.Optional(
-          Type.Number({ description: "Max results (default: 5)" }),
-        ),
-        after: Type.Optional(
-          Type.String({ description: "Only return memories created on or after this date (ISO 8601 or YYYY-MM-DD)" }),
-        ),
-        before: Type.Optional(
-          Type.String({ description: "Only return memories created before this date (ISO 8601 or YYYY-MM-DD)" }),
-        ),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { query: string; limit?: number; after?: string; before?: string },
-      ) {
-        const limit = params.limit ?? 5
-        log.debug(`search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"}`)
+  cfg: HyperspellConfig,
+) {
+  return (ctx: Record<string, unknown>) => ({
+    name: "hyperspell_search",
+    label: "Memory Search",
+    description:
+      "Search through the user's connected sources (Notion, Slack, Gmail, Google Drive, etc.) for relevant information.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      limit: Type.Optional(
+        Type.Number({ description: "Max results (default: 5)" }),
+      ),
+      after: Type.Optional(
+        Type.String({ description: "Only return memories created on or after this date (ISO 8601 or YYYY-MM-DD)" }),
+      ),
+      before: Type.Optional(
+        Type.String({ description: "Only return memories created before this date (ISO 8601 or YYYY-MM-DD)" }),
+      ),
+      userId: Type.Optional(
+        Type.String({
+          description:
+            "Search as a specific user (e.g. 'ben', 'shared'). Omit to search as current sender.",
+        }),
+      ),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { query: string; limit?: number; after?: string; before?: string; userId?: string },
+    ) {
+      const limit = params.limit ?? 5
+      // Resolve userId: explicit param > sender resolution > config default
+      const resolved = resolveUser(ctx, cfg)
+      const userId = params.userId ?? resolved?.userId
+      log.debug(
+        `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId}`,
+      )
 
-        try {
-          const response = await client.searchRaw(params.query, { limit, after: params.after, before: params.before })
-          const documents = (response.documents ?? []) as Array<{
-            source: string
-            resource_id: string
-            score?: number
-            summary?: string
-            title?: string
-            metadata?: Record<string, unknown>
-            highlights?: Array<{ text: string }>
-            data?: Array<{ text: string }>
-          }>
+      try {
+        const response = await client.searchRaw(params.query, {
+          limit,
+          after: params.after,
+          before: params.before,
+          userId,
+        })
+        const documents = (response.documents ?? []) as Array<{
+          source: string
+          resource_id: string
+          score?: number
+          summary?: string
+          title?: string
+          metadata?: Record<string, unknown>
+          highlights?: Array<{ text: string }>
+          data?: Array<{ text: string }>
+        }>
 
-          if (documents.length === 0) {
-            return {
-              content: [
-                { type: "text" as const, text: "No relevant memories found." },
-              ],
-            }
-          }
-
-          const formattedDocs = documents
-            .map((doc, i) => {
-              const relevance = doc.score
-                ? `${Math.round(doc.score * 100)}%`
-                : "N/A"
-              const title = doc.title || "(untitled)"
-              const summary = doc.summary || "(no summary)"
-              return `${i + 1}. Source: ${doc.source}\n   Title: ${title}\n   Summary: ${summary}\n   Relevance: ${relevance}`
-            })
-            .join("\n\n")
-
-          const text = `Found ${documents.length} memories:\n\n${formattedDocs}`
-
+        if (documents.length === 0) {
           return {
             content: [
-              {
-                type: "text" as const,
-                text,
-              },
-            ],
-            details: {
-              count: documents.length,
-              documents,
-            },
-          }
-        } catch (err) {
-          log.error("search tool failed", err)
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
-              },
+              { type: "text" as const, text: "No relevant memories found." },
             ],
           }
         }
-      },
+
+        const formattedDocs = documents
+          .map((doc, i) => {
+            const relevance = doc.score
+              ? `${Math.round(doc.score * 100)}%`
+              : "N/A"
+            const title = doc.title || "(untitled)"
+            const summary = doc.summary || "(no summary)"
+            return `${i + 1}. Source: ${doc.source}\n   Title: ${title}\n   Summary: ${summary}\n   Relevance: ${relevance}`
+          })
+          .join("\n\n")
+
+        const text = `Found ${documents.length} memories:\n\n${formattedDocs}`
+
+        return {
+          content: [{ type: "text" as const, text }],
+          details: { count: documents.length, documents },
+        }
+      } catch (err) {
+        log.error("search tool failed", err)
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        }
+      }
     },
-    { name: "hyperspell_search" },
-  )
+  })
 }

--- a/types/openclaw.d.ts
+++ b/types/openclaw.d.ts
@@ -48,6 +48,22 @@ declare module "openclaw/plugin-sdk" {
       },
       meta: { name: string },
     ): void
+    registerTool<T = unknown>(
+      factory: (ctx: Record<string, unknown>) => {
+        name: string
+        label: string
+        description: string
+        parameters: unknown
+        execute: (
+          toolCallId: string,
+          params: T,
+        ) => Promise<{
+          content: Array<{ type: "text"; text: string }>
+          details?: Record<string, unknown>
+        }>
+      },
+      meta: { name: string },
+    ): void
     on(event: string, handler: (event: Record<string, unknown>, ctx?: Record<string, unknown>) => Promise<{ prependContext?: string } | void> | void): void
     registerService(options: {
       id: string


### PR DESCRIPTION
## Summary

Adds per-sender user scoping so multiple people sharing an OpenClaw instance get isolated personal context and shared common context through a single Hyperspell app.

- Sender identity resolved from OpenClaw's `sessionKey` (substring matching) or direct `senderId` lookup (slash commands)
- Auto-context performs dual parallel search (personal + shared) with sectioned injection using `Promise.allSettled` for resilience
- Tools use factory pattern `(ctx) => toolDef` for sender context, with explicit `userId` override parameter
- Slash commands resolve sender and scope all API calls via `X-As-User` header
- Workspace memory files sync under `sharedUserId` (available to all users)
- Knowledge graph scans all user IDs for comprehensive entity extraction
- Fully backward compatible — single-user mode works identically when `multiUser` config is absent

## Configuration

```json
{
  "multiUser": {
    "senderMap": {
      "+15555550101": { "userId": "ben", "name": "Ben", "context": "Dad, software engineer" },
      "+15555550102": { "userId": "alice", "name": "Alice", "context": "Mom, designer" }
    },
    "sharedUserId": "shared",
    "includeSharedInSearch": true
  }
}
```

## Changes

### New files
- `lib/sender.ts` — Sender resolution utility (`resolveUser`, `getAllUserIds`)

### Modified files
- `config.ts` — `UserProfile`, `MultiUserConfig` types and `parseMultiUser()` parser
- `client.ts` — `requestOptions()` helper passes `X-As-User` header; `userId` param on all methods
- `hooks/auto-context.ts` — Dual parallel search with `Promise.allSettled`, sectioned `<personal-context>` / `<shared-context>` injection
- `hooks/memory-sync.ts` — Pass `sharedUserId` through sync pipeline
- `sync/markdown.ts` — Accept `userId` option for sync operations
- `tools/search.ts` — Factory pattern with sender resolution and `userId` override
- `tools/remember.ts` — Factory pattern with sender resolution and `userId` override
- `commands/slash.ts` — Sender resolution in `/getcontext`, `/remember`, `/sync`
- `graph/ops.ts` — `scanMemories` iterates all user IDs
- `graph/tools.ts` — Pass `cfg` to `scanMemories`
- `types/openclaw.d.ts` — Factory overload for `registerTool`, `ctx` param for `on()` handler
- `index.ts` — Wiring: factory registration, `sharedUserId` passthrough

## Known limitations
- Entity ownership promotion (personal vs shared based on contributors) is deferred — all graph entities sync under `sharedUserId`
- `senderId` is only available in slash command contexts, not tool factory contexts (tools rely on `sessionKey` matching)

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Single-user mode (no `multiUser` config) — all existing behavior unchanged
- [ ] Multi-user auto-context shows sectioned personal + shared results with identity preamble
- [ ] Unknown sender fallback — only shared context returned
- [ ] `/getcontext` and `/remember` resolve correct user
- [ ] `hyperspell_search` and `hyperspell_remember` with and without explicit `userId`
- [ ] Memory sync stores files under shared user
- [ ] Knowledge graph scan iterates all user IDs
- [ ] One search failing doesn't lose the other's results (`Promise.allSettled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)