### PR TITLE
Add ClawHub publishing metadata and update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ OpenClaw plugin for [Hyperspell](https://hyperspell.com) - Context and memory fo
 ## Installation
 
 ```bash
-openclaw plugins install @hyperspell/openclaw-hyperspell
+openclaw plugins install --dangerously-force-unsafe-install @hyperspell/openclaw-hyperspell
 ```
+
+> **Note:** The `--dangerously-force-unsafe-install` flag is required because OpenClaw's automated install scanner detects standard operations that are essential to how the plugin works — opening your browser during setup, scheduling background jobs, and securely communicating with the Hyperspell API. These are normal, expected behaviors and the plugin does not execute arbitrary code or access data beyond what is needed to function. The source is fully open and auditable in this repository.
 
 ## Quick Start
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
 	"id": "openclaw-hyperspell",
+	"name": "Hyperspell",
+	"description": "Context and memory for your AI agents — search across Notion, Slack, Google Drive, and more",
+	"version": "0.7.2",
 	"kind": "memory",
 	"uiHints": {
 		"apiKey": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "openclaw.plugin.json",
     "README.md"
   ],
+  "author": "Hyperspell <hello@hyperspell.com> (https://hyperspell.com)",
+  "homepage": "https://hyperspell.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hyperspell/hyperspell-openclaw.git"
@@ -49,7 +51,15 @@
     "extensions": [
       "./index.ts"
     ],
-    "hooks": []
+    "hooks": [],
+    "compat": {
+      "pluginApi": ">=2026.1.29",
+      "minGatewayVersion": "2026.1.29"
+    },
+    "build": {
+      "openclawVersion": "2026.3.24-beta.2",
+      "pluginSdkVersion": "2026.3.24-beta.2"
+    }
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- Add required ClawHub metadata to `openclaw.plugin.json` (`name`, `description`, `version`)
- Add `author`, `homepage`, `openclaw.compat`, and `openclaw.build` fields to `package.json`
- Update install command in README with `--dangerously-force-unsafe-install` flag and explain why it's needed

## Test plan
- [ ] Verify `clawhub package publish` accepts the updated metadata
- [ ] Confirm `openclaw plugins install --dangerously-force-unsafe-install @hyperspell/openclaw-hyperspell` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)