### PR TITLE
fix: correct repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hyperspell/openclaw-hyperspell.git"
+    "url": "git+https://github.com/hyperspell/hyperspell-openclaw.git"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary

- Fix `repository.url` in package.json: `openclaw-hyperspell` → `hyperspell-openclaw`
- npm provenance validation requires this to match the actual GitHub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)