### PR TITLE
feat: startup orientation — inject recent interactions + unfinished loops once per session

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -340,6 +340,14 @@ async function runSetup(): Promise<void> {
         relevanceThreshold: 0.6,
         debug: false,
         knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+        startupOrientation: {
+          enabled: false,
+          recentDays: 7,
+          recentLimit: 5,
+          loopsLimit: 3,
+          recentQuery: "conversation session interaction",
+          loopsQuery: "open tasks pending questions unfinished promised need to follow up",
+        },
       })
 
       const result = await syncAllMemoryFiles(hyperspellClient, workspaceDir)

--- a/config.test.ts
+++ b/config.test.ts
@@ -200,3 +200,33 @@ test("parseConfig — valid scoping parses", () => {
   assert.equal(cfg.multiUser?.scoping?.collections?.family, "household")
   assert.equal(cfg.multiUser?.scoping?.voiceId?.confidenceThreshold, 0.8)
 })
+
+test("parseConfig — startupOrientation defaults to disabled with sensible values", () => {
+  const cfg = parseConfig(base)
+  assert.equal(cfg.startupOrientation.enabled, false)
+  assert.equal(cfg.startupOrientation.recentDays, 7)
+  assert.equal(cfg.startupOrientation.recentLimit, 5)
+  assert.equal(cfg.startupOrientation.loopsLimit, 3)
+  assert.ok(cfg.startupOrientation.recentQuery.length > 0)
+  assert.ok(cfg.startupOrientation.loopsQuery.length > 0)
+})
+
+test("parseConfig — startupOrientation accepts overrides", () => {
+  const cfg = parseConfig({
+    ...base,
+    startupOrientation: {
+      enabled: true,
+      recentDays: 14,
+      recentLimit: 3,
+      loopsLimit: 5,
+      recentQuery: "custom recent",
+      loopsQuery: "custom loops",
+    },
+  })
+  assert.equal(cfg.startupOrientation.enabled, true)
+  assert.equal(cfg.startupOrientation.recentDays, 14)
+  assert.equal(cfg.startupOrientation.recentLimit, 3)
+  assert.equal(cfg.startupOrientation.loopsLimit, 5)
+  assert.equal(cfg.startupOrientation.recentQuery, "custom recent")
+  assert.equal(cfg.startupOrientation.loopsQuery, "custom loops")
+})

--- a/config.ts
+++ b/config.ts
@@ -25,6 +25,15 @@ export type AutoTraceConfig = {
 	metadata?: Record<string, string | number | boolean>;
 };
 
+export type StartupOrientationConfig = {
+	enabled: boolean;
+	recentDays: number;
+	recentLimit: number;
+	loopsLimit: number;
+	recentQuery: string;
+	loopsQuery: string;
+};
+
 export type UserProfile = {
 	userId: string;
 	name: string;
@@ -81,6 +90,7 @@ export type HyperspellConfig = {
 	autoTrace: AutoTraceConfig;
 	emotionalContext: boolean;
 	relationshipId?: string;
+	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
 	sources: HyperspellSource[];
 	maxResults: number;
@@ -97,6 +107,7 @@ const ALLOWED_KEYS = [
 	"autoTrace",
 	"emotionalContext",
 	"relationshipId",
+	"startupOrientation",
 	"syncMemories",
 	"sources",
 	"maxResults",
@@ -369,6 +380,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 
 	const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>;
 	const atRaw = (cfg.autoTrace ?? {}) as Record<string, unknown>;
+	const soRaw = (cfg.startupOrientation ?? {}) as Record<string, unknown>;
 
 	return {
 		apiKey,
@@ -385,6 +397,17 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 		},
 		emotionalContext: (cfg.emotionalContext as boolean) ?? false,
 		relationshipId: cfg.relationshipId as string | undefined,
+		startupOrientation: {
+			enabled: (soRaw.enabled as boolean) ?? false,
+			recentDays: (soRaw.recentDays as number) ?? 7,
+			recentLimit: (soRaw.recentLimit as number) ?? 5,
+			loopsLimit: (soRaw.loopsLimit as number) ?? 3,
+			recentQuery:
+				(soRaw.recentQuery as string) ?? "conversation session interaction",
+			loopsQuery:
+				(soRaw.loopsQuery as string) ??
+				"open tasks pending questions unfinished promised need to follow up",
+		},
 		syncMemories: (cfg.syncMemories as boolean) ?? false,
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -1,0 +1,245 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { HyperspellClient, SearchResult } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import {
+	buildStartupOrientationCompactionHandler,
+	buildStartupOrientationHandler,
+	buildStartupOrientationSessionCleanupHandler,
+} from "./startup-orientation.ts";
+
+type SearchCall = {
+	query: string;
+	options?: Parameters<HyperspellClient["search"]>[1];
+};
+
+function makeClient(responses: {
+	recent?: SearchResult[];
+	loops?: SearchResult[];
+}) {
+	const calls: SearchCall[] = [];
+	const client = {
+		calls,
+		async search(
+			query: string,
+			options?: Parameters<HyperspellClient["search"]>[1],
+		) {
+			calls.push({ query, options });
+			if (options?.after) return responses.recent ?? [];
+			return responses.loops ?? [];
+		},
+	};
+	return client;
+}
+
+function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
+	return {
+		apiKey: "k",
+		autoContext: false,
+		autoTrace: { enabled: false, extract: ["procedure"] },
+		emotionalContext: false,
+		startupOrientation: {
+			enabled: true,
+			recentDays: 7,
+			recentLimit: 5,
+			loopsLimit: 3,
+			recentQuery: "conversation session interaction",
+			loopsQuery: "open tasks pending questions",
+		},
+		syncMemories: false,
+		sources: [],
+		maxResults: 10,
+		relevanceThreshold: 0.6,
+		debug: false,
+		knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+		...overrides,
+	};
+}
+
+function makeResult(partial: Partial<SearchResult>): SearchResult {
+	return {
+		resourceId: "r1",
+		title: "some session",
+		source: "trace",
+		score: 0.8,
+		url: null,
+		createdAt: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+		highlights: [{ id: "h1", score: 0.75, text: "we talked about the plan" }],
+		...partial,
+	};
+}
+
+test("startup-orientation — injects once per session, caches on subsequent turns", async () => {
+	const client = makeClient({
+		recent: [makeResult({ title: "yesterday's session" })],
+		loops: [
+			makeResult({
+				title: "followup question",
+				highlights: [{ id: "h", score: 0.4, text: "follow up on the config" }],
+			}),
+		],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const ctx = { sessionKey: "s1" };
+
+	const first = await handler({}, ctx);
+	const prepend = (first as { prependContext?: string } | undefined)
+		?.prependContext;
+	assert.ok(prepend);
+	assert.ok(prepend.includes("<hyperspell-recent-interactions>"));
+	assert.ok(prepend.includes("<hyperspell-unfinished-loops>"));
+	assert.ok(prepend.includes("yesterday's session"));
+	assert.equal(client.calls.length, 2, "fires both searches in parallel");
+
+	const second = await handler({}, ctx);
+	assert.equal(second, undefined);
+	assert.equal(
+		client.calls.length,
+		2,
+		"does not re-search within same session",
+	);
+});
+
+test("startup-orientation — compaction clears cache, next turn re-injects", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const onCompaction = buildStartupOrientationCompactionHandler();
+	const ctx = { sessionKey: "s-compact" };
+
+	await handler({}, ctx);
+	await handler({}, ctx);
+	assert.equal(client.calls.length, 2);
+
+	await onCompaction({}, ctx);
+	await handler({}, ctx);
+	assert.equal(client.calls.length, 4, "re-searches after compaction");
+});
+
+test("startup-orientation — session_end cleanup allows later re-injection", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const onSessionEnd = buildStartupOrientationSessionCleanupHandler();
+	const ctx = { sessionKey: "s-end" };
+
+	await handler({}, ctx);
+	await onSessionEnd({}, ctx);
+	await handler({}, ctx);
+	assert.equal(
+		client.calls.length,
+		4,
+		"resumes searching after session end drops the cache entry",
+	);
+});
+
+test("startup-orientation — empty results cache the attempt (no retry storm)", async () => {
+	const client = makeClient({ recent: [], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const ctx = { sessionKey: "s-empty" };
+
+	const out = await handler({}, ctx);
+	assert.equal(out, undefined);
+	assert.equal(client.calls.length, 2);
+
+	await handler({}, ctx);
+	assert.equal(
+		client.calls.length,
+		2,
+		"empty results still mark session as handled",
+	);
+});
+
+test("startup-orientation — recent search uses `after` and metadata filter", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	await handler({}, { sessionKey: "s-filter" });
+
+	const recentCall = client.calls.find((c) => c.options?.after);
+	assert.ok(recentCall, "recent search must include `after`");
+	assert.equal(
+		(recentCall.options?.filter as { openclaw_source?: unknown } | undefined)
+			?.openclaw_source,
+		"agent_end",
+	);
+	assert.equal(recentCall.options?.limit, 5);
+});
+
+test("startup-orientation — loops search runs without filter or threshold", async () => {
+	const client = makeClient({
+		recent: [],
+		loops: [makeResult({ title: "q" })],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	await handler({}, { sessionKey: "s-loops" });
+
+	const loopsCall = client.calls.find((c) => !c.options?.after);
+	assert.ok(loopsCall, "loops search must exist");
+	assert.equal(
+		loopsCall.options?.filter,
+		undefined,
+		"loops search has no metadata filter",
+	);
+	assert.equal(loopsCall.options?.limit, 3);
+});
+
+test("startup-orientation — skips orientation for unknown sender in multi-user mode", async () => {
+	const client = makeClient({
+		recent: [makeResult({})],
+		loops: [makeResult({})],
+	});
+	const cfg = makeCfg({
+		multiUser: {
+			senderMap: { "+111": { userId: "alice", name: "Alice" } },
+			sharedUserId: "shared",
+			includeSharedInSearch: true,
+		},
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		cfg,
+	);
+	const out = await handler({}, { sessionKey: "s-unknown", senderId: "+999" });
+	assert.equal(out, undefined);
+	assert.equal(client.calls.length, 0, "no searches for unresolved sender");
+});
+
+test("startup-orientation — uses resolved userId for personal-only search in multi-user mode", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const cfg = makeCfg({
+		multiUser: {
+			senderMap: { "+111": { userId: "alice", name: "Alice" } },
+			sharedUserId: "shared",
+			includeSharedInSearch: true,
+		},
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		cfg,
+	);
+	await handler({}, { sessionKey: "s-known", senderId: "+111" });
+	assert.ok(client.calls.length === 2);
+	for (const c of client.calls) {
+		assert.equal(
+			c.options?.userId,
+			"alice",
+			"both searches scoped to resolved personal userId",
+		);
+	}
+});

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -1,0 +1,189 @@
+import type { HyperspellClient, SearchResult } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { resolveUser } from "../lib/sender.ts";
+import { log } from "../logger.ts";
+
+type AgentContext = Record<string, unknown> & { sessionKey?: string };
+
+const RECENT_FILTER = { openclaw_source: "agent_end" } as const;
+
+/**
+ * Track which sessions already received the orientation injection. The block is
+ * expensive (two search calls + a few hundred tokens of wrapper) and its
+ * contents don't change within a session, so inject-once is the right shape.
+ * Lifecycle mirrors the emotional-context hook: first turn injects, later turns
+ * skip, `after_compaction` clears (injection may have been trimmed), and
+ * `session_end` deletes to keep the Set bounded.
+ */
+const injectedSessions = new Set<string>();
+
+function formatRelativeTime(iso: string | null): string {
+	if (!iso) return "";
+	try {
+		const dt = new Date(iso);
+		const now = new Date();
+		const hours = (now.getTime() - dt.getTime()) / 3_600_000;
+		if (hours < 1) return "just now";
+		if (hours < 24) return `${Math.floor(hours)}h ago`;
+		const days = hours / 24;
+		if (days < 7) return `${Math.floor(days)}d ago`;
+		const month = dt.toLocaleString("en", { month: "short" });
+		return `${dt.getDate()} ${month}`;
+	} catch {
+		return "";
+	}
+}
+
+function formatRecentInteractions(results: SearchResult[]): string | null {
+	if (results.length === 0) return null;
+	const lines = results.map((r) => {
+		const when = formatRelativeTime(r.createdAt);
+		const title = r.title ?? `[${r.source}]`;
+		const prefix = when ? `[${when}] ` : "";
+		const top = r.highlights[0]?.text?.replace(/\n/g, " ").slice(0, 140);
+		const tail = top ? ` — ${top}` : "";
+		return `- ${prefix}${title}${tail}`;
+	});
+	return lines.join("\n");
+}
+
+function formatUnfinishedLoops(results: SearchResult[]): string | null {
+	const bullets: string[] = [];
+	for (const r of results) {
+		const top = r.highlights[0];
+		if (!top) continue;
+		const title = r.title ?? `[${r.source}]`;
+		bullets.push(`- ${title}: ${top.text.replace(/\n/g, " ")}`);
+	}
+	return bullets.length > 0 ? bullets.join("\n") : null;
+}
+
+function isoDaysAgo(days: number): string {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - days);
+	return d.toISOString();
+}
+
+/**
+ * Resolve the userId to use for personal searches. In multi-user mode, skip
+ * entirely for unknown senders — orientation is "what have *I* been doing", and
+ * an unresolved caller has no personal space to orient to. In single-user mode,
+ * return undefined so the client falls back to its configured userId.
+ */
+function personalUserId(
+	cfg: HyperspellConfig,
+	ctx: AgentContext | undefined,
+): { skip: boolean; userId?: string } {
+	if (!cfg.multiUser) return { skip: false, userId: undefined };
+	const resolved = resolveUser(ctx, cfg);
+	if (!resolved?.resolved) return { skip: true };
+	return { skip: false, userId: resolved.userId };
+}
+
+export function buildStartupOrientationHandler(
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
+) {
+	const so = cfg.startupOrientation;
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey && injectedSessions.has(sessionKey)) return;
+
+		const { skip, userId } = personalUserId(cfg, ctx);
+		if (skip) {
+			log.debug(
+				"startup-orientation: skipping — unknown sender in multi-user mode",
+			);
+			if (sessionKey) injectedSessions.add(sessionKey);
+			return;
+		}
+
+		const after = isoDaysAgo(so.recentDays);
+
+		const [recentSettled, loopsSettled] = await Promise.allSettled([
+			client.search(so.recentQuery, {
+				limit: so.recentLimit,
+				after,
+				filter: RECENT_FILTER,
+				userId,
+			}),
+			client.search(so.loopsQuery, {
+				limit: so.loopsLimit,
+				userId,
+			}),
+		]);
+
+		const recent =
+			recentSettled.status === "fulfilled" ? recentSettled.value : [];
+		if (recentSettled.status === "rejected") {
+			log.error(
+				"startup-orientation: recent search failed",
+				recentSettled.reason,
+			);
+		}
+		const loops = loopsSettled.status === "fulfilled" ? loopsSettled.value : [];
+		if (loopsSettled.status === "rejected") {
+			log.error(
+				"startup-orientation: loops search failed",
+				loopsSettled.reason,
+			);
+		}
+
+		const recentBody = formatRecentInteractions(recent);
+		const loopsBody = formatUnfinishedLoops(loops);
+
+		if (sessionKey) injectedSessions.add(sessionKey);
+
+		if (!recentBody && !loopsBody) {
+			log.debug("startup-orientation: nothing to inject");
+			return;
+		}
+
+		const blocks: string[] = [];
+		if (recentBody) {
+			blocks.push(
+				[
+					"<hyperspell-recent-interactions>",
+					`Your last ${so.recentDays} days of conversations with this user, most-relevant-first. Use for situational continuity — don't quote verbatim.`,
+					"",
+					recentBody,
+					"</hyperspell-recent-interactions>",
+				].join("\n"),
+			);
+		}
+		if (loopsBody) {
+			blocks.push(
+				[
+					"<hyperspell-unfinished-loops>",
+					"Possible open threads — promises made, questions pending, work in progress. Low-confidence retrieval; treat as prompts to consider, not facts to act on.",
+					"",
+					loopsBody,
+					"</hyperspell-unfinished-loops>",
+				].join("\n"),
+			);
+		}
+
+		log.debug(
+			`startup-orientation: injecting recent=${recent.length} loops=${loops.length}`,
+		);
+		return { prependContext: blocks.join("\n\n") };
+	};
+}
+
+export function buildStartupOrientationCompactionHandler() {
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey && injectedSessions.delete(sessionKey)) {
+			log.debug(
+				`startup-orientation: cache cleared after compaction (session=${sessionKey})`,
+			);
+		}
+	};
+}
+
+export function buildStartupOrientationSessionCleanupHandler() {
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey) injectedSessions.delete(sessionKey);
+	};
+}

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,11 @@ import {
 	buildEmotionalStateStoreHandler,
 } from "./hooks/emotional-state.ts"
 import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
+import {
+	buildStartupOrientationCompactionHandler,
+	buildStartupOrientationHandler,
+	buildStartupOrientationSessionCleanupHandler,
+} from "./hooks/startup-orientation.ts"
 import { initLogger } from "./logger.ts"
 import { createRememberToolFactory } from "./tools/remember.ts"
 import { createSearchToolFactory } from "./tools/search.ts"
@@ -109,6 +114,14 @@ export default {
 		if (cfg.autoContext) {
 			const autoContextHandler = buildAutoContextHandler(client, cfg);
 			api.on("before_agent_start", autoContextHandler);
+		}
+
+		// Register startup-orientation hooks: recent-interactions + unfinished-loops
+		// injected once per session on first turn. Lifecycle mirrors emotional-context.
+		if (cfg.startupOrientation.enabled) {
+			api.on("before_agent_start", buildStartupOrientationHandler(client, cfg));
+			api.on("after_compaction", buildStartupOrientationCompactionHandler());
+			api.on("session_end", buildStartupOrientationSessionCleanupHandler());
 		}
 
 		// Register auto-trace hook (send conversations to Hyperspell on session end)

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -21,6 +21,14 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     relevanceThreshold: 0.6,
     debug: false,
     knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+    startupOrientation: {
+      enabled: false,
+      recentDays: 7,
+      recentLimit: 5,
+      loopsLimit: 3,
+      recentQuery: "conversation",
+      loopsQuery: "open tasks",
+    },
     multiUser: overrides.scoping
       ? {
           sharedUserId: "shared",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts"
+    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary

- Adds a session-start context hook that fires alongside the existing emotional-context block. It injects two sibling sections on the first `before_agent_start`:
  - `<hyperspell-recent-interactions>` — session traces from the last N days, filtered to `openclaw_source=agent_end` metadata and bounded by search's `after` parameter. Gives the agent "what's been happening."
  - `<hyperspell-unfinished-loops>` — semantic search for open threads/promises/pending questions. No relevance threshold, since orientation is speculative by nature ("what might I be forgetting").
- Lifecycle mirrors `emotional-context`: inject once per session, clear the cache on `after_compaction` (the block may have been trimmed out of history), drop the entry on `session_end`.
- Multi-user: personal-only. Skipped entirely for unresolved senders — "what have *I* been doing" has no answer for an unknown caller.
- Opt-in. `startupOrientation.enabled` defaults to `false` because the feature costs two extra search calls and ~500–800 tokens of injection per session. Day/limit/query strings are all overridable.

### Design notes

- **Why `memories.search` + `after` instead of `memories.list` chronological?** The SDK's `memories.list` doesn't expose `after`/`before` or a sort parameter. Search + date-window gets us bounded recency with the SDK as it actually exists today; relevance ordering *within* a 7-day window is a mild quirk, not a correctness failure.
- **Why no threshold on unfinished-loops?** Filtering weak matches defeats the purpose of a speculative query. Cap at `limit=3` and trust that three mediocre results cost a couple hundred tokens the agent can ignore.
- **Why three separate blocks (emotional + recent + loops) instead of one?** Scannability. Wrapper cost is ~50 tokens total across three blocks; each section is independently suppressible when empty.

## Test plan

- [x] `npm run check-types` clean
- [x] `npm test` — 54/54 pass, 10 new (8 hook lifecycle + 2 config)
- [x] `npx @biomejs/biome ci` clean on touched files
- [ ] Smoke test against a real Hyperspell user with session traces to verify the `after` + `openclaw_source=agent_end` filter returns session traces and not polluted memory
- [ ] Enable on one agent (e.g. A Linea) with `startupOrientation.enabled=true` and verify both blocks render + the agent uses them without referencing them verbatim
- [ ] Confirm the block survives compaction cleanly (trigger a compaction mid-session, watch for re-injection on the next turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)