### PR TITLE
feat: auto-send conversation traces on session end

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,252 +1,304 @@
-import Hyperspell from "hyperspell"
-import type { HyperspellConfig, HyperspellSource } from "./config.ts"
-import { log } from "./logger.ts"
+import Hyperspell from "hyperspell";
+import type { HyperspellConfig, HyperspellSource } from "./config.ts";
+import { log } from "./logger.ts";
 
 export type SearchResult = {
-  resourceId: string
-  title: string | null
-  source: HyperspellSource
-  score: number | null
-  url: string | null
-  createdAt: string | null
-}
+	resourceId: string;
+	title: string | null;
+	source: HyperspellSource;
+	score: number | null;
+	url: string | null;
+	createdAt: string | null;
+};
 
 export type SearchWithAnswerResult = {
-  answer: string | null
-  documents: SearchResult[]
-}
+	answer: string | null;
+	documents: SearchResult[];
+};
 
 export type Integration = {
-  id: string
-  name: string
-  provider: HyperspellSource
-  icon: string
-}
+	id: string;
+	name: string;
+	provider: HyperspellSource;
+	icon: string;
+};
 
 export type Connection = {
-  id: string
-  integrationId: string
-  label: string | null
-  provider: HyperspellSource
-}
+	id: string;
+	integrationId: string;
+	label: string | null;
+	provider: HyperspellSource;
+};
 
 export class HyperspellClient {
-  private client: Hyperspell
-  private config: HyperspellConfig
+	private client: Hyperspell;
+	private config: HyperspellConfig;
 
-  constructor(config: HyperspellConfig) {
-    this.config = config
-    this.client = new Hyperspell({
-      apiKey: config.apiKey,
-      userID: config.userId,
-    })
-    log.info(`client initialized${config.userId ? ` for user ${config.userId}` : ""}`)
-  }
+	constructor(config: HyperspellConfig) {
+		this.config = config;
+		this.client = new Hyperspell({
+			apiKey: config.apiKey,
+			userID: config.userId,
+		});
+		log.info(
+			`client initialized${config.userId ? ` for user ${config.userId}` : ""}`,
+		);
+	}
 
-  async search(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<SearchResult[]> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async search(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<SearchResult[]> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search", { query, limit, sources })
+		log.debugRequest("memories.search", { query, limit, sources });
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    const results: SearchResult[] = response.documents.map((doc) => ({
-      resourceId: doc.resource_id,
-      title: doc.title ?? null,
-      source: doc.source as HyperspellSource,
-      score: doc.score ?? null,
-      url: doc.metadata?.url as string | null ?? null,
-      createdAt: doc.metadata?.created_at as string | null ?? null,
-    }))
+		const results: SearchResult[] = response.documents.map((doc) => ({
+			resourceId: doc.resource_id,
+			title: doc.title ?? null,
+			source: doc.source as HyperspellSource,
+			score: doc.score ?? null,
+			url: (doc.metadata?.url as string | null) ?? null,
+			createdAt: (doc.metadata?.created_at as string | null) ?? null,
+		}));
 
-    log.debugResponse("memories.search", { count: results.length })
-    return results
-  }
+		log.debugResponse("memories.search", { count: results.length });
+		return results;
+	}
 
-  async searchRaw(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<Record<string, unknown>> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async searchRaw(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<Record<string, unknown>> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search (raw)", { query, limit, sources })
+		log.debugRequest("memories.search (raw)", { query, limit, sources });
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    log.debugResponse("memories.search (raw)", { count: response.documents.length })
+		log.debugResponse("memories.search (raw)", {
+			count: response.documents.length,
+		});
 
-    return response as unknown as Record<string, unknown>
-  }
+		return response as unknown as Record<string, unknown>;
+	}
 
-  async searchWithAnswer(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<SearchWithAnswerResult> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async searchWithAnswer(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<SearchWithAnswerResult> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search (with answer)", { query, limit, sources })
+		log.debugRequest("memories.search (with answer)", {
+			query,
+			limit,
+			sources,
+		});
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      answer: true,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			answer: true,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    const documents: SearchResult[] = response.documents.map((doc) => ({
-      resourceId: doc.resource_id,
-      title: doc.title ?? null,
-      source: doc.source as HyperspellSource,
-      score: doc.score ?? null,
-      url: doc.metadata?.url as string | null ?? null,
-      createdAt: doc.metadata?.created_at as string | null ?? null,
-    }))
+		const documents: SearchResult[] = response.documents.map((doc) => ({
+			resourceId: doc.resource_id,
+			title: doc.title ?? null,
+			source: doc.source as HyperspellSource,
+			score: doc.score ?? null,
+			url: (doc.metadata?.url as string | null) ?? null,
+			createdAt: (doc.metadata?.created_at as string | null) ?? null,
+		}));
 
-    log.debugResponse("memories.search (with answer)", {
-      count: documents.length,
-      hasAnswer: !!response.answer,
-    })
+		log.debugResponse("memories.search (with answer)", {
+			count: documents.length,
+			hasAnswer: !!response.answer,
+		});
 
-    return {
-      answer: response.answer ?? null,
-      documents,
-    }
-  }
+		return {
+			answer: response.answer ?? null,
+			documents,
+		};
+	}
 
-  async addMemory(
-    text: string,
-    options?: {
-      title?: string
-      resourceId?: string
-      collection?: string
-      metadata?: Record<string, string | number | boolean>
-    },
-  ): Promise<{ resourceId: string }> {
-    log.debugRequest("memories.add", {
-      textLength: text.length,
-      title: options?.title,
-      resourceId: options?.resourceId,
-      collection: options?.collection,
-    })
+	async addMemory(
+		text: string,
+		options?: {
+			title?: string;
+			resourceId?: string;
+			collection?: string;
+			metadata?: Record<string, string | number | boolean>;
+		},
+	): Promise<{ resourceId: string }> {
+		log.debugRequest("memories.add", {
+			textLength: text.length,
+			title: options?.title,
+			resourceId: options?.resourceId,
+			collection: options?.collection,
+		});
 
-    const result = await this.client.memories.add({
-      text,
-      title: options?.title,
-      resource_id: options?.resourceId,
-      collection: options?.collection,
-      metadata: {
-        ...options?.metadata,
-        openclaw_source: "command",
-      },
-    })
+		const result = await this.client.memories.add({
+			text,
+			title: options?.title,
+			resource_id: options?.resourceId,
+			collection: options?.collection,
+			metadata: {
+				...options?.metadata,
+				openclaw_source: "command",
+			},
+		});
 
-    log.debugResponse("memories.add", { resourceId: result.resource_id })
-    return { resourceId: result.resource_id }
-  }
+		log.debugResponse("memories.add", { resourceId: result.resource_id });
+		return { resourceId: result.resource_id };
+	}
 
-  async listIntegrations(): Promise<Integration[]> {
-    log.debugRequest("integrations.list", {})
+	async listIntegrations(): Promise<Integration[]> {
+		log.debugRequest("integrations.list", {});
 
-    const response = await this.client.integrations.list()
+		const response = await this.client.integrations.list();
 
-    const integrations: Integration[] = response.integrations.map((int) => ({
-      id: int.id,
-      name: int.name,
-      provider: int.provider as HyperspellSource,
-      icon: int.icon,
-    }))
+		const integrations: Integration[] = response.integrations.map((int) => ({
+			id: int.id,
+			name: int.name,
+			provider: int.provider as HyperspellSource,
+			icon: int.icon,
+		}));
 
-    log.debugResponse("integrations.list", { count: integrations.length })
-    return integrations
-  }
+		log.debugResponse("integrations.list", { count: integrations.length });
+		return integrations;
+	}
 
-  async getConnectUrl(integrationId: string): Promise<{ url: string; expiresAt: string }> {
-    log.debugRequest("integrations.connect", { integrationId })
+	async getConnectUrl(
+		integrationId: string,
+	): Promise<{ url: string; expiresAt: string }> {
+		log.debugRequest("integrations.connect", { integrationId });
 
-    const response = await this.client.integrations.connect(integrationId)
+		const response = await this.client.integrations.connect(integrationId);
 
-    log.debugResponse("integrations.connect", { url: response.url })
-    return {
-      url: response.url,
-      expiresAt: response.expires_at,
-    }
-  }
+		log.debugResponse("integrations.connect", { url: response.url });
+		return {
+			url: response.url,
+			expiresAt: response.expires_at,
+		};
+	}
 
-  async *listMemories(
-    options?: { source?: HyperspellSource; collection?: string; pageSize?: number },
-  ): AsyncGenerator<{
-    resourceId: string
-    source: HyperspellSource
-    title: string | null
-    metadata: Record<string, unknown>
-  }> {
-    log.debugRequest("memories.list", { source: options?.source, collection: options?.collection })
+	async *listMemories(options?: {
+		source?: HyperspellSource;
+		collection?: string;
+		pageSize?: number;
+	}): AsyncGenerator<{
+		resourceId: string;
+		source: HyperspellSource;
+		title: string | null;
+		metadata: Record<string, unknown>;
+	}> {
+		log.debugRequest("memories.list", {
+			source: options?.source,
+			collection: options?.collection,
+		});
 
-    const params: Record<string, unknown> = {
-      size: options?.pageSize ?? 100,
-    }
-    if (options?.source) params.source = options.source
-    if (options?.collection) params.collection = options.collection
+		const params: Record<string, unknown> = {
+			size: options?.pageSize ?? 100,
+		};
+		if (options?.source) params.source = options.source;
+		if (options?.collection) params.collection = options.collection;
 
-    for await (const memory of this.client.memories.list(params as any)) {
-      yield {
-        resourceId: memory.resource_id,
-        source: memory.source as HyperspellSource,
-        title: memory.title ?? null,
-        metadata: (memory.metadata ?? {}) as Record<string, unknown>,
-      }
-    }
-  }
+		for await (const memory of this.client.memories.list(params as any)) {
+			yield {
+				resourceId: memory.resource_id,
+				source: memory.source as HyperspellSource,
+				title: memory.title ?? null,
+				metadata: (memory.metadata ?? {}) as Record<string, unknown>,
+			};
+		}
+	}
 
-  async getMemory(
-    resourceId: string,
-    source: HyperspellSource,
-  ): Promise<Record<string, unknown>> {
-    log.debugRequest("memories.get", { resourceId, source })
+	async getMemory(
+		resourceId: string,
+		source: HyperspellSource,
+	): Promise<Record<string, unknown>> {
+		log.debugRequest("memories.get", { resourceId, source });
 
-    const response = await this.client.memories.get(resourceId, { source })
-    const raw = response as unknown as Record<string, unknown>
+		const response = await this.client.memories.get(resourceId, { source });
+		const raw = response as unknown as Record<string, unknown>;
 
-    log.debugResponse("memories.get", { resourceId, hasData: "data" in raw })
-    return raw
-  }
+		log.debugResponse("memories.get", { resourceId, hasData: "data" in raw });
+		return raw;
+	}
 
-  async listConnections(): Promise<Connection[]> {
-    log.debugRequest("connections.list", {})
+	async sendTrace(
+		history: string,
+		options?: {
+			sessionId?: string;
+			title?: string;
+			extract?: Array<"procedure" | "memory" | "mood">;
+			metadata?: Record<string, string | number | boolean>;
+		},
+	): Promise<{ resourceId: string; status: string }> {
+		log.debugRequest("sessions.add", {
+			historyLength: history.length,
+			sessionId: options?.sessionId,
+			extract: options?.extract,
+		});
 
-    const response = await this.client.connections.list()
+		const result = await this.client.sessions.add({
+			history,
+			session_id: options?.sessionId,
+			title: options?.title,
+			format: "openclaw",
+			extract: options?.extract ?? ["procedure"],
+			metadata: {
+				...options?.metadata,
+				openclaw_source: "agent_end",
+			},
+		});
 
-    const connections: Connection[] = response.connections.map((conn) => ({
-      id: conn.id,
-      integrationId: conn.integration_id,
-      label: conn.label,
-      provider: conn.provider as HyperspellSource,
-    }))
+		log.debugResponse("sessions.add", {
+			resourceId: result.resource_id,
+			status: result.status,
+		});
+		return { resourceId: result.resource_id, status: result.status };
+	}
 
-    log.debugResponse("connections.list", { count: connections.length })
-    return connections
-  }
+	async listConnections(): Promise<Connection[]> {
+		log.debugRequest("connections.list", {});
+
+		const response = await this.client.connections.list();
+
+		const connections: Connection[] = response.connections.map((conn) => ({
+			id: conn.id,
+			integrationId: conn.integration_id,
+			label: conn.label,
+			provider: conn.provider as HyperspellSource,
+		}));
+
+		log.debugResponse("connections.list", { count: connections.length });
+		return connections;
+	}
 }

--- a/config.ts
+++ b/config.ts
@@ -1,206 +1,234 @@
 export type HyperspellSource =
-  | "collections"
-  | "reddit"
-  | "notion"
-  | "slack"
-  | "google_calendar"
-  | "google_mail"
-  | "box"
-  | "google_drive"
-  | "vault"
-  | "web_crawler"
+	| "collections"
+	| "reddit"
+	| "notion"
+	| "slack"
+	| "google_calendar"
+	| "google_mail"
+	| "box"
+	| "google_drive"
+	| "vault"
+	| "web_crawler";
 
 export type KnowledgeGraphConfig = {
-  enabled: boolean
-  scanIntervalMinutes: number
-  batchSize: number
-}
+	enabled: boolean;
+	scanIntervalMinutes: number;
+	batchSize: number;
+};
+
+export type AutoTraceConfig = {
+	enabled: boolean;
+	extract: Array<"procedure" | "memory" | "mood">;
+	metadata?: Record<string, string | number | boolean>;
+};
 
 export type HyperspellConfig = {
-  apiKey: string
-  userId?: string
-  autoContext: boolean
-  syncMemories: boolean
-  sources: HyperspellSource[]
-  maxResults: number
-  debug: boolean
-  knowledgeGraph: KnowledgeGraphConfig
-}
+	apiKey: string;
+	userId?: string;
+	autoContext: boolean;
+	autoTrace: AutoTraceConfig;
+	syncMemories: boolean;
+	sources: HyperspellSource[];
+	maxResults: number;
+	debug: boolean;
+	knowledgeGraph: KnowledgeGraphConfig;
+};
 
 const ALLOWED_KEYS = [
-  "apiKey",
-  "userId",
-  "autoContext",
-  "syncMemories",
-  "sources",
-  "maxResults",
-  "debug",
-  "knowledgeGraph",
-]
+	"apiKey",
+	"userId",
+	"autoContext",
+	"autoTrace",
+	"syncMemories",
+	"sources",
+	"maxResults",
+	"debug",
+	"knowledgeGraph",
+];
 
 const VALID_SOURCES: HyperspellSource[] = [
-  "collections",
-  "reddit",
-  "notion",
-  "slack",
-  "google_calendar",
-  "google_mail",
-  "box",
-  "google_drive",
-  "vault",
-  "web_crawler",
-]
+	"collections",
+	"reddit",
+	"notion",
+	"slack",
+	"google_calendar",
+	"google_mail",
+	"box",
+	"google_drive",
+	"vault",
+	"web_crawler",
+];
 
 function assertAllowedKeys(
-  value: Record<string, unknown>,
-  allowed: string[],
-  label: string,
+	value: Record<string, unknown>,
+	allowed: string[],
+	label: string,
 ): void {
-  const unknown = Object.keys(value).filter((k) => !allowed.includes(k))
-  if (unknown.length > 0) {
-    throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`)
-  }
+	const unknown = Object.keys(value).filter((k) => !allowed.includes(k));
+	if (unknown.length > 0) {
+		throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+	}
 }
 
 function resolveEnvVars(value: string): string {
-  return value.replace(/\$\{([^}]+)\}/g, (_, envVar: string) => {
-    const envValue = process.env[envVar]
-    if (!envValue) {
-      throw new Error(`Environment variable ${envVar} is not set`)
-    }
-    return envValue
-  })
+	return value.replace(/\$\{([^}]+)\}/g, (_, envVar: string) => {
+		const envValue = process.env[envVar];
+		if (!envValue) {
+			throw new Error(`Environment variable ${envVar} is not set`);
+		}
+		return envValue;
+	});
 }
 
 function parseSources(raw: string | string[] | undefined): HyperspellSource[] {
-  if (!raw) {
-    return []
-  }
+	if (!raw) {
+		return [];
+	}
 
-  // Handle array input
-  if (Array.isArray(raw)) {
-    const sources = raw
-      .map((s) => String(s).trim().toLowerCase())
-      .filter((s) => s.length > 0) as HyperspellSource[]
+	// Handle array input
+	if (Array.isArray(raw)) {
+		const sources = raw
+			.map((s) => String(s).trim().toLowerCase())
+			.filter((s) => s.length > 0) as HyperspellSource[];
 
-    for (const source of sources) {
-      if (!VALID_SOURCES.includes(source)) {
-        throw new Error(
-          `Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
-        )
-      }
-    }
+		for (const source of sources) {
+			if (!VALID_SOURCES.includes(source)) {
+				throw new Error(
+					`Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
+				);
+			}
+		}
 
-    return sources
-  }
+		return sources;
+	}
 
-  // Handle string input (comma-separated)
-  if (typeof raw === "string" && raw.trim() === "") {
-    return []
-  }
+	// Handle string input (comma-separated)
+	if (typeof raw === "string" && raw.trim() === "") {
+		return [];
+	}
 
-  const sources = raw
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter((s) => s.length > 0) as HyperspellSource[]
+	const sources = raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0) as HyperspellSource[];
 
-  for (const source of sources) {
-    if (!VALID_SOURCES.includes(source)) {
-      throw new Error(
-        `Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
-      )
-    }
-  }
+	for (const source of sources) {
+		if (!VALID_SOURCES.includes(source)) {
+			throw new Error(
+				`Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
+			);
+		}
+	}
 
-  return sources
+	return sources;
 }
 
 export function parseConfig(raw: unknown): HyperspellConfig {
-  const cfg =
-    raw && typeof raw === "object" && !Array.isArray(raw)
-      ? (raw as Record<string, unknown>)
-      : {}
+	const cfg =
+		raw && typeof raw === "object" && !Array.isArray(raw)
+			? (raw as Record<string, unknown>)
+			: {};
 
-  if (Object.keys(cfg).length > 0) {
-    assertAllowedKeys(cfg, ALLOWED_KEYS, "hyperspell config")
-  }
+	if (Object.keys(cfg).length > 0) {
+		assertAllowedKeys(cfg, ALLOWED_KEYS, "hyperspell config");
+	}
 
-  const apiKey =
-    typeof cfg.apiKey === "string" && cfg.apiKey.length > 0
-      ? resolveEnvVars(cfg.apiKey)
-      : process.env.HYPERSPELL_API_KEY
+	const apiKey =
+		typeof cfg.apiKey === "string" && cfg.apiKey.length > 0
+			? resolveEnvVars(cfg.apiKey)
+			: process.env.HYPERSPELL_API_KEY;
 
-  if (!apiKey) {
-    throw new Error(
-      "hyperspell: apiKey is required (set in plugin config or HYPERSPELL_API_KEY env var)",
-    )
-  }
+	if (!apiKey) {
+		throw new Error(
+			"hyperspell: apiKey is required (set in plugin config or HYPERSPELL_API_KEY env var)",
+		);
+	}
 
-  const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>
+	const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>;
+	const atRaw = (cfg.autoTrace ?? {}) as Record<string, unknown>;
 
-  return {
-    apiKey,
-    userId: cfg.userId as string | undefined,
-    autoContext: (cfg.autoContext as boolean) ?? true,
-    syncMemories: (cfg.syncMemories as boolean) ?? false,
-    sources: parseSources(cfg.sources as string | string[] | undefined),
-    maxResults: (cfg.maxResults as number) ?? 10,
-    debug: (cfg.debug as boolean) ?? false,
-    knowledgeGraph: {
-      enabled: (kgRaw.enabled as boolean) ?? false,
-      scanIntervalMinutes: (kgRaw.scanIntervalMinutes as number) ?? 60,
-      batchSize: (kgRaw.batchSize as number) ?? 20,
-    },
-  }
+	return {
+		apiKey,
+		userId: cfg.userId as string | undefined,
+		autoContext: (cfg.autoContext as boolean) ?? true,
+		autoTrace: {
+			enabled: (atRaw.enabled as boolean) ?? false,
+			extract: (atRaw.extract as Array<"procedure" | "memory" | "mood">) ?? [
+				"procedure",
+			],
+			metadata: atRaw.metadata as
+				| Record<string, string | number | boolean>
+				| undefined,
+		},
+		syncMemories: (cfg.syncMemories as boolean) ?? false,
+		sources: parseSources(cfg.sources as string | string[] | undefined),
+		maxResults: (cfg.maxResults as number) ?? 10,
+		debug: (cfg.debug as boolean) ?? false,
+		knowledgeGraph: {
+			enabled: (kgRaw.enabled as boolean) ?? false,
+			scanIntervalMinutes: (kgRaw.scanIntervalMinutes as number) ?? 60,
+			batchSize: (kgRaw.batchSize as number) ?? 20,
+		},
+	};
 }
 
 export const hyperspellConfigSchema = {
-  parse: parseConfig,
-}
+	parse: parseConfig,
+};
 
 /**
  * Get the workspace directory from OpenClaw config
  */
 export function getWorkspaceDir(): string {
-  const { homedir } = require("node:os")
-  const fs = require("node:fs")
-  const path = require("node:path")
+	const { homedir } = require("node:os");
+	const fs = require("node:fs");
+	const path = require("node:path");
 
-  // Resolve config path
-  const override = process.env.OPENCLAW_CONFIG_PATH?.trim() || process.env.CLAWDBOT_CONFIG_PATH?.trim()
-  let configPath: string
-  if (override) {
-    configPath = override.startsWith("~")
-      ? override.replace(/^~(?=$|[\\/])/, homedir())
-      : path.resolve(override)
-  } else {
-    const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim()
-    const resolvedStateDir = stateDir
-      ? (stateDir.startsWith("~") ? stateDir.replace(/^~(?=$|[\\/])/, homedir()) : path.resolve(stateDir))
-      : path.join(homedir(), ".openclaw")
-    configPath = path.join(resolvedStateDir, "openclaw.json")
-  }
+	// Resolve config path
+	const override =
+		process.env.OPENCLAW_CONFIG_PATH?.trim() ||
+		process.env.CLAWDBOT_CONFIG_PATH?.trim();
+	let configPath: string;
+	if (override) {
+		configPath = override.startsWith("~")
+			? override.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(override);
+	} else {
+		const stateDir =
+			process.env.OPENCLAW_STATE_DIR?.trim() ||
+			process.env.CLAWDBOT_STATE_DIR?.trim();
+		const resolvedStateDir = stateDir
+			? stateDir.startsWith("~")
+				? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+				: path.resolve(stateDir)
+			: path.join(homedir(), ".openclaw");
+		configPath = path.join(resolvedStateDir, "openclaw.json");
+	}
 
-  // Read workspace from config
-  if (fs.existsSync(configPath)) {
-    try {
-      const content = fs.readFileSync(configPath, "utf-8")
-      const config = JSON.parse(content)
-      const workspace = config?.agents?.defaults?.workspace
-      if (workspace) {
-        return workspace.startsWith("~")
-          ? workspace.replace(/^~(?=$|[\\/])/, homedir())
-          : workspace
-      }
-    } catch (_e) {
-      // Fall back to default
-    }
-  }
+	// Read workspace from config
+	if (fs.existsSync(configPath)) {
+		try {
+			const content = fs.readFileSync(configPath, "utf-8");
+			const config = JSON.parse(content);
+			const workspace = config?.agents?.defaults?.workspace;
+			if (workspace) {
+				return workspace.startsWith("~")
+					? workspace.replace(/^~(?=$|[\\/])/, homedir())
+					: workspace;
+			}
+		} catch (_e) {
+			// Fall back to default
+		}
+	}
 
-  // Default workspace
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim()
-  const resolvedStateDir = stateDir
-    ? (stateDir.startsWith("~") ? stateDir.replace(/^~(?=$|[\\/])/, homedir()) : path.resolve(stateDir))
-    : path.join(homedir(), ".openclaw")
-  return path.join(resolvedStateDir, "workspace")
+	// Default workspace
+	const stateDir =
+		process.env.OPENCLAW_STATE_DIR?.trim() ||
+		process.env.CLAWDBOT_STATE_DIR?.trim();
+	const resolvedStateDir = stateDir
+		? stateDir.startsWith("~")
+			? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(stateDir)
+		: path.join(homedir(), ".openclaw");
+	return path.join(resolvedStateDir, "workspace");
 }

--- a/hooks/auto-trace.ts
+++ b/hooks/auto-trace.ts
@@ -1,0 +1,127 @@
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { log } from "../logger.ts";
+
+type Message = { role?: string; content?: string | unknown };
+
+const MIN_MESSAGES = 3;
+const MIN_CONVERSATION_LENGTH = 100;
+
+/**
+ * Convert event.messages into OpenClaw JSONL format for the trace API.
+ */
+function messagesToJSONL(messages: unknown[], sessionId: string): string {
+	const lines: string[] = [];
+
+	// Session header
+	lines.push(
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id: sessionId,
+			timestamp: new Date().toISOString(),
+		}),
+	);
+
+	// Message entries
+	for (const raw of messages as Message[]) {
+		if (!raw.role || !raw.content) continue;
+
+		const content =
+			typeof raw.content === "string"
+				? [{ type: "text", text: raw.content }]
+				: Array.isArray(raw.content)
+					? raw.content
+					: [{ type: "text", text: JSON.stringify(raw.content) }];
+
+		const id = crypto.randomUUID().slice(0, 8);
+
+		if (raw.role === "tool" || raw.role === "toolResult") {
+			// Tool results use a different structure
+			lines.push(
+				JSON.stringify({
+					type: "message",
+					id,
+					timestamp: new Date().toISOString(),
+					message: {
+						role: "toolResult",
+						toolCallId: (raw as Record<string, unknown>).toolCallId ?? id,
+						toolName: (raw as Record<string, unknown>).toolName ?? "unknown",
+						content,
+						isError: (raw as Record<string, unknown>).isError ?? false,
+					},
+				}),
+			);
+		} else {
+			lines.push(
+				JSON.stringify({
+					type: "message",
+					id,
+					timestamp: new Date().toISOString(),
+					message: { role: raw.role, content },
+				}),
+			);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Extract and store conversation trace at session end.
+ * Runs on `agent_end` — fire-and-forget.
+ */
+export function buildAutoTraceHandler(
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
+) {
+	return async (event: Record<string, unknown>) => {
+		if (event.success === false) {
+			log.debug("auto-trace: skipping — agent ended with error");
+			return;
+		}
+
+		const messages = event.messages as unknown[] | undefined;
+		if (!messages || messages.length < MIN_MESSAGES) {
+			log.debug(
+				`auto-trace: skipping — too few messages (${messages?.length ?? 0})`,
+			);
+			return;
+		}
+
+		// Quick content length check
+		const estimate = (messages as Message[])
+			.filter((m) => m.content)
+			.reduce((acc, m) => acc + String(m.content).length, 0);
+		if (estimate < MIN_CONVERSATION_LENGTH) {
+			log.debug(
+				`auto-trace: skipping — conversation too short (${estimate} chars)`,
+			);
+			return;
+		}
+
+		const sessionId = (event.sessionId as string) ?? crypto.randomUUID();
+		const history = messagesToJSONL(messages, sessionId);
+
+		// Title from first user message
+		const firstUser = (messages as Message[]).find((m) => m.role === "user");
+		const title = firstUser?.content
+			? String(firstUser.content).slice(0, 80).replace(/\n/g, " ")
+			: undefined;
+
+		try {
+			const result = await client.sendTrace(history, {
+				sessionId,
+				title,
+				extract: cfg.autoTrace.extract,
+				metadata: cfg.autoTrace.metadata,
+			});
+			log.info(
+				`auto-trace: sent ${result.resourceId} (${messages.length} messages)`,
+			);
+		} catch (err) {
+			// Fire-and-forget — never break the session
+			log.error("auto-trace failed", err);
+		}
+	};
+}

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { registerWineCommands } from "./commands/wine.ts"
 import { registerCliCommands } from "./commands/setup.ts"
 import { parseConfig, hyperspellConfigSchema, getWorkspaceDir } from "./config.ts"
 import { buildAutoContextHandler } from "./hooks/auto-context.ts"
+import { buildAutoTraceHandler } from "./hooks/auto-trace.ts"
 import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
 import { initLogger } from "./logger.ts"
 import { registerRememberTool } from "./tools/remember.ts"
@@ -13,108 +14,122 @@ import { registerSommelierTool, registerSommelierRateTool } from "./tools/sommel
 import { registerNetworkTools } from "./graph/index.ts"
 
 export default {
-  id: "openclaw-hyperspell",
-  name: "Hyperspell",
-  description: "Hyperspell gives your Molty context and memory from all your existing data",
-  kind: "memory" as const,
-  configSchema: hyperspellConfigSchema,
+	id: "openclaw-hyperspell",
+	name: "Hyperspell",
+	description:
+		"Hyperspell gives your Molty context and memory from all your existing data",
+	kind: "memory" as const,
+	configSchema: hyperspellConfigSchema,
 
-  register(api: OpenClawPluginApi) {
-    // Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
-    api.registerCli(
-      (ctx) => {
-        registerCliCommands(ctx.program, api.pluginConfig)
-      },
-      { commands: ["openclaw-hyperspell"] },
-    )
+	register(api: OpenClawPluginApi) {
+		// Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
+		api.registerCli(
+			(ctx) => {
+				registerCliCommands(ctx.program, api.pluginConfig);
+			},
+			{ commands: ["openclaw-hyperspell"] },
+		);
 
-    // Check if configured
-    const rawConfig = api.pluginConfig as Record<string, unknown> | undefined
-    const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY
+		// Check if configured
+		const rawConfig = api.pluginConfig as Record<string, unknown> | undefined;
+		const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY;
 
-    // SommeliAgent works independently of Hyperspell config — it just needs uv + Spotify
-    registerSommelierTool(api)
-    registerSommelierRateTool(api)
-    registerWineCommands(api)
+		// SommeliAgent works independently of Hyperspell config — it just needs uv + Spotify
+		registerSommelierTool(api)
+		registerSommelierRateTool(api)
+		registerWineCommands(api)
 
-    if (!hasConfig) {
-      api.logger.info("hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'")
-      // Still register slash commands so they show up, but they'll return an error
-      api.registerCommand({
-        name: "getcontext",
-        description: "Search your memories for relevant context",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "remember",
-        description: "Save something to memory",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "sync",
-        description: "Sync memory/*.md files with Hyperspell",
-        acceptsArgs: false,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      return
-    }
+		if (!hasConfig) {
+			api.logger.info(
+				"hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'",
+			)
+			// Still register slash commands so they show up, but they'll return an error
+			api.registerCommand({
+				name: "getcontext",
+				description: "Search your memories for relevant context",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					}
+				},
+			})
+			api.registerCommand({
+				name: "remember",
+				description: "Save something to memory",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					}
+				},
+			})
+			api.registerCommand({
+				name: "sync",
+				description: "Sync memory/*.md files with Hyperspell",
+				acceptsArgs: false,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					}
+				},
+			})
+			return
+		}
 
-    const cfg = parseConfig(api.pluginConfig)
+		const cfg = parseConfig(api.pluginConfig);
 
-    initLogger(api.logger, cfg.debug)
+		initLogger(api.logger, cfg.debug);
 
-    const client = new HyperspellClient(cfg)
+		const client = new HyperspellClient(cfg);
 
-    // Register AI tools
-    registerSearchTool(api, client, cfg)
-    registerRememberTool(api, client, cfg)
+		// Register AI tools
+		registerSearchTool(api, client, cfg);
+		registerRememberTool(api, client, cfg);
 
-    // Register auto-context hook
-    if (cfg.autoContext) {
-      const autoContextHandler = buildAutoContextHandler(client, cfg)
-      api.on("before_agent_start", autoContextHandler)
-    }
+		// Register auto-context hook
+		if (cfg.autoContext) {
+			const autoContextHandler = buildAutoContextHandler(client, cfg);
+			api.on("before_agent_start", autoContextHandler);
+		}
 
-    // Register memory sync hook
-    if (cfg.syncMemories) {
-      const fileSyncHandler = buildFileSyncHandler(client, cfg)
-      api.on("file_changed", fileSyncHandler)
-    }
+		// Register auto-trace hook (send conversations to Hyperspell on session end)
+		if (cfg.autoTrace.enabled) {
+			api.on("agent_end", buildAutoTraceHandler(client, cfg));
+		}
 
-    // Register memory network tools
-    if (cfg.knowledgeGraph.enabled) {
-      registerNetworkTools(api, client, cfg)
-    }
+		// Register memory sync hook
+		if (cfg.syncMemories) {
+			const fileSyncHandler = buildFileSyncHandler(client, cfg);
+			api.on("file_changed", fileSyncHandler);
+		}
 
-    // Register slash commands
-    registerCommands(api, client, cfg)
+		// Register memory network tools
+		if (cfg.knowledgeGraph.enabled) {
+			registerNetworkTools(api, client, cfg);
+		}
 
-    // Register service for lifecycle management
-    api.registerService({
-      id: "openclaw-hyperspell",
-      start: async () => {
-        api.logger.info("hyperspell: connected")
+		// Register slash commands
+		registerCommands(api, client, cfg);
 
-        // Sync memories on startup if enabled
-        if (cfg.syncMemories) {
-          const workspaceDir = getWorkspaceDir()
-          await syncMemoriesOnStartup(client, workspaceDir)
-        }
-      },
-      stop: () => {
-        api.logger.info("hyperspell: stopped")
-      },
-    })
-  },
-}
+		// Register service for lifecycle management
+		api.registerService({
+			id: "openclaw-hyperspell",
+			start: async () => {
+				api.logger.info("hyperspell: connected");
+
+				// Sync memories on startup if enabled
+				if (cfg.syncMemories) {
+					const workspaceDir = getWorkspaceDir();
+					await syncMemoriesOnStartup(client, workspaceDir);
+				}
+			},
+			stop: () => {
+				api.logger.info("hyperspell: stopped");
+			},
+		});
+	},
+};

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,88 +1,111 @@
 {
-  "id": "openclaw-hyperspell",
-  "kind": "memory",
-  "uiHints": {
-    "apiKey": {
-      "label": "Hyperspell API Key",
-      "sensitive": true,
-      "placeholder": "hs_...",
-      "help": "Your API key from app.hyperspell.com (or use ${HYPERSPELL_API_KEY})"
-    },
-    "userId": {
-      "label": "User ID",
-      "placeholder": "user_123",
-      "help": "User ID (can be your email)",
-      "advanced": false
-    },
-    "autoContext": {
-      "label": "Auto-Context",
-      "help": "Inject relevant memories before every AI turn",
-      "advanced": true
-    },
-    "sources": {
-      "label": "Sources",
-      "placeholder": "notion,slack,google_drive",
-      "help": "Comma-separated list of sources to search. Leave empty for all sources.",
-      "advanced": true
-    },
-    "maxResults": {
-      "label": "Max Results",
-      "placeholder": "10",
-      "help": "Maximum memories injected into context per turn",
-      "advanced": true
-    },
-    "debug": {
-      "label": "Debug Logging",
-      "help": "Enable verbose debug logs for API calls and responses",
-      "advanced": true
-    },
-    "syncMemories": {
-      "label": "Sync Memory Files",
-      "help": "Automatically sync markdown files in workspace/memory/ to Hyperspell",
-      "advanced": true
-    },
-    "knowledgeGraph": {
-      "label": "Memory Network",
-      "help": "Extract entities (people, projects, orgs, topics) from memories into structured markdown files. Requires a cron job for periodic scanning.",
-      "advanced": true
-    }
-  },
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-      "apiKey": {
-        "type": "string"
-      },
-      "userId": {
-        "type": "string"
-      },
-      "autoContext": {
-        "type": "boolean"
-      },
-      "sources": {
-        "type": "string"
-      },
-      "maxResults": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 20
-      },
-      "debug": {
-        "type": "boolean"
-      },
-      "syncMemories": {
-        "type": "boolean"
-      },
-      "knowledgeGraph": {
-        "type": "object",
-        "properties": {
-          "enabled": { "type": "boolean" },
-          "scanIntervalMinutes": { "type": "number", "minimum": 5, "maximum": 1440 },
-          "batchSize": { "type": "number", "minimum": 5, "maximum": 100 }
-        }
-      }
-    },
-    "required": []
-  }
+	"id": "openclaw-hyperspell",
+	"kind": "memory",
+	"uiHints": {
+		"apiKey": {
+			"label": "Hyperspell API Key",
+			"sensitive": true,
+			"placeholder": "hs_...",
+			"help": "Your API key from app.hyperspell.com (or use ${HYPERSPELL_API_KEY})"
+		},
+		"userId": {
+			"label": "User ID",
+			"placeholder": "user_123",
+			"help": "User ID (can be your email)",
+			"advanced": false
+		},
+		"autoContext": {
+			"label": "Auto-Context",
+			"help": "Inject relevant memories before every AI turn",
+			"advanced": true
+		},
+		"autoTrace": {
+			"label": "Auto-Trace",
+			"help": "Automatically send conversation traces to Hyperspell for memory extraction (procedural, mood) at the end of each session",
+			"advanced": true
+		},
+		"sources": {
+			"label": "Sources",
+			"placeholder": "notion,slack,google_drive",
+			"help": "Comma-separated list of sources to search. Leave empty for all sources.",
+			"advanced": true
+		},
+		"maxResults": {
+			"label": "Max Results",
+			"placeholder": "10",
+			"help": "Maximum memories injected into context per turn",
+			"advanced": true
+		},
+		"debug": {
+			"label": "Debug Logging",
+			"help": "Enable verbose debug logs for API calls and responses",
+			"advanced": true
+		},
+		"syncMemories": {
+			"label": "Sync Memory Files",
+			"help": "Automatically sync markdown files in workspace/memory/ to Hyperspell",
+			"advanced": true
+		},
+		"knowledgeGraph": {
+			"label": "Memory Network",
+			"help": "Extract entities (people, projects, orgs, topics) from memories into structured markdown files. Requires a cron job for periodic scanning.",
+			"advanced": true
+		}
+	},
+	"configSchema": {
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"apiKey": {
+				"type": "string"
+			},
+			"userId": {
+				"type": "string"
+			},
+			"autoContext": {
+				"type": "boolean"
+			},
+			"autoTrace": {
+				"type": "object",
+				"properties": {
+					"enabled": { "type": "boolean" },
+					"extract": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["procedure", "memory", "mood"]
+						}
+					},
+					"metadata": { "type": "object" }
+				}
+			},
+			"sources": {
+				"type": "string"
+			},
+			"maxResults": {
+				"type": "number",
+				"minimum": 1,
+				"maximum": 20
+			},
+			"debug": {
+				"type": "boolean"
+			},
+			"syncMemories": {
+				"type": "boolean"
+			},
+			"knowledgeGraph": {
+				"type": "object",
+				"properties": {
+					"enabled": { "type": "boolean" },
+					"scanIntervalMinutes": {
+						"type": "number",
+						"minimum": 5,
+						"maximum": 1440
+					},
+					"batchSize": { "type": "number", "minimum": 5, "maximum": 100 }
+				}
+			}
+		},
+		"required": []
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `agent_end` hook that serializes conversation to OpenClaw JSONL and sends to `POST /trace/add`
- New `autoTrace` config: `{ enabled: boolean, extract: ["procedure", "mood"], metadata: {} }`
- Uses SDK's `sessions.add()` method (no raw fetch calls)
- Fire-and-forget: errors logged but never break the session
- Skips traces with < 3 messages or < 100 chars

## Replaces
This is a cleaner alternative to #2 (emotional context). Instead of custom `/emotional-state` endpoints, this uses the standard trace pipeline with the mood extractor from hyperspell/hyperspell#581.

## Dependencies
- hyperspell/hyperspell#581 (mood extractor) for `extract: ["mood"]` support
- Node SDK needs `"mood"` added to `SessionAddParams.extract` types

## Test plan
- [ ] Set `autoTrace: { enabled: true, extract: ["procedure", "mood"] }` in plugin config
- [ ] Have a conversation (3+ messages)
- [ ] Verify trace appears in Hyperspell dashboard
- [ ] Verify short conversations (< 3 messages) are skipped
- [ ] Verify failed sessions (`success: false`) are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)