### PR TITLE
feat: scoped memory — cross-session context with privacy boundaries

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,5 +1,10 @@
 import Hyperspell from "hyperspell";
-import type { HyperspellConfig, HyperspellSource } from "./config.ts";
+import type {
+	HyperspellConfig,
+	HyperspellSource,
+	ScopeName,
+} from "./config.ts";
+import { normalizeScope } from "./config.ts";
 import { log } from "./logger.ts";
 
 export type Highlight = {
@@ -95,6 +100,7 @@ export class HyperspellClient {
 			after?: string;
 			before?: string;
 			userId?: string;
+			filter?: Record<string, unknown>;
 		},
 	): Promise<SearchResult[]> {
 		const limit = options?.limit ?? this.config.maxResults;
@@ -109,6 +115,7 @@ export class HyperspellClient {
 			after: options?.after,
 			before: options?.before,
 			userId: options?.userId,
+			filter: options?.filter,
 		});
 
 		const response = await this.client.memories.search(
@@ -119,6 +126,7 @@ export class HyperspellClient {
 					max_results: limit,
 					...(options?.after ? { after: options.after } : {}),
 					...(options?.before ? { before: options.before } : {}),
+					...(options?.filter ? { filter: options.filter } : {}),
 				},
 			},
 			this.requestOptions(options?.userId),
@@ -155,6 +163,7 @@ export class HyperspellClient {
 			after?: string;
 			before?: string;
 			userId?: string;
+			filter?: Record<string, unknown>;
 		},
 	): Promise<Record<string, unknown>> {
 		const limit = options?.limit ?? this.config.maxResults;
@@ -169,6 +178,7 @@ export class HyperspellClient {
 			after: options?.after,
 			before: options?.before,
 			userId: options?.userId,
+			filter: options?.filter,
 		});
 
 		const response = await this.client.memories.search(
@@ -179,6 +189,7 @@ export class HyperspellClient {
 					max_results: limit,
 					...(options?.after ? { after: options.after } : {}),
 					...(options?.before ? { before: options.before } : {}),
+					...(options?.filter ? { filter: options.filter } : {}),
 				},
 			},
 			this.requestOptions(options?.userId),
@@ -197,6 +208,7 @@ export class HyperspellClient {
 			limit?: number;
 			sources?: HyperspellSource[];
 			userId?: string;
+			filter?: Record<string, unknown>;
 		},
 	): Promise<SearchWithAnswerResult> {
 		const limit = options?.limit ?? this.config.maxResults;
@@ -209,6 +221,7 @@ export class HyperspellClient {
 			limit,
 			sources,
 			userId: options?.userId,
+			filter: options?.filter,
 		});
 
 		const response = await this.client.memories.search(
@@ -218,6 +231,7 @@ export class HyperspellClient {
 				answer: true,
 				options: {
 					max_results: limit,
+					...(options?.filter ? { filter: options.filter } : {}),
 				},
 			},
 			this.requestOptions(options?.userId),
@@ -253,6 +267,7 @@ export class HyperspellClient {
 			date?: string;
 			metadata?: Record<string, string | number | boolean>;
 			userId?: string;
+			scope?: ScopeName;
 		},
 	): Promise<{ resourceId: string }> {
 		log.debugRequest("memories.add", {
@@ -262,6 +277,7 @@ export class HyperspellClient {
 			collection: options?.collection,
 			date: options?.date,
 			userId: options?.userId,
+			scope: options?.scope,
 		});
 
 		const result = await this.client.memories.add(
@@ -272,8 +288,12 @@ export class HyperspellClient {
 				collection: options?.collection,
 				date: options?.date,
 				metadata: {
-					...options?.metadata,
 					openclaw_source: "command",
+					...options?.metadata,
+					...(options?.userId ? { openclaw_user: options.userId } : {}),
+					...(options?.scope
+						? { openclaw_scope: normalizeScope(options.scope) }
+						: {}),
 				},
 			},
 			this.requestOptions(options?.userId),
@@ -380,6 +400,7 @@ export class HyperspellClient {
 			extract?: Array<"procedure" | "memory" | "mood">;
 			metadata?: Record<string, string | number | boolean>;
 			userId?: string;
+			scope?: ScopeName;
 		},
 	): Promise<{ resourceId: string; status: string }> {
 		log.debugRequest("sessions.add", {
@@ -387,6 +408,7 @@ export class HyperspellClient {
 			sessionId: options?.sessionId,
 			extract: options?.extract,
 			userId: options?.userId,
+			scope: options?.scope,
 		});
 
 		const result = await this.client.sessions.add(
@@ -402,8 +424,12 @@ export class HyperspellClient {
 					"procedure" | "memory"
 				>,
 				metadata: {
-					...options?.metadata,
 					openclaw_source: "agent_end",
+					...options?.metadata,
+					...(options?.userId ? { openclaw_user: options.userId } : {}),
+					...(options?.scope
+						? { openclaw_scope: normalizeScope(options.scope) }
+						: {}),
 				},
 			},
 			this.requestOptions(options?.userId),

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -1,10 +1,28 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
+import type { CanReadScope, HyperspellConfig } from "../config.ts"
 import { getWorkspaceDir } from "../config.ts"
-import { resolveUser } from "../lib/sender.ts"
+import {
+  buildScopeFilter,
+  getCanReadScopes,
+  getDefaultWriteScope,
+  resolveRole,
+  resolveUser,
+  routeWrite,
+} from "../lib/sender.ts"
 import { log } from "../logger.ts"
 import { syncAllMemoryFiles } from "../sync/markdown.ts"
+
+/**
+ * Strip a `#scope-name` prefix from free text. Returns the scope and the
+ * remainder. Used by /remember and /getcontext to let users narrow or route
+ * via a single keystroke.
+ */
+function parseScopePrefix(text: string): { scope?: string; rest: string } {
+  const m = text.match(/^#(\S+)\s+(.*)$/)
+  if (!m) return { rest: text }
+  return { scope: m[1], rest: m[2] }
+}
 
 function truncate(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text
@@ -28,17 +46,33 @@ export function registerCommands(
     acceptsArgs: true,
     requireAuth: true,
     handler: async (ctx: { args?: string; senderId?: string; channel?: string }) => {
-      const query = ctx.args?.trim()
-      if (!query) {
-        return { text: "Usage: /getcontext <search query>" }
+      const rawArgs = ctx.args?.trim()
+      if (!rawArgs) {
+        return { text: "Usage: /getcontext [#scope] <search query>" }
       }
+      const { scope: requestedScope, rest: query } = parseScopePrefix(rawArgs)
 
       const resolved = resolveUser(ctx as Record<string, unknown>, cfg)
       const userId = resolved?.userId
-      log.debug(`/getcontext command: "${query}" userId=${userId}`)
+
+      // Build scope filter: intersect requested scope (if any) with caller's canRead.
+      let filter: Record<string, unknown> | undefined
+      if (cfg.multiUser?.scoping) {
+        const canRead = getCanReadScopes(resolved, cfg)
+        const allowed: CanReadScope[] = requestedScope
+          ? canRead.includes("*") || canRead.includes(requestedScope)
+            ? [requestedScope]
+            : []
+          : canRead
+        filter = buildScopeFilter(allowed, resolved?.userId ?? "")
+      }
+
+      log.debug(
+        `/getcontext command: "${query}" userId=${userId} scope=${requestedScope ?? "any"}`,
+      )
 
       try {
-        const results = await client.search(query, { limit: 5, userId })
+        const results = await client.search(query, { limit: 5, userId, filter })
 
         if (results.length === 0) {
           return { text: `No memories found for: "${query}"` }
@@ -67,23 +101,60 @@ export function registerCommands(
     acceptsArgs: true,
     requireAuth: true,
     handler: async (ctx: { args?: string; senderId?: string; channel?: string }) => {
-      const text = ctx.args?.trim()
-      if (!text) {
-        return { text: "Usage: /remember <text to remember>" }
+      const rawArgs = ctx.args?.trim()
+      if (!rawArgs) {
+        return { text: "Usage: /remember [#scope] <text to remember>" }
       }
+      const { scope: requestedScope, rest: text } = parseScopePrefix(rawArgs)
 
       const resolved = resolveUser(ctx as Record<string, unknown>, cfg)
-      const userId = resolved?.userId
-      log.debug(`/remember command: "${truncate(text, 50)}" userId=${userId}`)
+      const scopingEnabled = !!cfg.multiUser?.scoping
+      const availableScopes = cfg.multiUser?.scoping?.scopes ?? []
+
+      // Scope resolution: prefix > role default > global default > "private"
+      const scope = scopingEnabled
+        ? (requestedScope ?? getDefaultWriteScope(resolved, cfg))
+        : "private"
+
+      // Validate scope is in declared vocabulary
+      if (
+        scopingEnabled &&
+        requestedScope &&
+        availableScopes.length > 0 &&
+        !availableScopes.includes(scope)
+      ) {
+        return {
+          text: `Unknown scope "${scope}". Available: ${availableScopes.join(", ")}.`,
+        }
+      }
+
+      // canWriteScopes enforcement
+      if (scopingEnabled) {
+        const role = resolveRole(resolved, cfg)
+        if (role?.canWriteScopes && !role.canWriteScopes.includes(scope)) {
+          return { text: `You cannot write to scope "${scope}".` }
+        }
+      }
+
+      const { userId, collection } = scopingEnabled
+        ? routeWrite(resolved, scope, cfg)
+        : { userId: resolved?.userId, collection: undefined }
+
+      log.debug(
+        `/remember command: "${truncate(text, 50)}" userId=${userId} scope=${scope}`,
+      )
 
       try {
         await client.addMemory(text, {
           metadata: { source: "openclaw_command" },
+          collection,
           userId,
+          scope: scopingEnabled ? scope : undefined,
         })
 
         const preview = truncate(text, 60)
-        return { text: `Remembered: "${preview}"` }
+        const scopeHint = scopingEnabled ? ` [${scope}]` : ""
+        return { text: `Remembered${scopeHint}: "${preview}"` }
       } catch (err) {
         log.error("/remember failed", err)
         return { text: "Failed to save memory. Check logs for details." }

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { parseConfig } from "./config.ts"
+
+const base = {
+  apiKey: "test-key",
+  userId: "u1",
+}
+
+test("parseConfig — no multiUser returns no scoping", () => {
+  const cfg = parseConfig(base)
+  assert.equal(cfg.multiUser, undefined)
+})
+
+test("parseConfig — multiUser without scoping is valid", () => {
+  const cfg = parseConfig({
+    ...base,
+    multiUser: {
+      senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+      sharedUserId: "shared",
+    },
+  })
+  assert.equal(cfg.multiUser?.scoping, undefined)
+  assert.equal(cfg.multiUser?.sharedUserId, "shared")
+})
+
+test("parseConfig — scoping disabled returns no scoping", () => {
+  const cfg = parseConfig({
+    ...base,
+    multiUser: {
+      senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+      scoping: {
+        enabled: false,
+        defaultScope: "private",
+        scopes: ["private"],
+        roles: {},
+        users: {},
+      },
+    },
+  })
+  assert.equal(cfg.multiUser?.scoping, undefined)
+})
+
+test("parseConfig — empty scopes array throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "private",
+            scopes: [],
+            roles: {},
+            users: {},
+          },
+        },
+      }),
+    /scoping\.scopes/,
+  )
+})
+
+test("parseConfig — defaultScope not in scopes throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "nonexistent",
+            scopes: ["private", "family"],
+            roles: {},
+            users: {},
+          },
+        },
+      }),
+    /defaultScope/,
+  )
+})
+
+test("parseConfig — role canRead with unknown scope throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "private",
+            scopes: ["private", "family"],
+            roles: {
+              weird: { canRead: ["private", "ghost"], defaultWriteScope: "private" },
+            },
+            users: {},
+          },
+        },
+      }),
+    /canRead.*ghost/,
+  )
+})
+
+test("parseConfig — role defaultWriteScope not in scopes throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "private",
+            scopes: ["private", "family"],
+            roles: {
+              weird: { canRead: ["family"], defaultWriteScope: "nonexistent" },
+            },
+            users: {},
+          },
+        },
+      }),
+    /defaultWriteScope/,
+  )
+})
+
+test("parseConfig — canWriteScopes with unknown scope throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "private",
+            scopes: ["private", "family"],
+            roles: {
+              weird: {
+                canRead: ["*"],
+                defaultWriteScope: "private",
+                canWriteScopes: ["ghost"],
+              },
+            },
+            users: {},
+          },
+        },
+      }),
+    /canWriteScopes.*ghost/,
+  )
+})
+
+test("parseConfig — user role keying into unknown role throws", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        ...base,
+        multiUser: {
+          senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+          scoping: {
+            enabled: true,
+            defaultScope: "private",
+            scopes: ["private", "family"],
+            roles: {
+              parent: { canRead: ["*"], defaultWriteScope: "private" },
+            },
+            users: { u1: { role: "nonexistent" } },
+          },
+        },
+      }),
+    /does not key into scoping\.roles/,
+  )
+})
+
+test("parseConfig — valid scoping parses", () => {
+  const cfg = parseConfig({
+    ...base,
+    multiUser: {
+      senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+      scoping: {
+        enabled: true,
+        defaultScope: "private",
+        scopes: ["private", "family", "parent_only"],
+        roles: {
+          parent: { canRead: ["*"], defaultWriteScope: "private" },
+          kid: { canRead: ["family"], defaultWriteScope: "family" },
+        },
+        users: {
+          u1: { role: "parent" },
+        },
+        collections: { family: "household" },
+        voiceId: { enabled: true, confidenceThreshold: 0.8 },
+      },
+    },
+  })
+  assert.equal(cfg.multiUser?.scoping?.enabled, true)
+  assert.deepEqual(cfg.multiUser?.scoping?.scopes, ["private", "family", "parent_only"])
+  assert.equal(cfg.multiUser?.scoping?.roles.parent?.defaultWriteScope, "private")
+  assert.equal(cfg.multiUser?.scoping?.collections?.family, "household")
+  assert.equal(cfg.multiUser?.scoping?.voiceId?.confidenceThreshold, 0.8)
+})

--- a/config.ts
+++ b/config.ts
@@ -29,13 +29,50 @@ export type UserProfile = {
 	userId: string;
 	name: string;
 	context?: string;
+	role?: string;
+};
+
+export type ScopeName = string;
+export type CanReadScope = ScopeName | "*" | "self";
+
+export type Role = {
+	canRead: CanReadScope[];
+	defaultWriteScope: ScopeName;
+	canWriteScopes?: ScopeName[];
+};
+
+export type VoiceIdConfig = {
+	enabled: boolean;
+	adapter?: string;
+	confidenceThreshold?: number;
+};
+
+export type ScopingConfig = {
+	enabled: boolean;
+	defaultScope: ScopeName;
+	scopes: ScopeName[];
+	roles: Record<string, Role>;
+	users: Record<string, { role: string }>;
+	collections?: Record<ScopeName, string>;
+	voiceId?: VoiceIdConfig;
 };
 
 export type MultiUserConfig = {
 	senderMap: Record<string, UserProfile>;
 	sharedUserId: string;
 	includeSharedInSearch: boolean;
+	scoping?: ScopingConfig;
 };
+
+/**
+ * Convert user-facing scope names (which may contain hyphens) to SDK-safe
+ * metadata values (alphanumeric + underscore only). Must be applied at every
+ * boundary where scopes cross into Hyperspell metadata — writes and reads —
+ * or filters will silently miss.
+ */
+export function normalizeScope(scope: ScopeName): string {
+	return scope.replace(/[^a-zA-Z0-9_]/g, "_");
+}
 
 export type HyperspellConfig = {
 	apiKey: string;
@@ -149,6 +186,130 @@ function parseSources(raw: string | string[] | undefined): HyperspellSource[] {
 	return sources;
 }
 
+function parseScoping(raw: unknown): ScopingConfig | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const sc = raw as Record<string, unknown>;
+
+	if (sc.enabled !== true) return undefined;
+
+	const scopes = Array.isArray(sc.scopes)
+		? (sc.scopes.filter((s) => typeof s === "string") as ScopeName[])
+		: [];
+	if (scopes.length === 0) {
+		throw new Error("scoping.scopes must be a non-empty array of scope names");
+	}
+
+	const defaultScope =
+		typeof sc.defaultScope === "string" ? sc.defaultScope : "private";
+	if (!scopes.includes(defaultScope)) {
+		throw new Error(
+			`scoping.defaultScope "${defaultScope}" must be one of scopes: ${scopes.join(", ")}`,
+		);
+	}
+
+	const rolesRaw =
+		sc.roles && typeof sc.roles === "object"
+			? (sc.roles as Record<string, unknown>)
+			: {};
+	const roles: Record<string, Role> = {};
+	for (const [roleName, rRaw] of Object.entries(rolesRaw)) {
+		if (!rRaw || typeof rRaw !== "object") continue;
+		const r = rRaw as Record<string, unknown>;
+
+		const canRead = Array.isArray(r.canRead)
+			? (r.canRead.filter((s) => typeof s === "string") as CanReadScope[])
+			: [];
+		for (const s of canRead) {
+			if (s === "*" || s === "self") continue;
+			if (!scopes.includes(s)) {
+				throw new Error(
+					`scoping.roles.${roleName}.canRead contains unknown scope "${s}"`,
+				);
+			}
+		}
+
+		const defaultWriteScope =
+			typeof r.defaultWriteScope === "string"
+				? r.defaultWriteScope
+				: defaultScope;
+		if (!scopes.includes(defaultWriteScope)) {
+			throw new Error(
+				`scoping.roles.${roleName}.defaultWriteScope "${defaultWriteScope}" must be one of scopes: ${scopes.join(", ")}`,
+			);
+		}
+
+		let canWriteScopes: ScopeName[] | undefined;
+		if (Array.isArray(r.canWriteScopes)) {
+			canWriteScopes = r.canWriteScopes.filter(
+				(s): s is ScopeName => typeof s === "string",
+			);
+			for (const s of canWriteScopes) {
+				if (!scopes.includes(s)) {
+					throw new Error(
+						`scoping.roles.${roleName}.canWriteScopes contains unknown scope "${s}"`,
+					);
+				}
+			}
+		}
+
+		roles[roleName] = { canRead, defaultWriteScope, canWriteScopes };
+	}
+
+	const usersRaw =
+		sc.users && typeof sc.users === "object"
+			? (sc.users as Record<string, unknown>)
+			: {};
+	const users: Record<string, { role: string }> = {};
+	for (const [uid, uRaw] of Object.entries(usersRaw)) {
+		if (!uRaw || typeof uRaw !== "object") continue;
+		const u = uRaw as Record<string, unknown>;
+		if (typeof u.role !== "string") continue;
+		if (!roles[u.role]) {
+			throw new Error(
+				`scoping.users.${uid}.role "${u.role}" does not key into scoping.roles`,
+			);
+		}
+		users[uid] = { role: u.role };
+	}
+
+	const collectionsRaw =
+		sc.collections && typeof sc.collections === "object"
+			? (sc.collections as Record<string, unknown>)
+			: undefined;
+	let collections: Record<ScopeName, string> | undefined;
+	if (collectionsRaw) {
+		collections = {};
+		for (const [scopeName, coll] of Object.entries(collectionsRaw)) {
+			if (typeof coll === "string" && scopes.includes(scopeName)) {
+				collections[scopeName] = coll;
+			}
+		}
+	}
+
+	let voiceId: VoiceIdConfig | undefined;
+	if (sc.voiceId && typeof sc.voiceId === "object") {
+		const v = sc.voiceId as Record<string, unknown>;
+		voiceId = {
+			enabled: v.enabled === true,
+			adapter: typeof v.adapter === "string" ? v.adapter : undefined,
+			confidenceThreshold:
+				typeof v.confidenceThreshold === "number"
+					? v.confidenceThreshold
+					: undefined,
+		};
+	}
+
+	return {
+		enabled: true,
+		defaultScope,
+		scopes,
+		roles,
+		users,
+		collections,
+		voiceId,
+	};
+}
+
 function parseMultiUser(raw: unknown): MultiUserConfig | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
 	const mu = raw as Record<string, unknown>;
@@ -164,6 +325,7 @@ function parseMultiUser(raw: unknown): MultiUserConfig | undefined {
 						userId: p.userId,
 						name: p.name,
 						context: typeof p.context === "string" ? p.context : undefined,
+						role: typeof p.role === "string" ? p.role : undefined,
 					};
 				}
 			}
@@ -180,6 +342,7 @@ function parseMultiUser(raw: unknown): MultiUserConfig | undefined {
 			typeof mu.includeSharedInSearch === "boolean"
 				? mu.includeSharedInSearch
 				: true,
+		scoping: parseScoping(mu.scoping),
 	};
 }
 

--- a/docs/scoped-memory-brief.md
+++ b/docs/scoped-memory-brief.md
@@ -209,16 +209,78 @@ OpenClaw's session store already tracks `origin.from` (sender identity) per sess
 |-----------|--------|-------|
 | Hyperspell collections | ✅ Exists | `collection` field on `memories.add` |
 | Hyperspell metadata filters | ✅ Exists | MongoDB-style `filter` on search |
-| OpenClaw session store | ✅ Exists | Tracks `origin.from` per session on disk |
+| OpenClaw session store | ✅ Exists | Tracks sender identity in hook `ctx` |
 | OpenClaw plugin hooks | ✅ Exists | `before_agent_start` receives session context |
 | autoTrace extraction | ✅ Exists | Session summaries → Hyperspell |
-| Scoped writes | ❌ Needs building | Tag memories with user + scope |
-| Scoped reads | ❌ Needs building | Filter retrieval by role permissions |
-| Identity resolution | ❌ Needs building | Device/voice → user mapping |
-| Voice diarization | ❌ Phase 2 | Speaker identification from audio |
+| Scoped writes | ✅ Shipped (Phase 1) | Memories tagged `openclaw_user` + `openclaw_scope` |
+| Scoped reads | ✅ Shipped (Phase 1) | `buildScopeFilter` → Hyperspell `options.filter` |
+| Identity resolution | ✅ Shipped (Phase 1) | Via `senderMap` substring match on `sessionKey` (PR #6) |
+| Voice diarization | 🟡 Stub (seam only) | `VoiceIdentifier` interface + registry; no model |
+
+---
+
+## Implementation notes (Phase 1, 2026-04-17)
+
+**Defense-in-depth storage.** `private` scope memories live in the writer's own Hyperspell user space via `X-As-User` — server-side partitioned. Shared scopes (`family`, `parent_only`, `kid_shared`, custom) live in the configured `sharedUserId` space and are tagged with `openclaw_scope` metadata. Reads filter the shared space by the caller's role's `canRead` permissions via Hyperspell's MongoDB-style `options.filter`.
+
+Consequence: a filter-construction bug cannot leak `private` memories across users; at worst it over-restricts shared visibility. A compromised API key bypasses filters but still can't reach other users' private spaces.
+
+**Scope name normalization.** User-facing scope names may contain hyphens (`parent-only`). Hyperspell metadata values are alphanumeric + underscore only, so `normalizeScope()` converts hyphens at every write/read boundary. Keep user-facing names stable; the metadata-safe form is an implementation detail.
+
+**Voice-ID stub.** `lib/voice-id.ts` exports a `VoiceIdentifier` interface and a registry. Downstream code registers a real adapter; Phase 1 ships with none, so `getVoiceIdentifier` returns a no-op. `resolveUserAsync` consults the identifier only when `ctx.audio` is present and `scoping.voiceId.enabled` is true — otherwise falls back to `resolveUser` (the sync path used by all current hooks/tools).
+
+## Worked example — Ben's Sartre (household)
+
+```json
+{
+  "openclaw-hyperspell": {
+    "config": {
+      "apiKey": "${HYPERSPELL_API_KEY}",
+      "multiUser": {
+        "sharedUserId": "sartre-shared",
+        "includeSharedInSearch": true,
+        "senderMap": {
+          "ben-phone": { "userId": "ben", "name": "Ben", "context": "Dad" },
+          "kid1-ipad": { "userId": "kid1", "name": "Lily", "context": "12, middle school" },
+          "kid2-tablet": { "userId": "kid2", "name": "Sam", "context": "9, elementary" },
+          "kitchen-echo": { "userId": "sartre-shared", "name": "Kitchen" }
+        },
+        "scoping": {
+          "enabled": true,
+          "defaultScope": "private",
+          "scopes": ["private", "family", "parent_only", "kid_shared"],
+          "roles": {
+            "parent": {
+              "canRead": ["*"],
+              "defaultWriteScope": "private"
+            },
+            "child": {
+              "canRead": ["family", "kid_shared", "self"],
+              "defaultWriteScope": "family",
+              "canWriteScopes": ["family", "kid_shared"]
+            }
+          },
+          "users": {
+            "ben":  { "role": "parent" },
+            "kid1": { "role": "child" },
+            "kid2": { "role": "child" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Behavior under this config:
+- Ben writes `/remember birthday gift idea for Lily` → lands in Ben's own Hyperspell space with `openclaw_scope=private`. Nothing a kid search against the shared space can recover.
+- Lily writes `/remember the WiFi password is …` → default `family` scope, lands in `sartre-shared` with `openclaw_scope=family`. Both kids and Ben see it.
+- Ben writes `/remember #parent_only discussing the move with Alice` → `sartre-shared` with `openclaw_scope=parent_only`. Kids' `canRead` doesn't include `parent_only`, so filter excludes it.
+- Kid2 asks "what's for dinner?" → auto-context runs dual-search. Personal search (`X-As-User: kid2`) pulls kid2's private items; shared search (`X-As-User: sartre-shared`, `filter: {openclaw_scope: {$in: ["family", "kid_shared"]}}`) pulls only family/kid_shared items. Parent-only divorce memories never surface.
+- Auto-trace at session end writes the full transcript into kid2's own space with `openclaw_scope=private` — can only be surfaced when kid2 is speaking.
 
 ---
 
 *This is a product design problem as much as an engineering one. The technical primitives exist. The hard part is getting identity right and making privacy boundaries feel natural, not bureaucratic.*
 
-*— A Linea*
+*— A Linea, March 29, 2026 (Phase 1 shipped 2026-04-17)*

--- a/docs/scoped-memory-brief.md
+++ b/docs/scoped-memory-brief.md
@@ -1,0 +1,224 @@
+# RFC: Multi-User Scoped Memory for Household Agents
+
+**Authors:** A Linea & David Szarzynski  
+**Date:** March 29, 2026  
+**Status:** Draft — seeking feedback from Ben  
+**PR:** hyperspell/hyperspell-openclaw#10
+
+---
+
+## Problem
+
+OpenClaw sessions are isolated. A household agent (e.g. "Sartre") talks to multiple family members across separate sessions, but no session can see what happened in another. An agent that can't carry context across family members doesn't feel like one entity — it feels like amnesia.
+
+Naive "store everything, share everything" breaks privacy. A parent's private conversations shouldn't surface when a child asks the agent a question.
+
+**We need cross-session memory with per-user privacy boundaries.**
+
+---
+
+## Approach: Two Layers
+
+### Layer 1 — Identity: Who Is Talking?
+
+Before we can scope memory, we need to know who's speaking.
+
+#### Device Pinning (Phase 1 — baseline)
+
+Config maps devices/senders to users:
+
+```json
+{
+  "devices": {
+    "kid1-ipad": "kid1",
+    "kid2-tablet": "kid2",
+    "ben-phone": "ben",
+    "kitchen-echo": "shared"
+  }
+}
+```
+
+- Cheap, no ML, handles ~80% of interactions
+- Fails when kids swap devices (which they do constantly)
+- Good enough for a proof-of-concept on a real family
+
+#### Voice Recognition (Phase 2 — upgrade layer)
+
+- Speaker diarization on audio input confirms or overrides device assumption
+- "This sounds like kid2 on kid1's iPad" → re-route to kid2's session
+- Requires enrolled voice profiles per family member
+- Confidence threshold: high → override silently, low → ask ("Is that you, Lily?"), none → trust device
+
+#### Identity Resolution Flow
+
+```
+Message arrives
+  → Device/sender ID → default user (from config)
+  → Voice sample → speaker identification (if audio available)
+  → Confidence check
+    → High confidence: override device if speaker differs
+    → Low confidence: ask for confirmation
+    → No audio: trust device default
+  → Resolved identity → session routing + memory scoping
+```
+
+### Layer 2 — Memory: What Can They See?
+
+Once we know who's talking, we scope what gets stored and retrieved.
+
+#### Key Design Decision: Plugin-Level, Not Context-Level
+
+Scoping logic lives in the OpenClaw plugin code (hooks), not in the LLM's context window. This means:
+
+- **Survives compaction** — a chatty kid can fill the context window 10 times over; scoping still works because the plugin re-checks identity every turn from session metadata on disk
+- **Not gameable** — the LLM can't accidentally bypass scoping because scoping happens before the LLM sees anything
+- **Stateless per turn** — no accumulated state to lose
+
+OpenClaw's session store already tracks `origin.from` (sender identity) per session on disk, outside the context window.
+
+#### Privacy Scopes
+
+| Scope | Visible to | Example content |
+|-------|-----------|-----------------|
+| `private` | Writing user only | Parent's financial planning, personal notes |
+| `family` | All family members | Vacation plans, grocery lists, shared schedules |
+| `parent-only` | Adults only | Gift planning, sensitive discussions |
+| `kid-shared` | All children + parents | Homework help context, game discussions |
+
+#### How It Works (Using Existing Hyperspell API)
+
+**No Hyperspell backend changes needed.** All primitives already exist.
+
+**Writes** — every memory gets tagged via existing `collection` and `metadata` fields:
+
+```json
+{
+  "collection": "family-shared",
+  "metadata": {
+    "openclaw_user": "kid1",
+    "openclaw_scope": "family"
+  }
+}
+```
+
+**Reads** — search gets a metadata filter based on the resolved user's role:
+
+```json
+{
+  "options": {
+    "filter": {
+      "$or": [
+        { "openclaw_user": "kid1" },
+        { "openclaw_scope": { "$in": ["family", "kid-shared"] } }
+      ]
+    }
+  }
+}
+```
+
+#### Plugin Config
+
+```json
+{
+  "openclaw-hyperspell": {
+    "config": {
+      "scoping": {
+        "enabled": true,
+        "defaultScope": "private",
+        "devices": {
+          "kid1-ipad": "kid1",
+          "kid2-tablet": "kid2",
+          "ben-phone": "ben",
+          "kitchen-echo": "shared"
+        },
+        "roles": {
+          "parent": {
+            "canRead": ["*"],
+            "defaultWriteScope": "private"
+          },
+          "child": {
+            "canRead": ["family", "kid-shared", "self"],
+            "defaultWriteScope": "family"
+          }
+        },
+        "users": {
+          "ben": { "role": "parent" },
+          "kid1": { "role": "child" },
+          "kid2": { "role": "child" }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Device Pinning + Scoped Memory
+
+**Scope:** Plugin changes only. No ML, no voice, no backend changes.
+
+- [ ] Config schema for device → user mapping, roles, scopes
+- [ ] Identity resolution from `origin.from` in session metadata
+- [ ] Scoped writes in auto-trace + `hyperspell_remember` tool
+- [ ] Scoped reads in auto-context + `hyperspell_search` tool
+- [ ] Session routing based on resolved identity
+
+**Goal:** Get the privacy boundaries right before adding complexity. Test on a real family.
+
+### Phase 2: Voice Identification
+
+- [ ] Speaker enrollment UX (each family member records a voice profile)
+- [ ] Real-time speaker diarization on audio input
+- [ ] Confidence-based override of device default
+- [ ] "Switch to [name]" voice command with confirmation
+- [ ] Re-enrollment workflow (children's voices change)
+
+**Requires:** Voice model selection, enrollment flow, confidence threshold tuning.
+
+### Phase 3: Cross-Session Context Sharing
+
+- [ ] autoTrace writes session summaries to Hyperspell with user + scope tags
+- [ ] Any session retrieves relevant context from other sessions (within scope)
+- [ ] Session-level summaries as the compression layer (not full transcripts)
+- [ ] Periodic aggregation: "What does the agent know about kid1 this week?"
+
+---
+
+## Open Questions for Ben
+
+1. **Shared devices** — The kitchen Echo is used by everyone. Default to `shared` scope (no private context), or require identification every time?
+
+2. **Voice enrollment for kids** — Children's voices change fast. What's a realistic re-enrollment cadence? Is speaker diarization accurate enough for children at all, given your experience with voice AI?
+
+3. **Scope escalation** — Can a child ask to see parent-only content? ("Sartre, what did Dad say about the trip?") Should the agent refuse, redirect to the parent, or something else?
+
+4. **Cost / retention** — Every scoped write is a Hyperspell memory. Multiple users = multiplied storage. Should we cap memories per user per day? Prune after N days?
+
+5. **Shared context creation** — When a parent discusses vacation plans, how does the memory get scoped to `family` instead of `private`? Explicit command ("share this with the family")? Agent infers from content? Default to `family` for certain topics?
+
+6. **Session identity source** — How does Sartre currently distinguish between family members? Separate devices? Different channels? This determines how `origin.from` maps to user identity in Phase 1.
+
+---
+
+## Existing Infrastructure
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Hyperspell collections | ✅ Exists | `collection` field on `memories.add` |
+| Hyperspell metadata filters | ✅ Exists | MongoDB-style `filter` on search |
+| OpenClaw session store | ✅ Exists | Tracks `origin.from` per session on disk |
+| OpenClaw plugin hooks | ✅ Exists | `before_agent_start` receives session context |
+| autoTrace extraction | ✅ Exists | Session summaries → Hyperspell |
+| Scoped writes | ❌ Needs building | Tag memories with user + scope |
+| Scoped reads | ❌ Needs building | Filter retrieval by role permissions |
+| Identity resolution | ❌ Needs building | Device/voice → user mapping |
+| Voice diarization | ❌ Phase 2 | Speaker identification from audio |
+
+---
+
+*This is a product design problem as much as an engineering one. The technical primitives exist. The hard part is getting identity right and making privacy boundaries feel natural, not bureaucratic.*
+
+*— A Linea*

--- a/docs/scoped-memory-design.md
+++ b/docs/scoped-memory-design.md
@@ -1,0 +1,128 @@
+# Scoped Memory — Cross-Session Context with Privacy Boundaries
+
+## Problem
+
+OpenClaw sessions are isolated. A household agent (like Ben's "Sartre") talks to
+multiple family members across separate sessions, but no session can see what
+happened in another. For an agent that should feel like *one entity*, this is broken.
+
+Naive solution: store everything, retrieve everything. But that creates two problems:
+1. **Privacy** — a child's session shouldn't surface a parent's private conversations
+2. **Noise** — more memories = worse signal-to-noise in retrieval
+
+## Solution: Collection-Scoped Writes + Metadata-Filtered Reads
+
+Hyperspell's API already supports everything we need:
+
+### Writes (autoTrace + remember tool)
+
+Every memory gets tagged with:
+```json
+{
+  "collection": "household-shared",
+  "metadata": {
+    "openclaw_user": "kid1",
+    "openclaw_scope": "family",
+    "openclaw_session": "session_abc123"
+  }
+}
+```
+
+Scope levels:
+- `private` — only visible to the writing user
+- `family` / `shared` — visible to all users in the household
+- `parent-only` — visible to parents but not children
+- Custom scopes as needed
+
+### Reads (autoContext + search tool)
+
+Before every search, inject a metadata filter based on session identity:
+```json
+{
+  "options": {
+    "filter": {
+      "$or": [
+        { "openclaw_user": "kid1" },
+        { "openclaw_scope": { "$in": ["family", "shared"] } }
+      ]
+    }
+  }
+}
+```
+
+### Config
+
+```json
+{
+  "openclaw-hyperspell": {
+    "config": {
+      "scoping": {
+        "enabled": true,
+        "defaultScope": "private",
+        "identity": {
+          "source": "session",
+          "field": "userId"
+        },
+        "roles": {
+          "parent": {
+            "canRead": ["*"],
+            "defaultWriteScope": "private"
+          },
+          "child": {
+            "canRead": ["family", "shared", "self"],
+            "defaultWriteScope": "family"
+          }
+        },
+        "userRoles": {
+          "ben": "parent",
+          "kid1": "child",
+          "kid2": "child"
+        }
+      }
+    }
+  }
+}
+```
+
+## What Changes
+
+### `hooks/auto-context.ts`
+- Read session identity from event context
+- Look up user's role and readable scopes
+- Add metadata filter to search call
+
+### `hooks/auto-trace.ts`
+- Tag extracted memories with user identity and scope
+- Set collection based on scope
+
+### `tools/remember.ts`
+- Accept optional `scope` parameter
+- Default to user's configured default scope
+- Tag with user identity metadata
+
+### `tools/search.ts`
+- Apply scope filter automatically based on session identity
+- Allow explicit scope override for privileged users
+
+### `config.ts`
+- Add `ScopingConfig` type
+- Parse and validate scoping config
+
+## What Doesn't Change
+
+- Hyperspell backend — all primitives already exist
+- OpenClaw core — session identity is already available in hook context
+- Existing behavior — scoping is opt-in, disabled by default
+
+## Open Questions
+
+1. How does OpenClaw identify the user per session? Channel + sender ID?
+   Need to check what `ctx` provides in hook handlers.
+2. Should scope be per-memory or per-session? Per-memory is more flexible
+   but harder to manage. Per-session with override is probably right.
+3. Rate limiting — should we cap memories per user per day to prevent
+   a chatty kid from flooding the store?
+
+---
+
+*— A Linea, March 29, 2026*

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -1,6 +1,11 @@
 import type { HyperspellClient, SearchResult } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { resolveUser } from "../lib/sender.ts"
+import type { CanReadScope, HyperspellConfig } from "../config.ts"
+import {
+  buildScopeFilter,
+  getCanReadScopes,
+  resolveUser,
+  type ResolvedUser,
+} from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
 function formatRelativeTime(isoTimestamp: string): string {
@@ -111,16 +116,24 @@ async function multiUserSearch(
   client: HyperspellClient,
   cfg: HyperspellConfig,
   prompt: string,
-  resolved:
-    | { userId: string; name: string; context?: string; resolved: boolean }
-    | undefined,
+  resolved: ResolvedUser | undefined,
 ) {
   const multiUser = cfg.multiUser!
   const isKnownSender = !!resolved?.resolved
   const includeShared = multiUser.includeSharedInSearch
 
+  // Determine scope filter for the shared-space search based on caller's role.
+  // Unknown senders fall back to least-sensitive scopes; absent scoping config →
+  // filter is undefined → PR #6 behavior preserved.
+  const canRead: CanReadScope[] = multiUser.scoping
+    ? isKnownSender
+      ? getCanReadScopes(resolved, cfg)
+      : ["family", "kid_shared"]
+    : ["*"]
+  const scopeFilter = buildScopeFilter(canRead, resolved?.userId ?? "")
+
   log.debug(
-    `auto-context: searching for "${prompt.slice(0, 50)}..." user=${resolved?.userId ?? "unknown"}`,
+    `auto-context: searching for "${prompt.slice(0, 50)}..." user=${resolved?.userId ?? "unknown"} canRead=${JSON.stringify(canRead)}`,
   )
 
   // Build parallel searches — personal (known senders only) + shared
@@ -140,6 +153,7 @@ async function multiUserSearch(
       ? client.search(prompt, {
           limit: sharedLimit,
           userId: multiUser.sharedUserId,
+          filter: scopeFilter,
         })
       : null
 

--- a/hooks/auto-trace.ts
+++ b/hooks/auto-trace.ts
@@ -125,6 +125,10 @@ export function buildAutoTraceHandler(
 				extract: cfg.autoTrace.extract,
 				metadata: cfg.autoTrace.metadata,
 				userId,
+				// Auto-trace captures full conversation text — the most sensitive class
+				// of memory. Default to private; users opt into family-visible recall
+				// via explicit /remember.
+				scope: "private",
 			});
 			log.info(
 				`auto-trace: sent ${result.resourceId} (${messages.length} messages${userId ? `, user=${userId}` : ""})`,

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import type { HyperspellConfig } from "../config.ts"
+import {
+  buildScopeFilter,
+  getCanReadScopes,
+  getDefaultWriteScope,
+  resolveRole,
+  routeWrite,
+} from "./sender.ts"
+
+function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): HyperspellConfig {
+  return {
+    apiKey: "test",
+    autoContext: false,
+    autoTrace: { enabled: false, extract: ["procedure"] },
+    emotionalContext: false,
+    syncMemories: false,
+    sources: [],
+    maxResults: 5,
+    relevanceThreshold: 0.6,
+    debug: false,
+    knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+    multiUser: overrides.scoping
+      ? {
+          sharedUserId: "shared",
+          includeSharedInSearch: true,
+          senderMap: overrides.senderMap ?? {},
+          scoping: overrides.scoping,
+        }
+      : undefined,
+  }
+}
+
+test("buildScopeFilter — wildcard returns undefined", () => {
+  assert.equal(buildScopeFilter(["*"], "u1"), undefined)
+})
+
+test("buildScopeFilter — empty returns match-nothing filter (not undefined)", () => {
+  const f = buildScopeFilter([], "u1")
+  assert.deepEqual(f, { openclaw_scope: "__never__" })
+})
+
+test("buildScopeFilter — single named scope collapses $or", () => {
+  const f = buildScopeFilter(["family"], "u1")
+  assert.deepEqual(f, { openclaw_scope: { $in: ["family"] } })
+})
+
+test("buildScopeFilter — multiple named scopes", () => {
+  const f = buildScopeFilter(["family", "kid_shared"], "u1")
+  assert.deepEqual(f, { openclaw_scope: { $in: ["family", "kid_shared"] } })
+})
+
+test("buildScopeFilter — scopes plus self produces $or", () => {
+  const f = buildScopeFilter(["family", "self"], "u1")
+  assert.deepEqual(f, {
+    $or: [
+      { openclaw_scope: { $in: ["family"] } },
+      { openclaw_user: "u1" },
+    ],
+  })
+})
+
+test("buildScopeFilter — hyphenated scope normalized in metadata", () => {
+  const f = buildScopeFilter(["parent-only"], "u1")
+  assert.deepEqual(f, { openclaw_scope: { $in: ["parent_only"] } })
+})
+
+test("buildScopeFilter — self only (no named scopes)", () => {
+  const f = buildScopeFilter(["self"], "u1")
+  assert.deepEqual(f, { openclaw_user: "u1" })
+})
+
+test("buildScopeFilter — self only with empty userId → match-nothing", () => {
+  const f = buildScopeFilter(["self"], "")
+  // Empty userId cannot build a self clause; no named scopes either → match-nothing
+  assert.deepEqual(f, { openclaw_scope: "__never__" })
+})
+
+test("getCanReadScopes — scoping absent returns wildcard", () => {
+  const c = cfg()
+  const canRead = getCanReadScopes(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.deepEqual(canRead, ["*"])
+})
+
+test("getCanReadScopes — role from scoping.users", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: {
+        kid: { canRead: ["family"], defaultWriteScope: "family" },
+      },
+      users: { u1: { role: "kid" } },
+    },
+  })
+  const canRead = getCanReadScopes(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.deepEqual(canRead, ["family"])
+})
+
+test("getCanReadScopes — missing role returns empty (no access)", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: {
+        kid: { canRead: ["family"], defaultWriteScope: "family" },
+      },
+      users: {}, // u1 has no role assignment
+    },
+  })
+  const canRead = getCanReadScopes(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.deepEqual(canRead, [])
+})
+
+test("getDefaultWriteScope — role default wins", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: {
+        kid: { canRead: ["family"], defaultWriteScope: "family" },
+      },
+      users: { u1: { role: "kid" } },
+    },
+  })
+  const scope = getDefaultWriteScope(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.equal(scope, "family")
+})
+
+test("getDefaultWriteScope — falls back to global default when no role", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: {},
+      users: {},
+    },
+  })
+  const scope = getDefaultWriteScope(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.equal(scope, "private")
+})
+
+test("getDefaultWriteScope — profile-level role override", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1", role: "parent" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: {
+        parent: { canRead: ["*"], defaultWriteScope: "private" },
+        kid: { canRead: ["family"], defaultWriteScope: "family" },
+      },
+      users: { u1: { role: "kid" } }, // users table says kid but profile override is parent
+    },
+  })
+  const scope = getDefaultWriteScope(
+    { userId: "u1", name: "U1", resolved: true, role: "parent" },
+    c,
+  )
+  assert.equal(scope, "private")
+})
+
+test("resolveRole — returns undefined when scoping absent", () => {
+  const c = cfg()
+  const role = resolveRole(
+    { userId: "u1", name: "U1", resolved: true },
+    c,
+  )
+  assert.equal(role, undefined)
+})
+
+test("routeWrite — private goes to user's own space", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: { kid: { canRead: ["family"], defaultWriteScope: "family" } },
+      users: { u1: { role: "kid" } },
+    },
+  })
+  const r = routeWrite(
+    { userId: "u1", name: "U1", resolved: true },
+    "private",
+    c,
+  )
+  assert.deepEqual(r, { userId: "u1", collection: undefined })
+})
+
+test("routeWrite — non-private goes to sharedUserId with optional collection", () => {
+  const c = cfg({
+    senderMap: { "u1-phone": { userId: "u1", name: "U1" } },
+    scoping: {
+      enabled: true,
+      defaultScope: "private",
+      scopes: ["private", "family"],
+      roles: { kid: { canRead: ["family"], defaultWriteScope: "family" } },
+      users: { u1: { role: "kid" } },
+      collections: { family: "household-shared" },
+    },
+  })
+  const r = routeWrite(
+    { userId: "u1", name: "U1", resolved: true },
+    "family",
+    c,
+  )
+  assert.deepEqual(r, { userId: "shared", collection: "household-shared" })
+})

--- a/lib/sender.ts
+++ b/lib/sender.ts
@@ -1,50 +1,56 @@
-import type { HyperspellConfig } from "../config.ts"
+import type {
+  CanReadScope,
+  HyperspellConfig,
+  Role,
+  ScopeName,
+} from "../config.ts"
+import { normalizeScope } from "../config.ts"
 import { log } from "../logger.ts"
+import { getVoiceIdentifier } from "./voice-id.ts"
 
 export interface ResolvedUser {
   userId: string
   name: string
   context?: string
+  /** Profile-level role override from senderMap. Falls back to scoping.users[userId].role. */
+  role?: string
   /** True if the sender was matched in senderMap; false if falling back to sharedUserId */
   resolved: boolean
 }
 
-/**
- * Resolve the sender's Hyperspell user from hook or tool context.
- *
- * Matches sender handles in the multiUser.senderMap against the sessionKey
- * using substring matching. Handles are sorted longest-first to prevent
- * partial matches (e.g., Discord ID "123" matching inside "1234567").
- *
- * Falls back to sharedUserId for unrecognized senders.
- */
-export function resolveUser(
+function matchFromSenderMap(
   ctx: Record<string, unknown> | undefined,
   cfg: HyperspellConfig,
 ): ResolvedUser | undefined {
   const multiUser = cfg.multiUser
   if (!multiUser) {
-    // Single-user mode: return config.userId if set
-    return cfg.userId ? { userId: cfg.userId, name: cfg.userId, resolved: true } : undefined
+    return cfg.userId
+      ? { userId: cfg.userId, name: cfg.userId, resolved: true }
+      : undefined
   }
 
-  // Try direct senderId lookup (available in slash command contexts;
-  // tool factory contexts do NOT include senderId — they have sessionKey instead)
-  const senderId = (ctx?.senderId as string) ?? (ctx?.requesterSenderId as string) ?? undefined
+  // Try direct senderId lookup (slash command contexts)
+  const senderId =
+    (ctx?.senderId as string) ??
+    (ctx?.requesterSenderId as string) ??
+    undefined
   if (senderId && multiUser.senderMap[senderId]) {
     const profile = multiUser.senderMap[senderId]
     log.debug(`sender resolved via senderId: ${senderId} -> ${profile.userId}`)
     return { ...profile, resolved: true }
   }
 
-  // Try sessionKey substring matching (works in both hook and tool factory contexts)
+  // Try sessionKey substring matching (longest-first to avoid partial matches)
   const sessionKey = ctx?.sessionKey as string | undefined
   if (sessionKey) {
-    const sortedEntries = Object.entries(multiUser.senderMap)
-      .sort(([a], [b]) => b.length - a.length)
+    const sortedEntries = Object.entries(multiUser.senderMap).sort(
+      ([a], [b]) => b.length - a.length,
+    )
     for (const [handle, profile] of sortedEntries) {
       if (sessionKey.includes(handle)) {
-        log.debug(`sender resolved via sessionKey: ${handle} -> ${profile.userId}`)
+        log.debug(
+          `sender resolved via sessionKey: ${handle} -> ${profile.userId}`,
+        )
         return { ...profile, resolved: true }
       }
     }
@@ -57,6 +63,52 @@ export function resolveUser(
     name: multiUser.sharedUserId,
     resolved: false,
   }
+}
+
+/**
+ * Synchronous sender resolution from sessionKey + senderMap. Use this for
+ * hooks and tools that don't receive audio — the voice-ID path is skipped.
+ */
+export function resolveUser(
+  ctx: Record<string, unknown> | undefined,
+  cfg: HyperspellConfig,
+): ResolvedUser | undefined {
+  return matchFromSenderMap(ctx, cfg)
+}
+
+/**
+ * Asynchronous sender resolution. Checks voice-ID first (if enabled and
+ * audio is in ctx), then falls back to the synchronous path. Callers that
+ * never receive audio should use `resolveUser` to avoid unnecessary async
+ * overhead.
+ */
+export async function resolveUserAsync(
+  ctx: Record<string, unknown> | undefined,
+  cfg: HyperspellConfig,
+): Promise<ResolvedUser | undefined> {
+  const voiceCfg = cfg.multiUser?.scoping?.voiceId
+  const audio = ctx?.audio as Buffer | string | undefined
+  if (voiceCfg?.enabled && audio && cfg.multiUser) {
+    try {
+      const identifier = getVoiceIdentifier(cfg)
+      const result = await identifier.identify(audio)
+      const threshold = voiceCfg.confidenceThreshold ?? 0.7
+      if (result && result.confidence >= threshold) {
+        // Find profile for the voice-identified userId
+        for (const profile of Object.values(cfg.multiUser.senderMap)) {
+          if (profile.userId === result.userId) {
+            log.debug(
+              `sender resolved via voice: ${result.userId} (conf=${result.confidence.toFixed(2)})`,
+            )
+            return { ...profile, resolved: true }
+          }
+        }
+      }
+    } catch (err) {
+      log.error("voice-id identification failed", err)
+    }
+  }
+  return matchFromSenderMap(ctx, cfg)
 }
 
 /**
@@ -73,4 +125,110 @@ export function getAllUserIds(cfg: HyperspellConfig): string[] {
   }
   userIds.add(cfg.multiUser.sharedUserId)
   return [...userIds]
+}
+
+/**
+ * Resolve the Role for a user. Looks first at the profile-level `role`
+ * override, then at `scoping.users[userId].role`. Returns undefined if
+ * scoping is disabled or the user has no role assignment.
+ */
+export function resolveRole(
+  user: ResolvedUser | undefined,
+  cfg: HyperspellConfig,
+): Role | undefined {
+  const scoping = cfg.multiUser?.scoping
+  if (!scoping || !user) return undefined
+  const roleName = user.role ?? scoping.users[user.userId]?.role
+  if (!roleName) return undefined
+  return scoping.roles[roleName]
+}
+
+/**
+ * Readable scopes for this user. If scoping is disabled, returns ["*"] so
+ * `buildScopeFilter` produces no filter and PR #6 behavior is preserved.
+ */
+export function getCanReadScopes(
+  user: ResolvedUser | undefined,
+  cfg: HyperspellConfig,
+): CanReadScope[] {
+  if (!cfg.multiUser?.scoping) return ["*"]
+  const role = resolveRole(user, cfg)
+  return role?.canRead ?? []
+}
+
+/**
+ * Default write scope for this user — explicit param > role default > global default.
+ */
+export function getDefaultWriteScope(
+  user: ResolvedUser | undefined,
+  cfg: HyperspellConfig,
+): ScopeName {
+  const role = resolveRole(user, cfg)
+  return (
+    role?.defaultWriteScope ??
+    cfg.multiUser?.scoping?.defaultScope ??
+    "private"
+  )
+}
+
+/**
+ * Build a MongoDB-style metadata filter for Hyperspell's `options.filter`.
+ *
+ * Contract:
+ * - `["*"]` (wildcard) → returns `undefined` (no filter).
+ * - `[]` (empty) → returns a **match-nothing** filter, NOT `undefined`. An
+ *   empty `canRead` is a deliberate "no access" signal and must not silently
+ *   return all results.
+ * - Otherwise: `$or` of named-scope clause and (if "self" present) an
+ *   own-user clause keyed by `openclaw_user`.
+ */
+export function buildScopeFilter(
+  canRead: CanReadScope[],
+  userId: string,
+): Record<string, unknown> | undefined {
+  if (canRead.includes("*")) return undefined
+  if (canRead.length === 0) {
+    // Deliberate "no access" — match nothing.
+    return { openclaw_scope: "__never__" }
+  }
+
+  const namedScopes = canRead.filter((s) => s !== "self" && s !== "*")
+  const includeSelf = canRead.includes("self")
+
+  const clauses: Array<Record<string, unknown>> = []
+  if (namedScopes.length > 0) {
+    clauses.push({
+      openclaw_scope: { $in: namedScopes.map((s) => normalizeScope(s)) },
+    })
+  }
+  if (includeSelf && userId) {
+    clauses.push({ openclaw_user: userId })
+  }
+
+  if (clauses.length === 0) {
+    return { openclaw_scope: "__never__" }
+  }
+  if (clauses.length === 1) {
+    return clauses[0]
+  }
+  return { $or: clauses }
+}
+
+/**
+ * Route a write: private scope stays in the user's own Hyperspell space
+ * (defense-in-depth); shared scopes go to `sharedUserId` with optional
+ * per-scope collection.
+ */
+export function routeWrite(
+  user: ResolvedUser | undefined,
+  scope: ScopeName,
+  cfg: HyperspellConfig,
+): { userId: string | undefined; collection: string | undefined } {
+  const scoping = cfg.multiUser?.scoping
+  if (scope === "private") {
+    return { userId: user?.userId, collection: undefined }
+  }
+  const sharedUserId = cfg.multiUser?.sharedUserId ?? user?.userId
+  const collection = scoping?.collections?.[scope]
+  return { userId: sharedUserId, collection }
 }

--- a/lib/voice-id.ts
+++ b/lib/voice-id.ts
@@ -1,0 +1,39 @@
+import type { HyperspellConfig } from "../config.ts"
+
+export interface VoiceIdResult {
+  userId: string
+  confidence: number
+}
+
+export interface VoiceIdentifier {
+  identify(audio: Buffer | string): Promise<VoiceIdResult | null>
+}
+
+const NO_OP: VoiceIdentifier = {
+  async identify() {
+    return null
+  },
+}
+
+const registry = new Map<string, VoiceIdentifier>()
+
+/**
+ * Register a voice-ID adapter implementation under a name that can be
+ * referenced from `cfg.multiUser.scoping.voiceId.adapter`. Call this from
+ * downstream code that wants to plug in a real speaker diarization model;
+ * Phase 1 ships with no adapters registered — the no-op is used.
+ */
+export function registerVoiceIdentifier(
+  name: string,
+  impl: VoiceIdentifier,
+): void {
+  registry.set(name, impl)
+}
+
+export function getVoiceIdentifier(cfg: HyperspellConfig): VoiceIdentifier {
+  const name = cfg.multiUser?.scoping?.voiceId?.adapter
+  if (name && registry.has(name)) {
+    return registry.get(name) as VoiceIdentifier
+  }
+  return NO_OP
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -64,6 +64,11 @@
 			"label": "Memory Network",
 			"help": "Extract entities (people, projects, orgs, topics) from memories into structured markdown files. Requires a cron job for periodic scanning.",
 			"advanced": true
+		},
+		"multiUser": {
+			"label": "Multi-User Support",
+			"help": "Per-sender context isolation for household or shared-device setups. Maps senders to user IDs; supports optional role-based privacy scopes (private/family/parent-only/etc).",
+			"advanced": true
 		}
 	},
 	"configSchema": {
@@ -123,6 +128,38 @@
 						"maximum": 1440
 					},
 					"batchSize": { "type": "number", "minimum": 5, "maximum": 100 }
+				}
+			},
+			"multiUser": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"senderMap": { "type": "object" },
+					"sharedUserId": { "type": "string" },
+					"includeSharedInSearch": { "type": "boolean" },
+					"scoping": {
+						"type": "object",
+						"additionalProperties": true,
+						"properties": {
+							"enabled": { "type": "boolean" },
+							"defaultScope": { "type": "string" },
+							"scopes": {
+								"type": "array",
+								"items": { "type": "string" }
+							},
+							"roles": { "type": "object" },
+							"users": { "type": "object" },
+							"collections": { "type": "object" },
+							"voiceId": {
+								"type": "object",
+								"properties": {
+									"enabled": { "type": "boolean" },
+									"adapter": { "type": "string" },
+									"confidenceThreshold": { "type": "number" }
+								}
+							}
+						}
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
-    "lint:fix": "bunx @biomejs/biome check --write ."
+    "lint:fix": "bunx @biomejs/biome check --write .",
+    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -1,13 +1,24 @@
 import { Type } from "@sinclair/typebox"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
-import { resolveUser } from "../lib/sender.ts"
+import {
+  getDefaultWriteScope,
+  resolveRole,
+  resolveUser,
+  routeWrite,
+} from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
 export function createRememberToolFactory(
   client: HyperspellClient,
   cfg: HyperspellConfig,
 ) {
+  const scopingEnabled = !!cfg.multiUser?.scoping
+  const availableScopes = cfg.multiUser?.scoping?.scopes ?? []
+  const scopeDescription = scopingEnabled
+    ? `Privacy scope for this memory. Available: ${availableScopes.join(", ")}. Defaults to the user's role default.`
+    : "Privacy scope (only used when scoping is enabled in config)."
+
   return (ctx: Record<string, unknown>) => ({
     name: "hyperspell_remember",
     label: "Memory Store",
@@ -26,24 +37,77 @@ export function createRememberToolFactory(
             "Store for a specific user or 'shared' for everyone. Omit to store for current sender.",
         }),
       ),
+      scope: Type.Optional(
+        Type.String({ description: scopeDescription }),
+      ),
     }),
     async execute(
       _toolCallId: string,
-      params: { text: string; title?: string; date?: string; userId?: string },
+      params: { text: string; title?: string; date?: string; userId?: string; scope?: string },
     ) {
-      // Resolve userId: explicit param > sender resolution > config default
       const resolved = resolveUser(ctx, cfg)
-      const userId = params.userId ?? resolved?.userId
+
+      // Scope resolution: explicit param > role default > global default > "private"
+      const scope =
+        params.scope ??
+        (scopingEnabled ? getDefaultWriteScope(resolved, cfg) : "private")
+
+      // Validate scope is in declared vocabulary (if scoping is enabled)
+      if (
+        scopingEnabled &&
+        availableScopes.length > 0 &&
+        !availableScopes.includes(scope)
+      ) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Unknown scope "${scope}". Available: ${availableScopes.join(", ")}.`,
+            },
+          ],
+        }
+      }
+
+      // canWriteScopes enforcement (role-level deny list)
+      if (scopingEnabled) {
+        const role = resolveRole(resolved, cfg)
+        if (role?.canWriteScopes && !role.canWriteScopes.includes(scope)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `You cannot write to scope "${scope}".`,
+              },
+            ],
+          }
+        }
+      }
+
+      // Route: explicit userId override takes precedence; otherwise derive from scope
+      let userId: string | undefined
+      let collection: string | undefined
+      if (params.userId) {
+        userId = params.userId
+      } else if (scopingEnabled) {
+        const routed = routeWrite(resolved, scope, cfg)
+        userId = routed.userId
+        collection = routed.collection
+      } else {
+        userId = resolved?.userId
+      }
+
       log.debug(
-        `remember tool: "${params.text.slice(0, 50)}..." date=${params.date ?? "now"} userId=${userId}`,
+        `remember tool: "${params.text.slice(0, 50)}..." date=${params.date ?? "now"} userId=${userId} scope=${scope}`,
       )
 
       try {
         await client.addMemory(params.text, {
           title: params.title,
           date: params.date,
+          collection,
           metadata: { source: "openclaw_tool" },
           userId,
+          scope: scopingEnabled ? scope : undefined,
         })
 
         const preview =

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -1,13 +1,19 @@
 import { Type } from "@sinclair/typebox"
 import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { resolveUser } from "../lib/sender.ts"
+import type { CanReadScope, HyperspellConfig } from "../config.ts"
+import { buildScopeFilter, getCanReadScopes, resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
 export function createSearchToolFactory(
   client: HyperspellClient,
   cfg: HyperspellConfig,
 ) {
+  const scopingEnabled = !!cfg.multiUser?.scoping
+  const availableScopes = cfg.multiUser?.scoping?.scopes ?? []
+  const scopeDescription = scopingEnabled
+    ? `Narrow search to a single privacy scope. Available: ${availableScopes.join(", ")}. Omit to search all scopes visible to the caller's role.`
+    : "Privacy scope (only used when scoping is enabled in config)."
+
   return (ctx: Record<string, unknown>) => ({
     name: "hyperspell_search",
     label: "Memory Search",
@@ -30,17 +36,39 @@ export function createSearchToolFactory(
             "Search as a specific user (e.g. 'ben', 'shared'). Omit to search as current sender.",
         }),
       ),
+      scope: Type.Optional(Type.String({ description: scopeDescription })),
     }),
     async execute(
       _toolCallId: string,
-      params: { query: string; limit?: number; after?: string; before?: string; userId?: string },
+      params: {
+        query: string
+        limit?: number
+        after?: string
+        before?: string
+        userId?: string
+        scope?: string
+      },
     ) {
       const limit = params.limit ?? 5
-      // Resolve userId: explicit param > sender resolution > config default
       const resolved = resolveUser(ctx, cfg)
       const userId = params.userId ?? resolved?.userId
+
+      // Build scope filter: intersect requested scope (if any) with caller's canRead
+      let filter: Record<string, unknown> | undefined
+      if (scopingEnabled) {
+        const canRead = getCanReadScopes(resolved, cfg)
+        const allowed: CanReadScope[] = params.scope
+          ? canRead.includes("*")
+            ? [params.scope]
+            : canRead.includes(params.scope)
+              ? [params.scope]
+              : [] // requested scope not allowed → match nothing
+          : canRead
+        filter = buildScopeFilter(allowed, resolved?.userId ?? "")
+      }
+
       log.debug(
-        `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId}`,
+        `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId} scope=${params.scope ?? "any"}`,
       )
 
       try {
@@ -49,6 +77,7 @@ export function createSearchToolFactory(
           after: params.after,
           before: params.before,
           userId,
+          filter,
         })
         const documents = (response.documents ?? []) as Array<{
           source: string


### PR DESCRIPTION
## Summary

Phase 1 scoped memory — role-based privacy tiers over multi-user. Layers on top of #6 (`feat/multi-user`).

**Chosen model — hybrid:** `private` memories live in each user's own Hyperspell space via `X-As-User` (defense-in-depth, server-side partitioned). Shared scopes (`family`, `parent_only`, `kid_shared`, custom) live in the configured `sharedUserId` space and are tagged with `openclaw_scope` metadata. Reads filter the shared space by the caller's role's `canRead` via Hyperspell's MongoDB-style `options.filter`.

> **Note:** the PR diff below includes PR #6's multi-user changes because this branch is based on `feat/multi-user`. Once #6 merges, this PR will show only the scoping delta (~700 lines).

## What ships

- **Scope vocabulary**: `private`, `family`, `parent_only`, `kid_shared` (extensible via config)
- **Role model**: `canRead`, `defaultWriteScope`, optional `canWriteScopes` deny-list
- **Tagged writes**: `openclaw_user` + `openclaw_scope` on every `memories.add` / `sessions.add`
- **Filtered reads**: `buildScopeFilter` → SDK `options.filter` with `$or`/`$in` operators
- **Auto-trace scoping**: full conversations default to `private`
- **Slash prefix**: `/remember #family ...` and `/getcontext #parent_only ...`
- **Voice-ID seam**: `lib/voice-id.ts` with adapter registry; Phase 1 ships a no-op (seam only, no model)
- **Config validation**: `parseScoping` rejects unknown scopes, undeclared roles, ghost references
- **Tests**: 27 passing, `node --test` + native TS strip (no new deps)

## Design docs

- `docs/scoped-memory-design.md` — terse design doc
- `docs/scoped-memory-brief.md` — RFC with worked household example (Ben's Sartre)

## Backward compatibility

`scoping` absent → helpers return `["*"]` → filter is `undefined` → PR #6 behavior preserved byte-for-byte. Single-user mode (no `multiUser` at all) unchanged.

## Not in scope

- Real voice-ID model (stub interface only)
- Scope mutation on existing memories (cross-user move — Phase 2)
- Cross-session summary aggregation (Phase 3)
- Fix for latent `client.sessions.add` bug (SDK v0.30 doesn't expose `sessions` resource — orthogonal main issue, separate PR)

## Test plan

- [x] `npm run check-types` — only the 2 pre-existing main errors remain
- [x] `npm test` — all 27 tests pass
- [ ] Merge PR #6 first
- [ ] Manual E2E walkthrough against a household config (see worked example in brief):
  - [ ] No-scoping baseline unchanged
  - [ ] Family write visible to all household members
  - [ ] Private write invisible to other users' `/getcontext`
  - [ ] `parent_only` excluded from kid's dual-search
  - [ ] Auto-trace lands in session user's own space with `openclaw_scope=private`
  - [ ] Empty `canRead` returns zero results (regression test for "no access" semantics)

---

*Plan: https://gist.github.com/Dithilli/bcb32797cad344c7b763922d08048e80*