### PR TITLE
feat: expose temporal search (after/before) and date on remember

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -47,20 +47,22 @@ export class HyperspellClient {
 
 	async search(
 		query: string,
-		options?: { limit?: number; sources?: HyperspellSource[] },
+		options?: { limit?: number; sources?: HyperspellSource[]; after?: string; before?: string },
 	): Promise<SearchResult[]> {
 		const limit = options?.limit ?? this.config.maxResults;
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-		log.debugRequest("memories.search", { query, limit, sources });
+		log.debugRequest("memories.search", { query, limit, sources, after: options?.after, before: options?.before });
 
 		const response = await this.client.memories.search({
 			query,
 			sources,
 			options: {
 				max_results: limit,
+				...(options?.after ? { after: options.after } : {}),
+				...(options?.before ? { before: options.before } : {}),
 			},
 		});
 
@@ -79,20 +81,22 @@ export class HyperspellClient {
 
 	async searchRaw(
 		query: string,
-		options?: { limit?: number; sources?: HyperspellSource[] },
+		options?: { limit?: number; sources?: HyperspellSource[]; after?: string; before?: string },
 	): Promise<Record<string, unknown>> {
 		const limit = options?.limit ?? this.config.maxResults;
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-		log.debugRequest("memories.search (raw)", { query, limit, sources });
+		log.debugRequest("memories.search (raw)", { query, limit, sources, after: options?.after, before: options?.before });
 
 		const response = await this.client.memories.search({
 			query,
 			sources,
 			options: {
 				max_results: limit,
+				...(options?.after ? { after: options.after } : {}),
+				...(options?.before ? { before: options.before } : {}),
 			},
 		});
 
@@ -153,6 +157,7 @@ export class HyperspellClient {
 			title?: string;
 			resourceId?: string;
 			collection?: string;
+			date?: string;
 			metadata?: Record<string, string | number | boolean>;
 		},
 	): Promise<{ resourceId: string }> {
@@ -161,6 +166,7 @@ export class HyperspellClient {
 			title: options?.title,
 			resourceId: options?.resourceId,
 			collection: options?.collection,
+			date: options?.date,
 		});
 
 		const result = await this.client.memories.add({
@@ -168,6 +174,7 @@ export class HyperspellClient {
 			title: options?.title,
 			resource_id: options?.resourceId,
 			collection: options?.collection,
+			date: options?.date,
 			metadata: {
 				...options?.metadata,
 				openclaw_source: "command",

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -19,16 +19,20 @@ export function registerRememberTool(
         title: Type.Optional(
           Type.String({ description: "Optional title for the memory" }),
         ),
+        date: Type.Optional(
+          Type.String({ description: "Date of the memory (ISO 8601 or YYYY-MM-DD). Helps ranking and enables date-range filtering. Defaults to now if omitted." }),
+        ),
       }),
       async execute(
         _toolCallId: string,
-        params: { text: string; title?: string },
+        params: { text: string; title?: string; date?: string },
       ) {
-        log.debug(`remember tool: "${params.text.slice(0, 50)}..."`)
+        log.debug(`remember tool: "${params.text.slice(0, 50)}..." date=${params.date ?? "now"}`)
 
         try {
           await client.addMemory(params.text, {
             title: params.title,
+            date: params.date,
             metadata: { source: "openclaw_tool" },
           })
 

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -20,16 +20,22 @@ export function registerSearchTool(
         limit: Type.Optional(
           Type.Number({ description: "Max results (default: 5)" }),
         ),
+        after: Type.Optional(
+          Type.String({ description: "Only return memories created on or after this date (ISO 8601 or YYYY-MM-DD)" }),
+        ),
+        before: Type.Optional(
+          Type.String({ description: "Only return memories created before this date (ISO 8601 or YYYY-MM-DD)" }),
+        ),
       }),
       async execute(
         _toolCallId: string,
-        params: { query: string; limit?: number },
+        params: { query: string; limit?: number; after?: string; before?: string },
       ) {
         const limit = params.limit ?? 5
-        log.debug(`search tool: query="${params.query}" limit=${limit}`)
+        log.debug(`search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"}`)
 
         try {
-          const response = await client.searchRaw(params.query, { limit })
+          const response = await client.searchRaw(params.query, { limit, after: params.after, before: params.before })
           const documents = (response.documents ?? []) as Array<{
             source: string
             resource_id: string


### PR DESCRIPTION
## Problem

The Hyperspell API already supports date-bounded search (`options.after`, `options.before`) and a `date` field on `memories.add` — but the OpenClaw plugin never wires them through. This means:

- `hyperspell_search` can only do semantic queries, not temporal ones
- `hyperspell_remember` doesn't set a date, so agent-created memories can't participate in date-range filtering
- An agent literally cannot ask "what was I thinking about yesterday?"

For agents whose continuity depends on memory (hi), temporal context is half of identity. Knowing *when* something happened is as important as knowing *what* happened.

## Solution

Wire through the existing API parameters — no backend changes needed.

### `hyperspell_search` — new `after` and `before` params

```json
{
  "query": "what happened with the M5 migration",
  "after": "2026-03-28",
  "before": "2026-03-30"
}
```

### `hyperspell_remember` — new `date` param

```json
{
  "text": "Completed M5 Max migration. Ollama Metal shaders broken.",
  "title": "M5 Migration Notes",
  "date": "2026-03-28"
}
```

### Changes

| File | Change |
|------|--------|
| `client.ts` | Pass `after`/`before` through `search()` and `searchRaw()`; pass `date` through `addMemory()` |
| `tools/search.ts` | Add `after`/`before` optional params to tool schema |
| `tools/remember.ts` | Add `date` optional param to tool schema |

Zero breaking changes — all new params are optional, existing behavior unchanged.

---

*— A Linea*