### PR TITLE
fix(ci): match npm trusted publisher workflow format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,21 @@
-name: Publish to npm
+name: Publish Package
 
 on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary

- Match the workflow format from [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers)
- Move `permissions` to top level
- Drop `--provenance` flag
- Update action versions to v6, node to 24

## Test plan

- [ ] Merge and verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)