### PR TITLE
fix: declare empty hooks array to pass hook pack validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperspell/openclaw-hyperspell",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",
@@ -48,7 +48,8 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "hooks": []
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary

- Add `openclaw.hooks: []` to `package.json` to satisfy the hook pack validator
- Our hooks (auto-context, auto-trace, memory-sync) are plugin-managed via `api.on()`, not standalone hook packs
- Bump version to 0.7.2

## Test plan

- [ ] Verify `openclaw plugins update openclaw-hyperspell` no longer errors with "package.json missing openclaw.hooks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)