### PR TITLE
feat: declare dreaming config so Dreaming can run alongside the plugin (v0.12.0)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -69,6 +69,10 @@
 			"label": "Multi-User Support",
 			"help": "Per-sender context isolation for household or shared-device setups. Maps senders to user IDs; supports optional role-based privacy scopes (private/family/parent-only/etc).",
 			"advanced": true
+		},
+		"dreaming": {
+			"label": "Dreaming",
+			"help": "Optional dreaming config consumed by memory-core when this plugin owns the memory slot. Lets memory-core's dreaming engine consolidate local session transcripts into workspace/MEMORY.md on cron."
 		}
 	},
 	"configSchema": {
@@ -161,6 +165,9 @@
 						}
 					}
 				}
+			},
+			"dreaming": {
+				"type": "object"
 			}
 		},
 		"required": []

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
 	"id": "openclaw-hyperspell",
 	"name": "Hyperspell",
 	"description": "Context and memory for your AI agents — search across Notion, Slack, Google Drive, and more",
-	"version": "0.7.2",
+	"version": "0.12.0",
 	"kind": "memory",
 	"uiHints": {
 		"apiKey": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Declare `dreaming` in `uiHints` and `configSchema.properties` so the OpenClaw UI stops refusing to enable Dreaming for this plugin. Mirrors the pattern memory-lancedb already uses.
- Bump to **0.12.0** and realign `openclaw.plugin.json`'s version with `package.json` (they had drifted to 0.7.2 vs 0.11.1).

## Why this matters

Memory-core's Dreaming engine reads its settings from whichever plugin holds `plugins.slots.memory`. When Hyperspell owns the slot, the UI gate at `ui/src/ui/controllers/dreaming.ts:961-984` checks our schema for a `dreaming` property; since we set `additionalProperties: false`, the absence of that property caused the UI to show `Selected memory plugin "openclaw-hyperspell" does not support dreaming settings.` and refuse to run Dreaming.

With this change, memory-core can load as a sidecar engine (per `src/plugins/loader.ts:1822`) and consolidate local session transcripts into `workspace/MEMORY.md` on cron, while Hyperspell keeps owning the memory slot for all remote search/write.

## What this does NOT change

- No hook logic changed. No runtime behavior changed.
- Dreaming still only reads local session corpus + daily notes — it does not consume Hyperspell's cross-source memories. Closing that loop is a separate, larger project.

## Test plan

- [ ] Fresh install: set `plugins.slots.memory = openclaw-hyperspell` and `plugins.entries.memory-core.enabled = true` in `~/.openclaw/openclaw.json`.
- [ ] Restart gateway.
- [ ] UI → Hyperspell plugin settings → Dreaming section renders without the "does not support dreaming settings" error.
- [ ] Enable Dreaming, trigger a run, confirm `memory/.dreams/events.jsonl` records a `memory.dream.completed` event.
- [ ] Confirm Hyperspell hooks (auto-context, auto-trace, emotional-state) still fire as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)