### PR TITLE
feat: capture every agent turn to Hyperspell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: npm ci --ignore-scripts
+      - run: npm run check-types
+      - run: npm run lint
+      - run: npm test

--- a/client.test.ts
+++ b/client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { HyperspellClient } from "./client.ts";
+import type { HyperspellConfig } from "./config.ts";
+
+const baseConfig: HyperspellConfig = {
+	apiKey: "test-key",
+	userId: "user@test.com",
+	autoContext: true,
+	syncMemories: false,
+	captureConversations: true,
+	sources: [],
+	maxResults: 10,
+	debug: false,
+	knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+};
+
+function makeClient() {
+	const client = new HyperspellClient(baseConfig);
+	const add = vi.fn().mockResolvedValue({ resource_id: "r1" });
+	(client as unknown as { client: { memories: { add: typeof add } } }).client =
+		{
+			memories: { add },
+		} as never;
+	return { client, add };
+}
+
+describe("HyperspellClient.addMemory", () => {
+	it("defaults openclaw_source to 'command' when caller omits it", async () => {
+		const { client, add } = makeClient();
+		await client.addMemory("hi");
+		const metadata = (
+			add.mock.calls[0][0] as { metadata: Record<string, unknown> }
+		).metadata;
+		expect(metadata.openclaw_source).toBe("command");
+	});
+
+	it("lets the caller override openclaw_source in metadata", async () => {
+		const { client, add } = makeClient();
+		await client.addMemory("hi", {
+			metadata: { openclaw_source: "conversation" },
+		});
+		const metadata = (
+			add.mock.calls[0][0] as { metadata: Record<string, unknown> }
+		).metadata;
+		expect(metadata.openclaw_source).toBe("conversation");
+	});
+});

--- a/client.ts
+++ b/client.ts
@@ -1,252 +1,270 @@
-import Hyperspell from "hyperspell"
-import type { HyperspellConfig, HyperspellSource } from "./config.ts"
-import { log } from "./logger.ts"
+import Hyperspell from "hyperspell";
+import type { HyperspellConfig, HyperspellSource } from "./config.ts";
+import { log } from "./logger.ts";
 
 export type SearchResult = {
-  resourceId: string
-  title: string | null
-  source: HyperspellSource
-  score: number | null
-  url: string | null
-  createdAt: string | null
-}
+	resourceId: string;
+	title: string | null;
+	source: HyperspellSource;
+	score: number | null;
+	url: string | null;
+	createdAt: string | null;
+};
 
 export type SearchWithAnswerResult = {
-  answer: string | null
-  documents: SearchResult[]
-}
+	answer: string | null;
+	documents: SearchResult[];
+};
 
 export type Integration = {
-  id: string
-  name: string
-  provider: HyperspellSource
-  icon: string
-}
+	id: string;
+	name: string;
+	provider: HyperspellSource;
+	icon: string;
+};
 
 export type Connection = {
-  id: string
-  integrationId: string
-  label: string | null
-  provider: HyperspellSource
-}
+	id: string;
+	integrationId: string;
+	label: string | null;
+	provider: HyperspellSource;
+};
 
 export class HyperspellClient {
-  private client: Hyperspell
-  private config: HyperspellConfig
+	private client: Hyperspell;
+	private config: HyperspellConfig;
 
-  constructor(config: HyperspellConfig) {
-    this.config = config
-    this.client = new Hyperspell({
-      apiKey: config.apiKey,
-      userID: config.userId,
-    })
-    log.info(`client initialized${config.userId ? ` for user ${config.userId}` : ""}`)
-  }
+	constructor(config: HyperspellConfig) {
+		this.config = config;
+		this.client = new Hyperspell({
+			apiKey: config.apiKey,
+			userID: config.userId,
+		});
+		log.info(
+			`client initialized${config.userId ? ` for user ${config.userId}` : ""}`,
+		);
+	}
 
-  async search(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<SearchResult[]> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async search(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<SearchResult[]> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search", { query, limit, sources })
+		log.debugRequest("memories.search", { query, limit, sources });
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    const results: SearchResult[] = response.documents.map((doc) => ({
-      resourceId: doc.resource_id,
-      title: doc.title ?? null,
-      source: doc.source as HyperspellSource,
-      score: doc.score ?? null,
-      url: doc.metadata?.url as string | null ?? null,
-      createdAt: doc.metadata?.created_at as string | null ?? null,
-    }))
+		const results: SearchResult[] = response.documents.map((doc) => ({
+			resourceId: doc.resource_id,
+			title: doc.title ?? null,
+			source: doc.source as HyperspellSource,
+			score: doc.score ?? null,
+			url: (doc.metadata?.url as string | null) ?? null,
+			createdAt: (doc.metadata?.created_at as string | null) ?? null,
+		}));
 
-    log.debugResponse("memories.search", { count: results.length })
-    return results
-  }
+		log.debugResponse("memories.search", { count: results.length });
+		return results;
+	}
 
-  async searchRaw(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<Record<string, unknown>> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async searchRaw(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<Record<string, unknown>> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search (raw)", { query, limit, sources })
+		log.debugRequest("memories.search (raw)", { query, limit, sources });
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    log.debugResponse("memories.search (raw)", { count: response.documents.length })
+		log.debugResponse("memories.search (raw)", {
+			count: response.documents.length,
+		});
 
-    return response as unknown as Record<string, unknown>
-  }
+		return response as unknown as Record<string, unknown>;
+	}
 
-  async searchWithAnswer(
-    query: string,
-    options?: { limit?: number; sources?: HyperspellSource[] },
-  ): Promise<SearchWithAnswerResult> {
-    const limit = options?.limit ?? this.config.maxResults
-    const sources =
-      options?.sources ?? (this.config.sources.length > 0 ? this.config.sources : undefined)
+	async searchWithAnswer(
+		query: string,
+		options?: { limit?: number; sources?: HyperspellSource[] },
+	): Promise<SearchWithAnswerResult> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
 
-    log.debugRequest("memories.search (with answer)", { query, limit, sources })
+		log.debugRequest("memories.search (with answer)", {
+			query,
+			limit,
+			sources,
+		});
 
-    const response = await this.client.memories.search({
-      query,
-      sources,
-      answer: true,
-      options: {
-        max_results: limit,
-      },
-    })
+		const response = await this.client.memories.search({
+			query,
+			sources,
+			answer: true,
+			options: {
+				max_results: limit,
+			},
+		});
 
-    const documents: SearchResult[] = response.documents.map((doc) => ({
-      resourceId: doc.resource_id,
-      title: doc.title ?? null,
-      source: doc.source as HyperspellSource,
-      score: doc.score ?? null,
-      url: doc.metadata?.url as string | null ?? null,
-      createdAt: doc.metadata?.created_at as string | null ?? null,
-    }))
+		const documents: SearchResult[] = response.documents.map((doc) => ({
+			resourceId: doc.resource_id,
+			title: doc.title ?? null,
+			source: doc.source as HyperspellSource,
+			score: doc.score ?? null,
+			url: (doc.metadata?.url as string | null) ?? null,
+			createdAt: (doc.metadata?.created_at as string | null) ?? null,
+		}));
 
-    log.debugResponse("memories.search (with answer)", {
-      count: documents.length,
-      hasAnswer: !!response.answer,
-    })
+		log.debugResponse("memories.search (with answer)", {
+			count: documents.length,
+			hasAnswer: !!response.answer,
+		});
 
-    return {
-      answer: response.answer ?? null,
-      documents,
-    }
-  }
+		return {
+			answer: response.answer ?? null,
+			documents,
+		};
+	}
 
-  async addMemory(
-    text: string,
-    options?: {
-      title?: string
-      resourceId?: string
-      collection?: string
-      metadata?: Record<string, string | number | boolean>
-    },
-  ): Promise<{ resourceId: string }> {
-    log.debugRequest("memories.add", {
-      textLength: text.length,
-      title: options?.title,
-      resourceId: options?.resourceId,
-      collection: options?.collection,
-    })
+	async addMemory(
+		text: string,
+		options?: {
+			title?: string;
+			resourceId?: string;
+			collection?: string;
+			metadata?: Record<string, string | number | boolean>;
+		},
+	): Promise<{ resourceId: string }> {
+		log.debugRequest("memories.add", {
+			textLength: text.length,
+			title: options?.title,
+			resourceId: options?.resourceId,
+			collection: options?.collection,
+		});
 
-    const result = await this.client.memories.add({
-      text,
-      title: options?.title,
-      resource_id: options?.resourceId,
-      collection: options?.collection,
-      metadata: {
-        ...options?.metadata,
-        openclaw_source: "command",
-      },
-    })
+		const result = await this.client.memories.add({
+			text,
+			title: options?.title,
+			resource_id: options?.resourceId,
+			collection: options?.collection,
+			metadata: {
+				openclaw_source: "command",
+				...options?.metadata,
+			},
+		});
 
-    log.debugResponse("memories.add", { resourceId: result.resource_id })
-    return { resourceId: result.resource_id }
-  }
+		log.debugResponse("memories.add", { resourceId: result.resource_id });
+		return { resourceId: result.resource_id };
+	}
 
-  async listIntegrations(): Promise<Integration[]> {
-    log.debugRequest("integrations.list", {})
+	async listIntegrations(): Promise<Integration[]> {
+		log.debugRequest("integrations.list", {});
 
-    const response = await this.client.integrations.list()
+		const response = await this.client.integrations.list();
 
-    const integrations: Integration[] = response.integrations.map((int) => ({
-      id: int.id,
-      name: int.name,
-      provider: int.provider as HyperspellSource,
-      icon: int.icon,
-    }))
+		const integrations: Integration[] = response.integrations.map((int) => ({
+			id: int.id,
+			name: int.name,
+			provider: int.provider as HyperspellSource,
+			icon: int.icon,
+		}));
 
-    log.debugResponse("integrations.list", { count: integrations.length })
-    return integrations
-  }
+		log.debugResponse("integrations.list", { count: integrations.length });
+		return integrations;
+	}
 
-  async getConnectUrl(integrationId: string): Promise<{ url: string; expiresAt: string }> {
-    log.debugRequest("integrations.connect", { integrationId })
+	async getConnectUrl(
+		integrationId: string,
+	): Promise<{ url: string; expiresAt: string }> {
+		log.debugRequest("integrations.connect", { integrationId });
 
-    const response = await this.client.integrations.connect(integrationId)
+		const response = await this.client.integrations.connect(integrationId);
 
-    log.debugResponse("integrations.connect", { url: response.url })
-    return {
-      url: response.url,
-      expiresAt: response.expires_at,
-    }
-  }
+		log.debugResponse("integrations.connect", { url: response.url });
+		return {
+			url: response.url,
+			expiresAt: response.expires_at,
+		};
+	}
 
-  async *listMemories(
-    options?: { source?: HyperspellSource; collection?: string; pageSize?: number },
-  ): AsyncGenerator<{
-    resourceId: string
-    source: HyperspellSource
-    title: string | null
-    metadata: Record<string, unknown>
-  }> {
-    log.debugRequest("memories.list", { source: options?.source, collection: options?.collection })
+	async *listMemories(options?: {
+		source?: HyperspellSource;
+		collection?: string;
+		pageSize?: number;
+	}): AsyncGenerator<{
+		resourceId: string;
+		source: HyperspellSource;
+		title: string | null;
+		metadata: Record<string, unknown>;
+	}> {
+		log.debugRequest("memories.list", {
+			source: options?.source,
+			collection: options?.collection,
+		});
 
-    const params: Record<string, unknown> = {
-      size: options?.pageSize ?? 100,
-    }
-    if (options?.source) params.source = options.source
-    if (options?.collection) params.collection = options.collection
+		const params: Record<string, unknown> = {
+			size: options?.pageSize ?? 100,
+		};
+		if (options?.source) params.source = options.source;
+		if (options?.collection) params.collection = options.collection;
 
-    for await (const memory of this.client.memories.list(params as any)) {
-      yield {
-        resourceId: memory.resource_id,
-        source: memory.source as HyperspellSource,
-        title: memory.title ?? null,
-        metadata: (memory.metadata ?? {}) as Record<string, unknown>,
-      }
-    }
-  }
+		for await (const memory of this.client.memories.list(params as any)) {
+			yield {
+				resourceId: memory.resource_id,
+				source: memory.source as HyperspellSource,
+				title: memory.title ?? null,
+				metadata: (memory.metadata ?? {}) as Record<string, unknown>,
+			};
+		}
+	}
 
-  async getMemory(
-    resourceId: string,
-    source: HyperspellSource,
-  ): Promise<Record<string, unknown>> {
-    log.debugRequest("memories.get", { resourceId, source })
+	async getMemory(
+		resourceId: string,
+		source: HyperspellSource,
+	): Promise<Record<string, unknown>> {
+		log.debugRequest("memories.get", { resourceId, source });
 
-    const response = await this.client.memories.get(resourceId, { source })
-    const raw = response as unknown as Record<string, unknown>
+		const response = await this.client.memories.get(resourceId, { source });
+		const raw = response as unknown as Record<string, unknown>;
 
-    log.debugResponse("memories.get", { resourceId, hasData: "data" in raw })
-    return raw
-  }
+		log.debugResponse("memories.get", { resourceId, hasData: "data" in raw });
+		return raw;
+	}
 
-  async listConnections(): Promise<Connection[]> {
-    log.debugRequest("connections.list", {})
+	async listConnections(): Promise<Connection[]> {
+		log.debugRequest("connections.list", {});
 
-    const response = await this.client.connections.list()
+		const response = await this.client.connections.list();
 
-    const connections: Connection[] = response.connections.map((conn) => ({
-      id: conn.id,
-      integrationId: conn.integration_id,
-      label: conn.label,
-      provider: conn.provider as HyperspellSource,
-    }))
+		const connections: Connection[] = response.connections.map((conn) => ({
+			id: conn.id,
+			integrationId: conn.integration_id,
+			label: conn.label,
+			provider: conn.provider as HyperspellSource,
+		}));
 
-    log.debugResponse("connections.list", { count: connections.length })
-    return connections
-  }
+		log.debugResponse("connections.list", { count: connections.length });
+		return connections;
+	}
 }

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -1,29 +1,35 @@
-import { exec, execFileSync } from "node:child_process"
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { homedir, platform, userInfo } from "node:os"
-import * as p from "@clack/prompts"
-import type { Command } from "commander"
-import Hyperspell from "hyperspell"
-import { syncAllMemoryFiles, getMemoryFiles } from "../sync/markdown.ts"
-import { HyperspellClient } from "../client.ts"
-import { getWorkspaceDir, parseConfig } from "../config.ts"
-import { buildExtractionPrompt, CRON_JOB_NAME } from "../graph/cron.ts"
-import { NetworkStateManager } from "../graph/state.ts"
-import { scanMemories, formatScanResults, completeMemories } from "../graph/ops.ts"
+import { exec, execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import { homedir, platform, userInfo } from "node:os";
+import * as path from "node:path";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import Hyperspell from "hyperspell";
+import { HyperspellClient } from "../client.ts";
+import { getWorkspaceDir, parseConfig } from "../config.ts";
+import { buildExtractionPrompt, CRON_JOB_NAME } from "../graph/cron.ts";
+import {
+	completeMemories,
+	formatScanResults,
+	scanMemories,
+} from "../graph/ops.ts";
+import { NetworkStateManager } from "../graph/state.ts";
+import { getMemoryFiles, syncAllMemoryFiles } from "../sync/markdown.ts";
 
 /**
  * Resolve OpenClaw state directory, matching OpenClaw's logic.
  * Checks OPENCLAW_STATE_DIR env var, falls back to ~/.openclaw
  */
 function resolveStateDir(): string {
-  const override = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim()
-  if (override) {
-    return override.startsWith("~")
-      ? override.replace(/^~(?=$|[\\/])/, homedir())
-      : path.resolve(override)
-  }
-  return path.join(homedir(), ".openclaw")
+	const override =
+		process.env.OPENCLAW_STATE_DIR?.trim() ||
+		process.env.CLAWDBOT_STATE_DIR?.trim();
+	if (override) {
+		return override.startsWith("~")
+			? override.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(override);
+	}
+	return path.join(homedir(), ".openclaw");
 }
 
 /**
@@ -31,687 +37,754 @@ function resolveStateDir(): string {
  * Checks OPENCLAW_CONFIG_PATH env var, falls back to $STATE_DIR/openclaw.json
  */
 function resolveConfigPath(): string {
-  const override = process.env.OPENCLAW_CONFIG_PATH?.trim() || process.env.CLAWDBOT_CONFIG_PATH?.trim()
-  if (override) {
-    return override.startsWith("~")
-      ? override.replace(/^~(?=$|[\\/])/, homedir())
-      : path.resolve(override)
-  }
-  return path.join(resolveStateDir(), "openclaw.json")
+	const override =
+		process.env.OPENCLAW_CONFIG_PATH?.trim() ||
+		process.env.CLAWDBOT_CONFIG_PATH?.trim();
+	if (override) {
+		return override.startsWith("~")
+			? override.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(override);
+	}
+	return path.join(resolveStateDir(), "openclaw.json");
 }
 
-async function fetchConnectionSources(client: Hyperspell, userId: string): Promise<string[]> {
-  try {
-    const userClient = new Hyperspell({
-      apiKey: client.apiKey,
-      userID: userId,
-    })
-    const response = await userClient.connections.list()
-    const providers = response.connections.map((conn) => conn.provider)
-    // Add vault and deduplicate
-    const sources = [...new Set(["vault", ...providers])]
-    return sources
-  } catch (_error) {
-    return ["vault"]
-  }
+async function fetchConnectionSources(
+	client: Hyperspell,
+	userId: string,
+): Promise<string[]> {
+	try {
+		const userClient = new Hyperspell({
+			apiKey: client.apiKey,
+			userID: userId,
+		});
+		const response = await userClient.connections.list();
+		const providers = response.connections.map((conn) => conn.provider);
+		// Add vault and deduplicate
+		const sources = [...new Set(["vault", ...providers])];
+		return sources;
+	} catch (_error) {
+		return ["vault"];
+	}
 }
 
 function updateConfigSources(configPath: string, sources: string[]): void {
-  if (!fs.existsSync(configPath)) return
+	if (!fs.existsSync(configPath)) return;
 
-  const content = fs.readFileSync(configPath, "utf-8")
-  const config = JSON.parse(content)
+	const content = fs.readFileSync(configPath, "utf-8");
+	const config = JSON.parse(content);
 
-  const pluginConfig = config?.plugins?.entries?.["openclaw-hyperspell"]?.config
-  if (pluginConfig) {
-    pluginConfig.sources = sources.join(",")
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n")
-  }
+	const pluginConfig =
+		config?.plugins?.entries?.["openclaw-hyperspell"]?.config;
+	if (pluginConfig) {
+		pluginConfig.sources = sources.join(",");
+		fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+	}
 }
 
 function openUrl(url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let command: string
-    switch (platform()) {
-      case "darwin":
-        command = `open "${url}"`
-        break
-      case "win32":
-        command = `start "" "${url}"`
-        break
-      default:
-        command = `xdg-open "${url}"`
-    }
-    exec(command, (error) => {
-      if (error) reject(error)
-      else resolve()
-    })
-  })
+	return new Promise((resolve, reject) => {
+		let command: string;
+		switch (platform()) {
+			case "darwin":
+				command = `open "${url}"`;
+				break;
+			case "win32":
+				command = `start "" "${url}"`;
+				break;
+			default:
+				command = `xdg-open "${url}"`;
+		}
+		exec(command, (error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
 }
 
 async function runSetup(): Promise<void> {
-  p.intro("Hyperspell Setup")
+	p.intro("Hyperspell Setup");
 
-  // Step 1: Check if they have an account
-  const hasAccount = await p.confirm({
-    message: "Do you already have a Hyperspell account?",
-  })
+	// Step 1: Check if they have an account
+	const hasAccount = await p.confirm({
+		message: "Do you already have a Hyperspell account?",
+	});
 
-  if (p.isCancel(hasAccount)) {
-    p.cancel("Setup cancelled")
-    return
-  }
+	if (p.isCancel(hasAccount)) {
+		p.cancel("Setup cancelled");
+		return;
+	}
 
-  if (!hasAccount) {
-    p.note(
-      "1. Go to https://app.hyperspell.com to create a free account\n" +
-        "2. Create a new app for your AI agent\n" +
-        "3. Select which integrations you want to connect (Notion, Slack, etc.)",
-      "Create an account",
-    )
+	if (!hasAccount) {
+		p.note(
+			"1. Go to https://app.hyperspell.com to create a free account\n" +
+				"2. Create a new app for your AI agent\n" +
+				"3. Select which integrations you want to connect (Notion, Slack, etc.)",
+			"Create an account",
+		);
 
-    const openSignup = await p.confirm({
-      message: "Open app.hyperspell.com in your browser?",
-    })
+		const openSignup = await p.confirm({
+			message: "Open app.hyperspell.com in your browser?",
+		});
 
-    if (p.isCancel(openSignup)) {
-      p.cancel("Setup cancelled")
-      return
-    }
+		if (p.isCancel(openSignup)) {
+			p.cancel("Setup cancelled");
+			return;
+		}
 
-    if (openSignup) {
-      await openUrl("https://app.hyperspell.com")
-      p.log.info("Browser opened. Come back when you've created your account.")
-    }
+		if (openSignup) {
+			await openUrl("https://app.hyperspell.com");
+			p.log.info("Browser opened. Come back when you've created your account.");
+		}
 
-    await p.confirm({
-      message: "Ready to continue?",
-      active: "Yes",
-      inactive: "No",
-    })
-  }
+		await p.confirm({
+			message: "Ready to continue?",
+			active: "Yes",
+			inactive: "No",
+		});
+	}
 
-  // Step 2: Get API Key
-  p.note(
-    "1. Go to your app in https://app.hyperspell.com\n" +
-      "2. Navigate to Settings > API Keys\n" +
-      "3. Create a new API key",
-    "API Key",
-  )
+	// Step 2: Get API Key
+	p.note(
+		"1. Go to your app in https://app.hyperspell.com\n" +
+			"2. Navigate to Settings > API Keys\n" +
+			"3. Create a new API key",
+		"API Key",
+	);
 
-  const apiKey = await p.text({
-    message: "Paste your API key",
-    placeholder: "hs_...",
-    validate: (value) => {
-      if (!value) return "API key is required"
-    },
-  })
+	const apiKey = await p.text({
+		message: "Paste your API key",
+		placeholder: "hs_...",
+		validate: (value) => {
+			if (!value) return "API key is required";
+		},
+	});
 
-  if (p.isCancel(apiKey)) {
-    p.cancel("Setup cancelled")
-    return
-  }
+	if (p.isCancel(apiKey)) {
+		p.cancel("Setup cancelled");
+		return;
+	}
 
-  // Validate API key
-  const s = p.spinner()
-  s.start("Validating API key")
+	// Validate API key
+	const s = p.spinner();
+	s.start("Validating API key");
 
-  let client: Hyperspell
-  try {
-    client = new Hyperspell({ apiKey })
-    await client.integrations.list()
-    s.stop("API key is valid")
-  } catch (_error) {
-    s.stop("API key validation failed")
-    p.log.error("Please check that your API key is correct and try again.")
-    return
-  }
+	let client: Hyperspell;
+	try {
+		client = new Hyperspell({ apiKey });
+		await client.integrations.list();
+		s.stop("API key is valid");
+	} catch (_error) {
+		s.stop("API key validation failed");
+		p.log.error("Please check that your API key is correct and try again.");
+		return;
+	}
 
-  // Step 3: User ID
-  p.note(
-    "Hyperspell is a multi-tenant memory platform. Each user's memories\n" +
-      "are stored separately, identified by a User ID.\n\n" +
-      "For a personal agent, use your email address or username.",
-    "User ID",
-  )
+	// Step 3: User ID
+	p.note(
+		"Hyperspell is a multi-tenant memory platform. Each user's memories\n" +
+			"are stored separately, identified by a User ID.\n\n" +
+			"For a personal agent, use your email address or username.",
+		"User ID",
+	);
 
-  const systemUser = userInfo().username
-  const userId = await p.text({
-    message: "Enter a User ID for this agent",
-    placeholder: systemUser || "your-email@example.com",
-    defaultValue: systemUser,
-  })
+	const systemUser = userInfo().username;
+	const userId = await p.text({
+		message: "Enter a User ID for this agent",
+		placeholder: systemUser || "your-email@example.com",
+		defaultValue: systemUser,
+	});
 
-  if (p.isCancel(userId)) {
-    p.cancel("Setup cancelled")
-    return
-  }
+	if (p.isCancel(userId)) {
+		p.cancel("Setup cancelled");
+		return;
+	}
 
-  // Step 4: List and connect integrations
-  let integrations: Awaited<ReturnType<typeof client.integrations.list>>
-  try {
-    integrations = await client.integrations.list()
-  } catch (_error) {
-    integrations = { integrations: [] }
-  }
+	// Step 4: List and connect integrations
+	let integrations: Awaited<ReturnType<typeof client.integrations.list>>;
+	try {
+		integrations = await client.integrations.list();
+	} catch (_error) {
+		integrations = { integrations: [] };
+	}
 
-  if (integrations.integrations.length === 0) {
-    p.note(
-      "No integrations are configured in your app yet.\n" +
-        "Go to https://app.hyperspell.com to add integrations,\n" +
-        "then use /connect <source> to connect them.",
-      "Connect Your Apps",
-    )
-  } else {
-    const integrationList = integrations.integrations
-      .map((int) => `• ${int.name} (${int.provider})`)
-      .join("\n")
+	if (integrations.integrations.length === 0) {
+		p.note(
+			"No integrations are configured in your app yet.\n" +
+				"Go to https://app.hyperspell.com to add integrations,\n" +
+				"then use /connect <source> to connect them.",
+			"Connect Your Apps",
+		);
+	} else {
+		const integrationList = integrations.integrations
+			.map((int) => `• ${int.name} (${int.provider})`)
+			.join("\n");
 
-    // Get a user token for the connect page
-    let connectUrl: string
-    try {
-      const tokenResponse = await client.auth.userToken({ user_id: userId })
-      connectUrl = `https://connect.hyperspell.com?token=${tokenResponse.token}`
-    } catch (_error) {
-      p.log.error("Could not generate connect URL. You can connect apps later using /connect.")
-      connectUrl = ""
-    }
+		// Get a user token for the connect page
+		let connectUrl: string;
+		try {
+			const tokenResponse = await client.auth.userToken({ user_id: userId });
+			connectUrl = `https://connect.hyperspell.com?token=${tokenResponse.token}`;
+		} catch (_error) {
+			p.log.error(
+				"Could not generate connect URL. You can connect apps later using /connect.",
+			);
+			connectUrl = "";
+		}
 
-    p.note(
-      `Available integrations:\n${integrationList}` +
-        (connectUrl ? `\n\nConnect your accounts at:\n${connectUrl}` : ""),
-      "Connect Your Apps",
-    )
+		p.note(
+			`Available integrations:\n${integrationList}` +
+				(connectUrl ? `\n\nConnect your accounts at:\n${connectUrl}` : ""),
+			"Connect Your Apps",
+		);
 
-    if (connectUrl) {
-      const openConnect = await p.confirm({
-        message: "Open connection page in your browser?",
-      })
+		if (connectUrl) {
+			const openConnect = await p.confirm({
+				message: "Open connection page in your browser?",
+			});
 
-      if (!p.isCancel(openConnect) && openConnect) {
-        await openUrl(connectUrl)
-        p.log.info("Browser opened. Connect your accounts and come back when done.")
+			if (!p.isCancel(openConnect) && openConnect) {
+				await openUrl(connectUrl);
+				p.log.info(
+					"Browser opened. Connect your accounts and come back when done.",
+				);
 
-        await p.confirm({
-          message: "Finished connecting accounts?",
-          active: "Yes",
-          inactive: "Not yet",
-        })
-      }
-    }
-  }
+				await p.confirm({
+					message: "Finished connecting accounts?",
+					active: "Yes",
+					inactive: "Not yet",
+				});
+			}
+		}
+	}
 
-  // Fetch connected sources
-  const s1 = p.spinner()
-  s1.start("Fetching connected sources")
-  const sources = await fetchConnectionSources(client, userId)
-  s1.stop(`Found ${sources.length} sources: ${sources.join(", ")}`)
+	// Fetch connected sources
+	const s1 = p.spinner();
+	s1.start("Fetching connected sources");
+	const sources = await fetchConnectionSources(client, userId);
+	s1.stop(`Found ${sources.length} sources: ${sources.join(", ")}`);
 
-  // Step 5: Ask about memory sync
-  p.note(
-    "OpenClaw can automatically sync markdown files in your workspace's\n" +
-      "memory/ directory with Hyperspell. This allows you to:\n\n" +
-      "• Store notes and context that persist across sessions\n" +
-      "• Have the AI reference your local documentation\n" +
-      "• Keep local files in sync with Hyperspell's search",
-    "Memory Sync",
-  )
+	// Step 5: Ask about memory sync
+	p.note(
+		"OpenClaw can automatically sync markdown files in your workspace's\n" +
+			"memory/ directory with Hyperspell. This allows you to:\n\n" +
+			"• Store notes and context that persist across sessions\n" +
+			"• Have the AI reference your local documentation\n" +
+			"• Keep local files in sync with Hyperspell's search",
+		"Memory Sync",
+	);
 
-  const syncMemories = await p.confirm({
-    message: "Enable automatic memory sync for markdown files?",
-    initialValue: true,
-  })
+	const syncMemories = await p.confirm({
+		message: "Enable automatic memory sync for markdown files?",
+		initialValue: true,
+	});
 
-  if (p.isCancel(syncMemories)) {
-    p.cancel("Setup cancelled")
-    return
-  }
+	if (p.isCancel(syncMemories)) {
+		p.cancel("Setup cancelled");
+		return;
+	}
 
-  // Step 5: Save configuration
-  const s2 = p.spinner()
-  s2.start("Saving configuration")
+	// Step 5: Save configuration
+	const s2 = p.spinner();
+	s2.start("Saving configuration");
 
-  try {
-    const configPath = resolveConfigPath()
-    const openclawDir = path.dirname(configPath)
-    const envPath = path.join(openclawDir, ".env")
+	try {
+		const configPath = resolveConfigPath();
+		const openclawDir = path.dirname(configPath);
+		const envPath = path.join(openclawDir, ".env");
 
-    // Ensure directory exists
-    if (!fs.existsSync(openclawDir)) {
-      fs.mkdirSync(openclawDir, { recursive: true })
-    }
+		// Ensure directory exists
+		if (!fs.existsSync(openclawDir)) {
+			fs.mkdirSync(openclawDir, { recursive: true });
+		}
 
-    // Read existing config or create new one
-    let config: Record<string, unknown> = {}
-    if (fs.existsSync(configPath)) {
-      const existing = fs.readFileSync(configPath, "utf-8")
-      config = JSON.parse(existing)
-    }
+		// Read existing config or create new one
+		let config: Record<string, unknown> = {};
+		if (fs.existsSync(configPath)) {
+			const existing = fs.readFileSync(configPath, "utf-8");
+			config = JSON.parse(existing);
+		}
 
-    // Merge in plugin configuration
-    if (!config.plugins) {
-      config.plugins = {}
-    }
-    const plugins = config.plugins as Record<string, unknown>
-    if (!plugins.entries) {
-      plugins.entries = {}
-    }
-    const entries = plugins.entries as Record<string, unknown>
-    entries["openclaw-hyperspell"] = {
-      enabled: true,
-      config: {
-        apiKey: "${HYPERSPELL_API_KEY}",
-        userId,
-        sources: sources.join(","),
-        autoContext: true,
-        syncMemories,
-      },
-    }
+		// Merge in plugin configuration
+		if (!config.plugins) {
+			config.plugins = {};
+		}
+		const plugins = config.plugins as Record<string, unknown>;
+		if (!plugins.entries) {
+			plugins.entries = {};
+		}
+		const entries = plugins.entries as Record<string, unknown>;
+		entries["openclaw-hyperspell"] = {
+			enabled: true,
+			config: {
+				apiKey: "${HYPERSPELL_API_KEY}",
+				userId,
+				sources: sources.join(","),
+				autoContext: true,
+				syncMemories,
+			},
+		};
 
-    // Write config
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n")
+		// Write config
+		fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
-    // Write or append to .env
-    const envLine = `HYPERSPELL_API_KEY=${apiKey}`
-    if (fs.existsSync(envPath)) {
-      const envContent = fs.readFileSync(envPath, "utf-8")
-      if (envContent.includes("HYPERSPELL_API_KEY=")) {
-        // Replace existing line
-        const updated = envContent.replace(/^HYPERSPELL_API_KEY=.*$/m, envLine)
-        fs.writeFileSync(envPath, updated)
-      } else {
-        // Append new line
-        fs.appendFileSync(envPath, (envContent.endsWith("\n") ? "" : "\n") + envLine + "\n")
-      }
-    } else {
-      fs.writeFileSync(envPath, envLine + "\n")
-    }
+		// Write or append to .env
+		const envLine = `HYPERSPELL_API_KEY=${apiKey}`;
+		if (fs.existsSync(envPath)) {
+			const envContent = fs.readFileSync(envPath, "utf-8");
+			if (envContent.includes("HYPERSPELL_API_KEY=")) {
+				// Replace existing line
+				const updated = envContent.replace(/^HYPERSPELL_API_KEY=.*$/m, envLine);
+				fs.writeFileSync(envPath, updated);
+			} else {
+				// Append new line
+				fs.appendFileSync(
+					envPath,
+					(envContent.endsWith("\n") ? "" : "\n") + envLine + "\n",
+				);
+			}
+		} else {
+			fs.writeFileSync(envPath, envLine + "\n");
+		}
 
-    s2.stop("Configuration saved")
+		s2.stop("Configuration saved");
 
-    p.note(
-      `Config: ${configPath}\n` +
-        `API Key: ${envPath}`,
-      "Files updated",
-    )
-  } catch (error) {
-    s2.stop("Failed to save configuration")
+		p.note(`Config: ${configPath}\n` + `API Key: ${envPath}`, "Files updated");
+	} catch (error) {
+		s2.stop("Failed to save configuration");
 
-    // Fall back to showing manual instructions
-    const configJson = JSON.stringify(
-      {
-        plugins: {
-          entries: {
-            "openclaw-hyperspell": {
-              enabled: true,
-              config: {
-                apiKey: "${HYPERSPELL_API_KEY}",
-                userId,
-                sources: sources.join(","),
-                autoContext: true,
-                syncMemories,
-              },
-            },
-          },
-        },
-      },
-      null,
-      2,
-    )
+		// Fall back to showing manual instructions
+		const configJson = JSON.stringify(
+			{
+				plugins: {
+					entries: {
+						"openclaw-hyperspell": {
+							enabled: true,
+							config: {
+								apiKey: "${HYPERSPELL_API_KEY}",
+								userId,
+								sources: sources.join(","),
+								autoContext: true,
+								syncMemories,
+							},
+						},
+					},
+				},
+			},
+			null,
+			2,
+		);
 
-    p.note(
-      `Add to your openclaw.json:\n\n${configJson}\n\n` +
-        `Set the environment variable:\n  export HYPERSPELL_API_KEY=${apiKey}`,
-      "Manual configuration required",
-    )
-  }
+		p.note(
+			`Add to your openclaw.json:\n\n${configJson}\n\n` +
+				`Set the environment variable:\n  export HYPERSPELL_API_KEY=${apiKey}`,
+			"Manual configuration required",
+		);
+	}
 
-  // Step 7: Sync existing memories if enabled
-  if (syncMemories) {
-    const workspaceDir = getWorkspaceDir()
-    const memoryFiles = getMemoryFiles(workspaceDir)
+	// Step 7: Sync existing memories if enabled
+	if (syncMemories) {
+		const workspaceDir = getWorkspaceDir();
+		const memoryFiles = getMemoryFiles(workspaceDir);
 
-    if (memoryFiles.length > 0) {
-      const s3 = p.spinner()
-      s3.start(`Syncing ${memoryFiles.length} memory file(s)`)
+		if (memoryFiles.length > 0) {
+			const s3 = p.spinner();
+			s3.start(`Syncing ${memoryFiles.length} memory file(s)`);
 
-      const hyperspellClient = new HyperspellClient({
-        apiKey,
-        userId,
-        autoContext: true,
-        syncMemories: true,
-        sources: [],
-        maxResults: 10,
-        debug: false,
-        knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
-      })
+			const hyperspellClient = new HyperspellClient({
+				apiKey,
+				userId,
+				autoContext: true,
+				syncMemories: true,
+				captureConversations: true,
+				sources: [],
+				maxResults: 10,
+				debug: false,
+				knowledgeGraph: {
+					enabled: false,
+					scanIntervalMinutes: 60,
+					batchSize: 20,
+				},
+			});
 
-      const result = await syncAllMemoryFiles(hyperspellClient, workspaceDir)
+			const result = await syncAllMemoryFiles(hyperspellClient, workspaceDir);
 
-      if (result.failed > 0) {
-        s3.stop(`Synced ${result.synced} files, ${result.failed} failed`)
-        for (const error of result.errors) {
-          p.log.error(`  ${error}`)
-        }
-      } else {
-        s3.stop(`Synced ${result.synced} memory files`)
-      }
-    } else {
-      p.log.info("No memory files found in memory/ directory")
-    }
-  }
+			if (result.failed > 0) {
+				s3.stop(`Synced ${result.synced} files, ${result.failed} failed`);
+				for (const error of result.errors) {
+					p.log.error(`  ${error}`);
+				}
+			} else {
+				s3.stop(`Synced ${result.synced} memory files`);
+			}
+		} else {
+			p.log.info("No memory files found in memory/ directory");
+		}
+	}
 
-  // Step 8: Memory Network setup
-  p.note(
-    "The Memory Network automatically extracts entities (people, projects,\n" +
-      "organizations, topics) from your memories into structured markdown\n" +
-      "files. This runs as a periodic cron job in the main session.",
-    "Memory Network",
-  )
+	// Step 8: Memory Network setup
+	p.note(
+		"The Memory Network automatically extracts entities (people, projects,\n" +
+			"organizations, topics) from your memories into structured markdown\n" +
+			"files. This runs as a periodic cron job in the main session.",
+		"Memory Network",
+	);
 
-  const enableNetwork = await p.confirm({
-    message: "Enable the Memory Network?",
-    initialValue: false,
-  })
+	const enableNetwork = await p.confirm({
+		message: "Enable the Memory Network?",
+		initialValue: false,
+	});
 
-  if (!p.isCancel(enableNetwork) && enableNetwork) {
-    // Update config to enable knowledgeGraph
-    try {
-      const configPath = resolveConfigPath()
-      if (fs.existsSync(configPath)) {
-        const configContent = fs.readFileSync(configPath, "utf-8")
-        const config = JSON.parse(configContent)
-        const pluginEntry = config?.plugins?.entries?.["openclaw-hyperspell"]?.config
-        if (pluginEntry) {
-          pluginEntry.knowledgeGraph = { enabled: true }
-          fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n")
-        }
-      }
-      p.log.success("Memory Network enabled in config")
-    } catch {
-      p.log.warn("Could not update config — add knowledgeGraph.enabled: true manually")
-    }
+	if (!p.isCancel(enableNetwork) && enableNetwork) {
+		// Update config to enable knowledgeGraph
+		try {
+			const configPath = resolveConfigPath();
+			if (fs.existsSync(configPath)) {
+				const configContent = fs.readFileSync(configPath, "utf-8");
+				const config = JSON.parse(configContent);
+				const pluginEntry =
+					config?.plugins?.entries?.["openclaw-hyperspell"]?.config;
+				if (pluginEntry) {
+					pluginEntry.knowledgeGraph = { enabled: true };
+					fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+				}
+			}
+			p.log.success("Memory Network enabled in config");
+		} catch {
+			p.log.warn(
+				"Could not update config — add knowledgeGraph.enabled: true manually",
+			);
+		}
 
-    // Write the extraction prompt to a file and create the cron job
-    const networkWorkspaceDir = getWorkspaceDir()
-    const promptPath = path.join(networkWorkspaceDir, "HYPERSPELL-MEMORY-NETWORK.md")
-    const prompt = buildExtractionPrompt(networkWorkspaceDir)
-    fs.mkdirSync(path.dirname(promptPath), { recursive: true })
-    fs.writeFileSync(promptPath, prompt)
+		// Write the extraction prompt to a file and create the cron job
+		const networkWorkspaceDir = getWorkspaceDir();
+		const promptPath = path.join(
+			networkWorkspaceDir,
+			"HYPERSPELL-MEMORY-NETWORK.md",
+		);
+		const prompt = buildExtractionPrompt(networkWorkspaceDir);
+		fs.mkdirSync(path.dirname(promptPath), { recursive: true });
+		fs.writeFileSync(promptPath, prompt);
 
-    const s4 = p.spinner()
-    s4.start("Creating Memory Network cron job")
+		const s4 = p.spinner();
+		s4.start("Creating Memory Network cron job");
 
-    let cronJobId: string | null = null
-    try {
-      const output = execFileSync("openclaw", [
-        "cron", "add",
-        "--name", CRON_JOB_NAME,
-        "--every", "1h",
-        "--session", "isolated",
-        "--message", `Read the file at ${promptPath} and follow the instructions inside it.`,
-      ], { stdio: ["pipe", "pipe", "pipe"], timeout: 10_000 })
+		let cronJobId: string | null = null;
+		try {
+			const output = execFileSync(
+				"openclaw",
+				[
+					"cron",
+					"add",
+					"--name",
+					CRON_JOB_NAME,
+					"--every",
+					"1h",
+					"--session",
+					"isolated",
+					"--message",
+					`Read the file at ${promptPath} and follow the instructions inside it.`,
+				],
+				{ stdio: ["pipe", "pipe", "pipe"], timeout: 10_000 },
+			);
 
-      // Extract job ID from the JSON output
-      const text = output.toString().trim()
-      // Find the JSON object in the output (skip any non-JSON prefix lines)
-      const jsonStart = text.indexOf("{")
-      if (jsonStart >= 0) {
-        try {
-          const job = JSON.parse(text.slice(jsonStart))
-          cronJobId = job?.id || null
-        } catch {}
-      }
+			// Extract job ID from the JSON output
+			const text = output.toString().trim();
+			// Find the JSON object in the output (skip any non-JSON prefix lines)
+			const jsonStart = text.indexOf("{");
+			if (jsonStart >= 0) {
+				try {
+					const job = JSON.parse(text.slice(jsonStart));
+					cronJobId = job?.id || null;
+				} catch {}
+			}
 
-      s4.stop("Cron job created — Memory Network will scan every hour")
-    } catch (cronErr) {
-      s4.stop("Could not create cron job automatically")
+			s4.stop("Cron job created — Memory Network will scan every hour");
+		} catch (cronErr) {
+			s4.stop("Could not create cron job automatically");
 
-      p.log.warn(`Cron creation failed. Create it manually:`)
+			p.log.warn(`Cron creation failed. Create it manually:`);
 
-      p.note(
-        `openclaw cron add \\\n` +
-          `  --name "${CRON_JOB_NAME}" \\\n` +
-          `  --every 1h \\\n` +
-          `  --session isolated \\\n` +
-          `  --message "Read the file at ${promptPath} and follow the instructions inside it."`,
-        "Manual cron setup",
-      )
-    }
+			p.note(
+				`openclaw cron add \\\n` +
+					`  --name "${CRON_JOB_NAME}" \\\n` +
+					`  --every 1h \\\n` +
+					`  --session isolated \\\n` +
+					`  --message "Read the file at ${promptPath} and follow the instructions inside it."`,
+				"Manual cron setup",
+			);
+		}
 
-    // Ask if they want to run the first extraction now
-    const runNow = await p.confirm({
-      message: "Run the Memory Network now? (If not, it will run automatically on the next cron cycle)",
-      initialValue: true,
-    })
+		// Ask if they want to run the first extraction now
+		const runNow = await p.confirm({
+			message:
+				"Run the Memory Network now? (If not, it will run automatically on the next cron cycle)",
+			initialValue: true,
+		});
 
-    if (!p.isCancel(runNow) && runNow) {
-      if (cronJobId) {
-        const s5 = p.spinner()
-        s5.start("Triggering Memory Network extraction")
+		if (!p.isCancel(runNow) && runNow) {
+			if (cronJobId) {
+				const s5 = p.spinner();
+				s5.start("Triggering Memory Network extraction");
 
-        try {
-          execFileSync("openclaw", [
-            "cron", "run", cronJobId,
-          ], { stdio: "pipe", timeout: 10_000 })
+				try {
+					execFileSync("openclaw", ["cron", "run", cronJobId], {
+						stdio: "pipe",
+						timeout: 10_000,
+					});
 
-          s5.stop("Memory Network extraction triggered — running in the background")
-        } catch {
-          s5.stop("Could not trigger automatically")
-          p.log.info(`You can trigger it manually with: openclaw cron run ${cronJobId}`)
-        }
-      } else {
-        p.log.info("Create the cron job first, then run it with: openclaw cron run <job-id>")
-      }
-    }
-  }
+					s5.stop(
+						"Memory Network extraction triggered — running in the background",
+					);
+				} catch {
+					s5.stop("Could not trigger automatically");
+					p.log.info(
+						`You can trigger it manually with: openclaw cron run ${cronJobId}`,
+					);
+				}
+			} else {
+				p.log.info(
+					"Create the cron job first, then run it with: openclaw cron run <job-id>",
+				);
+			}
+		}
+	}
 
-  const syncNote = syncMemories
-    ? "\n\nMemory sync is enabled — markdown files in memory/ will be\n" +
-      "automatically synced to Hyperspell when they change."
-    : ""
+	const syncNote = syncMemories
+		? "\n\nMemory sync is enabled — markdown files in memory/ will be\n" +
+			"automatically synced to Hyperspell when they change."
+		: "";
 
-  const networkNote = !p.isCancel(enableNetwork) && enableNetwork
-    ? "\n\nMemory Network is enabled — entities will be extracted into\n" +
-      "memory/people/, memory/projects/, memory/organizations/, memory/topics/"
-    : ""
+	const networkNote =
+		!p.isCancel(enableNetwork) && enableNetwork
+			? "\n\nMemory Network is enabled — entities will be extracted into\n" +
+				"memory/people/, memory/projects/, memory/organizations/, memory/topics/"
+			: "";
 
-  p.note(
-    "/getcontext <query>  Search your memories for relevant context\n" +
-      "/remember <text>     Save something directly to your vault\n\n" +
-      "To connect more apps, run: openclaw openclaw-hyperspell connect\n\n" +
-      "Auto-context is enabled by default — relevant memories are\n" +
-      "automatically injected before each AI response." +
-      syncNote +
-      networkNote,
-    "How to use Hyperspell",
-  )
+	p.note(
+		"/getcontext <query>  Search your memories for relevant context\n" +
+			"/remember <text>     Save something directly to your vault\n\n" +
+			"To connect more apps, run: openclaw openclaw-hyperspell connect\n\n" +
+			"Auto-context is enabled by default — relevant memories are\n" +
+			"automatically injected before each AI response." +
+			syncNote +
+			networkNote,
+		"How to use Hyperspell",
+	);
 
-  p.outro("Setup complete!")
+	p.outro("Setup complete!");
 }
 
 async function runConnect(pluginConfig: unknown): Promise<void> {
-  const config = pluginConfig as Record<string, unknown> | undefined
+	const config = pluginConfig as Record<string, unknown> | undefined;
 
-  p.intro("Hyperspell Connect")
+	p.intro("Hyperspell Connect");
 
-  if (!config?.apiKey) {
-    p.log.error("Not configured")
-    p.note("Run 'openclaw openclaw-hyperspell setup' to configure Hyperspell first.")
-    p.outro("")
-    return
-  }
+	if (!config?.apiKey) {
+		p.log.error("Not configured");
+		p.note(
+			"Run 'openclaw openclaw-hyperspell setup' to configure Hyperspell first.",
+		);
+		p.outro("");
+		return;
+	}
 
-  const s = p.spinner()
-  s.start("Generating connect URL")
+	const s = p.spinner();
+	s.start("Generating connect URL");
 
-  let client: Hyperspell
-  let userId: string
-  try {
-    client = new Hyperspell({ apiKey: config.apiKey as string })
-    userId = (config.userId as string) || userInfo().username || "user"
-    const tokenResponse = await client.auth.userToken({ user_id: userId })
-    const connectUrl = `https://connect.hyperspell.com?token=${tokenResponse.token}`
+	let client: Hyperspell;
+	let userId: string;
+	try {
+		client = new Hyperspell({ apiKey: config.apiKey as string });
+		userId = (config.userId as string) || userInfo().username || "user";
+		const tokenResponse = await client.auth.userToken({ user_id: userId });
+		const connectUrl = `https://connect.hyperspell.com?token=${tokenResponse.token}`;
 
-    s.stop("Connect URL ready")
+		s.stop("Connect URL ready");
 
-    await openUrl(connectUrl)
-    p.log.success("Browser opened to connect.hyperspell.com")
+		await openUrl(connectUrl);
+		p.log.success("Browser opened to connect.hyperspell.com");
 
-    await p.confirm({
-      message: "Finished connecting accounts?",
-      active: "Yes",
-      inactive: "Not yet",
-    })
+		await p.confirm({
+			message: "Finished connecting accounts?",
+			active: "Yes",
+			inactive: "Not yet",
+		});
 
-    // Fetch and update sources
-    const s2 = p.spinner()
-    s2.start("Updating sources configuration")
+		// Fetch and update sources
+		const s2 = p.spinner();
+		s2.start("Updating sources configuration");
 
-    const sources = await fetchConnectionSources(client, userId)
-    const configPath = resolveConfigPath()
-    updateConfigSources(configPath, sources)
+		const sources = await fetchConnectionSources(client, userId);
+		const configPath = resolveConfigPath();
+		updateConfigSources(configPath, sources);
 
-    s2.stop(`Sources updated: ${sources.join(", ")}`)
+		s2.stop(`Sources updated: ${sources.join(", ")}`);
 
-    p.outro("Done! Restart OpenClaw to apply changes.")
-  } catch (_error) {
-    s.stop("Failed to generate connect URL")
-    p.log.error("Check your API key and try again.")
-    p.outro("")
-  }
+		p.outro("Done! Restart OpenClaw to apply changes.");
+	} catch (_error) {
+		s.stop("Failed to generate connect URL");
+		p.log.error("Check your API key and try again.");
+		p.outro("");
+	}
 }
 
 async function runStatus(pluginConfig: unknown): Promise<void> {
-  const config = pluginConfig as Record<string, unknown> | undefined
+	const config = pluginConfig as Record<string, unknown> | undefined;
 
-  p.intro("Hyperspell Status")
+	p.intro("Hyperspell Status");
 
-  if (!config?.apiKey) {
-    p.log.warn("Not configured")
-    p.note("Run 'openclaw openclaw-hyperspell setup' to configure Hyperspell.")
-    p.outro("")
-    return
-  }
+	if (!config?.apiKey) {
+		p.log.warn("Not configured");
+		p.note("Run 'openclaw openclaw-hyperspell setup' to configure Hyperspell.");
+		p.outro("");
+		return;
+	}
 
-  p.log.success("Configured")
-  p.log.info(`User ID: ${config.userId || "(not set)"}`)
-  p.log.info(`Auto-Context: ${config.autoContext !== false ? "Enabled" : "Disabled"}`)
-  p.log.info(`Memory Sync: ${config.syncMemories ? "Enabled" : "Disabled"}`)
-  p.log.info(`Sources Filter: ${config.sources || "(all sources)"}`)
-  p.log.info(`Max Results: ${config.maxResults || 10}`)
+	p.log.success("Configured");
+	p.log.info(`User ID: ${config.userId || "(not set)"}`);
+	p.log.info(
+		`Auto-Context: ${config.autoContext !== false ? "Enabled" : "Disabled"}`,
+	);
+	p.log.info(`Memory Sync: ${config.syncMemories ? "Enabled" : "Disabled"}`);
+	p.log.info(`Sources Filter: ${config.sources || "(all sources)"}`);
+	p.log.info(`Max Results: ${config.maxResults || 10}`);
 
-  const s = p.spinner()
-  s.start("Testing connection")
+	const s = p.spinner();
+	s.start("Testing connection");
 
-  try {
-    const client = new Hyperspell({ apiKey: config.apiKey as string })
-    const integrations = await client.integrations.list()
-    s.stop(`Connection OK (${integrations.integrations.length} integrations available)`)
+	try {
+		const client = new Hyperspell({ apiKey: config.apiKey as string });
+		const integrations = await client.integrations.list();
+		s.stop(
+			`Connection OK (${integrations.integrations.length} integrations available)`,
+		);
 
-    if (integrations.integrations.length > 0) {
-      const list = integrations.integrations
-        .map((int) => `• ${int.name} (${int.provider})`)
-        .join("\n")
-      p.note(list, "Available integrations")
-    }
-  } catch (_error) {
-    s.stop("Connection failed")
-    p.log.error("Check your API key and try again.")
-  }
+		if (integrations.integrations.length > 0) {
+			const list = integrations.integrations
+				.map((int) => `• ${int.name} (${int.provider})`)
+				.join("\n");
+			p.note(list, "Available integrations");
+		}
+	} catch (_error) {
+		s.stop("Connection failed");
+		p.log.error("Check your API key and try again.");
+	}
 
-  p.outro("")
+	p.outro("");
 }
 
-export function registerCliCommands(program: Command, pluginConfig: unknown): void {
-  const hyperspellCmd = program
-    .command("openclaw-hyperspell")
-    .description("Hyperspell — Memory and context for your AI agent")
+export function registerCliCommands(
+	program: Command,
+	pluginConfig: unknown,
+): void {
+	const hyperspellCmd = program
+		.command("openclaw-hyperspell")
+		.description("Hyperspell — Memory and context for your AI agent");
 
-  hyperspellCmd
-    .command("setup")
-    .description("Interactive setup wizard for Hyperspell")
-    .action(async () => {
-      await runSetup()
-    })
+	hyperspellCmd
+		.command("setup")
+		.description("Interactive setup wizard for Hyperspell")
+		.action(async () => {
+			await runSetup();
+		});
 
-  hyperspellCmd
-    .command("status")
-    .description("Show Hyperspell connection status")
-    .action(async () => {
-      await runStatus(pluginConfig)
-    })
+	hyperspellCmd
+		.command("status")
+		.description("Show Hyperspell connection status")
+		.action(async () => {
+			await runStatus(pluginConfig);
+		});
 
-  hyperspellCmd
-    .command("connect")
-    .description("Open the Hyperspell connect page to link your accounts")
-    .action(async () => {
-      await runConnect(pluginConfig)
-    })
+	hyperspellCmd
+		.command("connect")
+		.description("Open the Hyperspell connect page to link your accounts")
+		.action(async () => {
+			await runConnect(pluginConfig);
+		});
 
-  // Memory Network CLI commands (used by isolated cron sessions via exec)
-  const networkCmd = hyperspellCmd
-    .command("network")
-    .description("Memory Network operations")
+	// Memory Network CLI commands (used by isolated cron sessions via exec)
+	const networkCmd = hyperspellCmd
+		.command("network")
+		.description("Memory Network operations");
 
-  networkCmd
-    .command("scan")
-    .description("Scan for unprocessed memories and output summaries")
-    .option("--batch-size <n>", "Max memories to return", "20")
-    .action(async (opts) => {
-      try {
-        const cfg = parseConfig(pluginConfig)
-        const client = new HyperspellClient(cfg)
-        const workspaceDir = getWorkspaceDir()
-        const stateManager = new NetworkStateManager(workspaceDir)
-        const batchSize = Number.parseInt(opts.batchSize, 10) || 20
+	networkCmd
+		.command("scan")
+		.description("Scan for unprocessed memories and output summaries")
+		.option("--batch-size <n>", "Max memories to return", "20")
+		.action(async (opts) => {
+			try {
+				const cfg = parseConfig(pluginConfig);
+				const client = new HyperspellClient(cfg);
+				const workspaceDir = getWorkspaceDir();
+				const stateManager = new NetworkStateManager(workspaceDir);
+				const batchSize = Number.parseInt(opts.batchSize, 10) || 20;
 
-        const memories = await scanMemories(client, stateManager, batchSize)
-        const text = formatScanResults(memories, stateManager.getProcessedCount(), stateManager.getLastScanAt())
-        process.stdout.write(text + "\n")
-      } catch (err) {
-        process.stderr.write(`Scan failed: ${err instanceof Error ? err.message : String(err)}\n`)
-        process.exit(1)
-      }
-    })
+				const memories = await scanMemories(client, stateManager, batchSize);
+				const text = formatScanResults(
+					memories,
+					stateManager.getProcessedCount(),
+					stateManager.getLastScanAt(),
+				);
+				process.stdout.write(text + "\n");
+			} catch (err) {
+				process.stderr.write(
+					`Scan failed: ${err instanceof Error ? err.message : String(err)}\n`,
+				);
+				process.exit(1);
+			}
+		});
 
-  networkCmd
-    .command("complete")
-    .description("Mark memory IDs as processed")
-    .requiredOption("--ids <ids>", "Comma-separated resource_ids")
-    .action((opts) => {
-      try {
-        const workspaceDir = getWorkspaceDir()
-        const stateManager = new NetworkStateManager(workspaceDir)
-        const memoryIds = (opts.ids as string).split(",").map((s: string) => s.trim()).filter(Boolean)
+	networkCmd
+		.command("complete")
+		.description("Mark memory IDs as processed")
+		.requiredOption("--ids <ids>", "Comma-separated resource_ids")
+		.action((opts) => {
+			try {
+				const workspaceDir = getWorkspaceDir();
+				const stateManager = new NetworkStateManager(workspaceDir);
+				const memoryIds = (opts.ids as string)
+					.split(",")
+					.map((s: string) => s.trim())
+					.filter(Boolean);
 
-        const { newCount, totalCount } = completeMemories(stateManager, memoryIds)
-        process.stdout.write(`Marked ${newCount} new memories as processed (${totalCount} total)\n`)
-      } catch (err) {
-        process.stderr.write(`Complete failed: ${err instanceof Error ? err.message : String(err)}\n`)
-        process.exit(1)
-      }
-    })
+				const { newCount, totalCount } = completeMemories(
+					stateManager,
+					memoryIds,
+				);
+				process.stdout.write(
+					`Marked ${newCount} new memories as processed (${totalCount} total)\n`,
+				);
+			} catch (err) {
+				process.stderr.write(
+					`Complete failed: ${err instanceof Error ? err.message : String(err)}\n`,
+				);
+				process.exit(1);
+			}
+		});
 
-  networkCmd
-    .command("sync")
-    .description("Sync entity files in memory/ to Hyperspell")
-    .action(async () => {
-      try {
-        const cfg = parseConfig(pluginConfig)
-        const client = new HyperspellClient(cfg)
-        const workspaceDir = getWorkspaceDir()
+	networkCmd
+		.command("sync")
+		.description("Sync entity files in memory/ to Hyperspell")
+		.action(async () => {
+			try {
+				const cfg = parseConfig(pluginConfig);
+				const client = new HyperspellClient(cfg);
+				const workspaceDir = getWorkspaceDir();
 
-        const result = await syncAllMemoryFiles(client, workspaceDir)
-        process.stdout.write(`Synced ${result.synced} files, ${result.failed} failed\n`)
-        if (result.errors.length > 0) {
-          for (const error of result.errors) {
-            process.stderr.write(`  ${error}\n`)
-          }
-        }
-      } catch (err) {
-        process.stderr.write(`Sync failed: ${err instanceof Error ? err.message : String(err)}\n`)
-        process.exit(1)
-      }
-    })
+				const result = await syncAllMemoryFiles(client, workspaceDir);
+				process.stdout.write(
+					`Synced ${result.synced} files, ${result.failed} failed\n`,
+				);
+				if (result.errors.length > 0) {
+					for (const error of result.errors) {
+						process.stderr.write(`  ${error}\n`);
+					}
+				}
+			} catch (err) {
+				process.stderr.write(
+					`Sync failed: ${err instanceof Error ? err.message : String(err)}\n`,
+				);
+				process.exit(1);
+			}
+		});
 }

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -1,119 +1,121 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { getWorkspaceDir } from "../config.ts"
-import { log } from "../logger.ts"
-import { syncAllMemoryFiles } from "../sync/markdown.ts"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { getWorkspaceDir } from "../config.ts";
+import { log } from "../logger.ts";
+import { syncAllMemoryFiles } from "../sync/markdown.ts";
 
 function truncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text
-  return `${text.slice(0, maxLength)}…`
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength)}…`;
 }
 
 function formatScore(score: number | null): string {
-  if (score === null) return ""
-  return ` (${Math.round(score * 100)}%)`
+	if (score === null) return "";
+	return ` (${Math.round(score * 100)}%)`;
 }
 
 export function registerCommands(
-  api: OpenClawPluginApi,
-  client: HyperspellClient,
-  _cfg: HyperspellConfig,
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
 ): void {
-  // /getcontext <query> - Search memories and show summaries
-  api.registerCommand({
-    name: "getcontext",
-    description: "Search your memories for relevant context",
-    acceptsArgs: true,
-    requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
-      const query = ctx.args?.trim()
-      if (!query) {
-        return { text: "Usage: /getcontext <search query>" }
-      }
+	// /getcontext <query> - Search memories and show summaries
+	api.registerCommand({
+		name: "getcontext",
+		description: "Search your memories for relevant context",
+		acceptsArgs: true,
+		requireAuth: true,
+		handler: async (ctx: { args?: string }) => {
+			const query = ctx.args?.trim();
+			if (!query) {
+				return { text: "Usage: /getcontext <search query>" };
+			}
 
-      log.debug(`/getcontext command: "${query}"`)
+			log.debug(`/getcontext command: "${query}"`);
 
-      try {
-        const results = await client.search(query, { limit: 5 })
+			try {
+				const results = await client.search(query, { limit: 5 });
 
-        if (results.length === 0) {
-          return { text: `No memories found for: "${query}"` }
-        }
+				if (results.length === 0) {
+					return { text: `No memories found for: "${query}"` };
+				}
 
-        const lines = results.map((r, i) => {
-          const title = r.title ? truncate(r.title, 60) : `[${r.source}]`
-          const score = formatScore(r.score)
-          return `${i + 1}. ${title}${score}`
-        })
+				const lines = results.map((r, i) => {
+					const title = r.title ? truncate(r.title, 60) : `[${r.source}]`;
+					const score = formatScore(r.score);
+					return `${i + 1}. ${title}${score}`;
+				});
 
-        return {
-          text: `Found ${results.length} memories:\n\n${lines.join("\n")}`,
-        }
-      } catch (err) {
-        log.error("/getcontext failed", err)
-        return { text: "Failed to search memories. Check logs for details." }
-      }
-    },
-  })
+				return {
+					text: `Found ${results.length} memories:\n\n${lines.join("\n")}`,
+				};
+			} catch (err) {
+				log.error("/getcontext failed", err);
+				return { text: "Failed to search memories. Check logs for details." };
+			}
+		},
+	});
 
-  // /remember <text> - Add a new memory
-  api.registerCommand({
-    name: "remember",
-    description: "Save something to memory",
-    acceptsArgs: true,
-    requireAuth: true,
-    handler: async (ctx: { args?: string }) => {
-      const text = ctx.args?.trim()
-      if (!text) {
-        return { text: "Usage: /remember <text to remember>" }
-      }
+	// /remember <text> - Add a new memory
+	api.registerCommand({
+		name: "remember",
+		description: "Save something to memory",
+		acceptsArgs: true,
+		requireAuth: true,
+		handler: async (ctx: { args?: string }) => {
+			const text = ctx.args?.trim();
+			if (!text) {
+				return { text: "Usage: /remember <text to remember>" };
+			}
 
-      log.debug(`/remember command: "${truncate(text, 50)}"`)
+			log.debug(`/remember command: "${truncate(text, 50)}"`);
 
-      try {
-        await client.addMemory(text, {
-          metadata: { source: "openclaw_command" },
-        })
+			try {
+				await client.addMemory(text, {
+					metadata: { source: "openclaw_command" },
+				});
 
-        const preview = truncate(text, 60)
-        return { text: `Remembered: "${preview}"` }
-      } catch (err) {
-        log.error("/remember failed", err)
-        return { text: "Failed to save memory. Check logs for details." }
-      }
-    },
-  })
+				const preview = truncate(text, 60);
+				return { text: `Remembered: "${preview}"` };
+			} catch (err) {
+				log.error("/remember failed", err);
+				return { text: "Failed to save memory. Check logs for details." };
+			}
+		},
+	});
 
-  // /sync - Manually sync memory files
-  api.registerCommand({
-    name: "sync",
-    description: "Sync memory/*.md files with Hyperspell",
-    acceptsArgs: false,
-    requireAuth: true,
-    handler: async () => {
-      log.debug("/sync command")
+	// /sync - Manually sync memory files
+	api.registerCommand({
+		name: "sync",
+		description: "Sync memory/*.md files with Hyperspell",
+		acceptsArgs: false,
+		requireAuth: true,
+		handler: async () => {
+			log.debug("/sync command");
 
-      try {
-        const workspaceDir = getWorkspaceDir()
-        const result = await syncAllMemoryFiles(client, workspaceDir)
+			try {
+				const workspaceDir = getWorkspaceDir();
+				const result = await syncAllMemoryFiles(client, workspaceDir);
 
-        if (result.synced === 0 && result.failed === 0) {
-          return { text: "No memory files found in memory/ directory." }
-        }
+				if (result.synced === 0 && result.failed === 0) {
+					return { text: "No memory files found in memory/ directory." };
+				}
 
-        if (result.failed > 0) {
-          const errors = result.errors.map((e) => `  • ${e}`).join("\n")
-          return {
-            text: `Synced ${result.synced} files, ${result.failed} failed:\n${errors}`,
-          }
-        }
+				if (result.failed > 0) {
+					const errors = result.errors.map((e) => `  • ${e}`).join("\n");
+					return {
+						text: `Synced ${result.synced} files, ${result.failed} failed:\n${errors}`,
+					};
+				}
 
-        return { text: `Synced ${result.synced} memory file(s) to Hyperspell.` }
-      } catch (err) {
-        log.error("/sync failed", err)
-        return { text: "Failed to sync memory files. Check logs for details." }
-      }
-    },
-  })
+				return {
+					text: `Synced ${result.synced} memory file(s) to Hyperspell.`,
+				};
+			} catch (err) {
+				log.error("/sync failed", err);
+				return { text: "Failed to sync memory files. Check logs for details." };
+			}
+		},
+	});
 }

--- a/config.ts
+++ b/config.ts
@@ -1,206 +1,221 @@
+export const CONVERSATION_COLLECTION = "openclaw_conversations";
+
 export type HyperspellSource =
-  | "collections"
-  | "reddit"
-  | "notion"
-  | "slack"
-  | "google_calendar"
-  | "google_mail"
-  | "box"
-  | "google_drive"
-  | "vault"
-  | "web_crawler"
+	| "collections"
+	| "reddit"
+	| "notion"
+	| "slack"
+	| "google_calendar"
+	| "google_mail"
+	| "box"
+	| "google_drive"
+	| "vault"
+	| "web_crawler";
 
 export type KnowledgeGraphConfig = {
-  enabled: boolean
-  scanIntervalMinutes: number
-  batchSize: number
-}
+	enabled: boolean;
+	scanIntervalMinutes: number;
+	batchSize: number;
+};
 
 export type HyperspellConfig = {
-  apiKey: string
-  userId?: string
-  autoContext: boolean
-  syncMemories: boolean
-  sources: HyperspellSource[]
-  maxResults: number
-  debug: boolean
-  knowledgeGraph: KnowledgeGraphConfig
-}
+	apiKey: string;
+	userId?: string;
+	autoContext: boolean;
+	syncMemories: boolean;
+	captureConversations: boolean;
+	sources: HyperspellSource[];
+	maxResults: number;
+	debug: boolean;
+	knowledgeGraph: KnowledgeGraphConfig;
+};
 
 const ALLOWED_KEYS = [
-  "apiKey",
-  "userId",
-  "autoContext",
-  "syncMemories",
-  "sources",
-  "maxResults",
-  "debug",
-  "knowledgeGraph",
-]
+	"apiKey",
+	"userId",
+	"autoContext",
+	"syncMemories",
+	"captureConversations",
+	"sources",
+	"maxResults",
+	"debug",
+	"knowledgeGraph",
+];
 
 const VALID_SOURCES: HyperspellSource[] = [
-  "collections",
-  "reddit",
-  "notion",
-  "slack",
-  "google_calendar",
-  "google_mail",
-  "box",
-  "google_drive",
-  "vault",
-  "web_crawler",
-]
+	"collections",
+	"reddit",
+	"notion",
+	"slack",
+	"google_calendar",
+	"google_mail",
+	"box",
+	"google_drive",
+	"vault",
+	"web_crawler",
+];
 
 function assertAllowedKeys(
-  value: Record<string, unknown>,
-  allowed: string[],
-  label: string,
+	value: Record<string, unknown>,
+	allowed: string[],
+	label: string,
 ): void {
-  const unknown = Object.keys(value).filter((k) => !allowed.includes(k))
-  if (unknown.length > 0) {
-    throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`)
-  }
+	const unknown = Object.keys(value).filter((k) => !allowed.includes(k));
+	if (unknown.length > 0) {
+		throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+	}
 }
 
 function resolveEnvVars(value: string): string {
-  return value.replace(/\$\{([^}]+)\}/g, (_, envVar: string) => {
-    const envValue = process.env[envVar]
-    if (!envValue) {
-      throw new Error(`Environment variable ${envVar} is not set`)
-    }
-    return envValue
-  })
+	return value.replace(/\$\{([^}]+)\}/g, (_, envVar: string) => {
+		const envValue = process.env[envVar];
+		if (!envValue) {
+			throw new Error(`Environment variable ${envVar} is not set`);
+		}
+		return envValue;
+	});
 }
 
 function parseSources(raw: string | string[] | undefined): HyperspellSource[] {
-  if (!raw) {
-    return []
-  }
+	if (!raw) {
+		return [];
+	}
 
-  // Handle array input
-  if (Array.isArray(raw)) {
-    const sources = raw
-      .map((s) => String(s).trim().toLowerCase())
-      .filter((s) => s.length > 0) as HyperspellSource[]
+	// Handle array input
+	if (Array.isArray(raw)) {
+		const sources = raw
+			.map((s) => String(s).trim().toLowerCase())
+			.filter((s) => s.length > 0) as HyperspellSource[];
 
-    for (const source of sources) {
-      if (!VALID_SOURCES.includes(source)) {
-        throw new Error(
-          `Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
-        )
-      }
-    }
+		for (const source of sources) {
+			if (!VALID_SOURCES.includes(source)) {
+				throw new Error(
+					`Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
+				);
+			}
+		}
 
-    return sources
-  }
+		return sources;
+	}
 
-  // Handle string input (comma-separated)
-  if (typeof raw === "string" && raw.trim() === "") {
-    return []
-  }
+	// Handle string input (comma-separated)
+	if (typeof raw === "string" && raw.trim() === "") {
+		return [];
+	}
 
-  const sources = raw
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter((s) => s.length > 0) as HyperspellSource[]
+	const sources = raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0) as HyperspellSource[];
 
-  for (const source of sources) {
-    if (!VALID_SOURCES.includes(source)) {
-      throw new Error(
-        `Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
-      )
-    }
-  }
+	for (const source of sources) {
+		if (!VALID_SOURCES.includes(source)) {
+			throw new Error(
+				`Invalid source "${source}". Valid sources: ${VALID_SOURCES.join(", ")}`,
+			);
+		}
+	}
 
-  return sources
+	return sources;
 }
 
 export function parseConfig(raw: unknown): HyperspellConfig {
-  const cfg =
-    raw && typeof raw === "object" && !Array.isArray(raw)
-      ? (raw as Record<string, unknown>)
-      : {}
+	const cfg =
+		raw && typeof raw === "object" && !Array.isArray(raw)
+			? (raw as Record<string, unknown>)
+			: {};
 
-  if (Object.keys(cfg).length > 0) {
-    assertAllowedKeys(cfg, ALLOWED_KEYS, "hyperspell config")
-  }
+	if (Object.keys(cfg).length > 0) {
+		assertAllowedKeys(cfg, ALLOWED_KEYS, "hyperspell config");
+	}
 
-  const apiKey =
-    typeof cfg.apiKey === "string" && cfg.apiKey.length > 0
-      ? resolveEnvVars(cfg.apiKey)
-      : process.env.HYPERSPELL_API_KEY
+	const apiKey =
+		typeof cfg.apiKey === "string" && cfg.apiKey.length > 0
+			? resolveEnvVars(cfg.apiKey)
+			: process.env.HYPERSPELL_API_KEY;
 
-  if (!apiKey) {
-    throw new Error(
-      "hyperspell: apiKey is required (set in plugin config or HYPERSPELL_API_KEY env var)",
-    )
-  }
+	if (!apiKey) {
+		throw new Error(
+			"hyperspell: apiKey is required (set in plugin config or HYPERSPELL_API_KEY env var)",
+		);
+	}
 
-  const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>
+	const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>;
 
-  return {
-    apiKey,
-    userId: cfg.userId as string | undefined,
-    autoContext: (cfg.autoContext as boolean) ?? true,
-    syncMemories: (cfg.syncMemories as boolean) ?? false,
-    sources: parseSources(cfg.sources as string | string[] | undefined),
-    maxResults: (cfg.maxResults as number) ?? 10,
-    debug: (cfg.debug as boolean) ?? false,
-    knowledgeGraph: {
-      enabled: (kgRaw.enabled as boolean) ?? false,
-      scanIntervalMinutes: (kgRaw.scanIntervalMinutes as number) ?? 60,
-      batchSize: (kgRaw.batchSize as number) ?? 20,
-    },
-  }
+	return {
+		apiKey,
+		userId: cfg.userId as string | undefined,
+		autoContext: (cfg.autoContext as boolean) ?? true,
+		syncMemories: (cfg.syncMemories as boolean) ?? false,
+		captureConversations: (cfg.captureConversations as boolean) ?? true,
+		sources: parseSources(cfg.sources as string | string[] | undefined),
+		maxResults: (cfg.maxResults as number) ?? 10,
+		debug: (cfg.debug as boolean) ?? false,
+		knowledgeGraph: {
+			enabled: (kgRaw.enabled as boolean) ?? false,
+			scanIntervalMinutes: (kgRaw.scanIntervalMinutes as number) ?? 60,
+			batchSize: (kgRaw.batchSize as number) ?? 20,
+		},
+	};
 }
 
 export const hyperspellConfigSchema = {
-  parse: parseConfig,
-}
+	parse: parseConfig,
+};
 
 /**
  * Get the workspace directory from OpenClaw config
  */
 export function getWorkspaceDir(): string {
-  const { homedir } = require("node:os")
-  const fs = require("node:fs")
-  const path = require("node:path")
+	const { homedir } = require("node:os");
+	const fs = require("node:fs");
+	const path = require("node:path");
 
-  // Resolve config path
-  const override = process.env.OPENCLAW_CONFIG_PATH?.trim() || process.env.CLAWDBOT_CONFIG_PATH?.trim()
-  let configPath: string
-  if (override) {
-    configPath = override.startsWith("~")
-      ? override.replace(/^~(?=$|[\\/])/, homedir())
-      : path.resolve(override)
-  } else {
-    const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim()
-    const resolvedStateDir = stateDir
-      ? (stateDir.startsWith("~") ? stateDir.replace(/^~(?=$|[\\/])/, homedir()) : path.resolve(stateDir))
-      : path.join(homedir(), ".openclaw")
-    configPath = path.join(resolvedStateDir, "openclaw.json")
-  }
+	// Resolve config path
+	const override =
+		process.env.OPENCLAW_CONFIG_PATH?.trim() ||
+		process.env.CLAWDBOT_CONFIG_PATH?.trim();
+	let configPath: string;
+	if (override) {
+		configPath = override.startsWith("~")
+			? override.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(override);
+	} else {
+		const stateDir =
+			process.env.OPENCLAW_STATE_DIR?.trim() ||
+			process.env.CLAWDBOT_STATE_DIR?.trim();
+		const resolvedStateDir = stateDir
+			? stateDir.startsWith("~")
+				? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+				: path.resolve(stateDir)
+			: path.join(homedir(), ".openclaw");
+		configPath = path.join(resolvedStateDir, "openclaw.json");
+	}
 
-  // Read workspace from config
-  if (fs.existsSync(configPath)) {
-    try {
-      const content = fs.readFileSync(configPath, "utf-8")
-      const config = JSON.parse(content)
-      const workspace = config?.agents?.defaults?.workspace
-      if (workspace) {
-        return workspace.startsWith("~")
-          ? workspace.replace(/^~(?=$|[\\/])/, homedir())
-          : workspace
-      }
-    } catch (_e) {
-      // Fall back to default
-    }
-  }
+	// Read workspace from config
+	if (fs.existsSync(configPath)) {
+		try {
+			const content = fs.readFileSync(configPath, "utf-8");
+			const config = JSON.parse(content);
+			const workspace = config?.agents?.defaults?.workspace;
+			if (workspace) {
+				return workspace.startsWith("~")
+					? workspace.replace(/^~(?=$|[\\/])/, homedir())
+					: workspace;
+			}
+		} catch (_e) {
+			// Fall back to default
+		}
+	}
 
-  // Default workspace
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim()
-  const resolvedStateDir = stateDir
-    ? (stateDir.startsWith("~") ? stateDir.replace(/^~(?=$|[\\/])/, homedir()) : path.resolve(stateDir))
-    : path.join(homedir(), ".openclaw")
-  return path.join(resolvedStateDir, "workspace")
+	// Default workspace
+	const stateDir =
+		process.env.OPENCLAW_STATE_DIR?.trim() ||
+		process.env.CLAWDBOT_STATE_DIR?.trim();
+	const resolvedStateDir = stateDir
+		? stateDir.startsWith("~")
+			? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+			: path.resolve(stateDir)
+		: path.join(homedir(), ".openclaw");
+	return path.join(resolvedStateDir, "workspace");
 }

--- a/docs/2026-03-26-conversation-capture-aggressive-context-design.md
+++ b/docs/2026-03-26-conversation-capture-aggressive-context-design.md
@@ -38,14 +38,17 @@ After every agent turn completes, capture the user prompt and assistant response
   Assistant: <assistant message>
   ```
 - Calls `client.addMemory()` with:
-  - `collection`: `"openclaw_conversations"`
+  - `collection`: `"openclaw_conversations"` (defined as `CONVERSATION_COLLECTION` constant in `config.ts`)
   - `title`: First ~80 chars of user prompt
-  - `metadata`: `{ source: "openclaw_conversation", session_id: event.sessionId }`
+  - `resourceId`: Deterministic ID `openclaw_conv_{sessionId}_{turnIndex}` where turnIndex is derived from the message count (prevents duplicates on retries)
+  - `metadata`: `{ openclaw_source: "conversation", session_id: event.sessionId }`
 - Fire-and-forget — errors are logged but don't block the user
 - Skipped if `event.success` is false or messages are empty
 - Gated by config: `captureConversations` (default: `true`)
 
-**Content extraction:** Handles both string content and array content blocks (same pattern as LanceDB plugin — type-guard for `{ type: "text", text: string }` blocks).
+**Content extraction:** Handles both string content and array content blocks (same pattern as LanceDB plugin — type-guard for `{ type: "text", text: string }` blocks). Combined content truncated to 10,000 chars max.
+
+**Note on `client.addMemory()`:** The existing method hardcodes `openclaw_source: "command"` in metadata. This will be changed so that caller-provided metadata keys take precedence — the hardcoded default only applies when the caller does not provide `openclaw_source`.
 
 ### 2. Session Start Context (`session_start` hook)
 
@@ -55,12 +58,12 @@ When a new session begins, fetch recent conversation history and inject it as co
 
 **Behavior:**
 - Registered on `session_start` event
-- Searches Hyperspell for recent conversation memories:
-  1. First search: recent memories (within `recentContextHours`, default 48h) from `openclaw_conversations` collection
-  2. If no results: fall back to an unfiltered search across all collections for the most relevant memories
-- Formats results as prepended context with a section header indicating these are prior conversation summaries
+- Uses `client.listMemories()` (not `search()`) filtered to `collection: "openclaw_conversations"` to fetch recent memories — this avoids needing a query string since there's no user prompt yet
+- Client-side filters to memories within `recentContextHours` (default 48h) using `metadata.created_at`
+- If no recent results: falls back to `client.search()` with a generic query like `"recent conversations and context"` across all collections, limited to `maxResults`
+- Formats results as prepended context
 - Returns `{ prependContext: formattedString }`
-- Uses `maxResults` config for result count
+- **Total context budget:** Max 5 conversation memories on session start, with each truncated to 500 chars preview. This caps the injected context at ~3,000 chars to avoid blowing up the LLM context window.
 
 **Context format:**
 ```
@@ -83,13 +86,15 @@ Modify the existing `before_agent_start` handler to do a broader search when ini
 
 **Trigger conditions (OR):**
 - Fewer than 3 results returned
-- All returned results have relevance score below 30%
+- All returned results have relevance score below the configured threshold (default 0.30, configurable via `minRelevanceScore`)
 
 **Fallback behavior:**
 - Run `client.searchWithAnswer()` with the same query — this does a broader search and generates an LLM-synthesized answer
 - Merge fallback results with initial results, deduplicating by `resourceId`
 - Include the synthesized answer in the context block if available
 - The merged + enhanced context replaces the original sparse context
+
+**Latency note:** `searchWithAnswer()` involves an LLM call and adds ~1-3s latency. This is acceptable because the fallback only triggers when the initial search failed to find good results — in the normal case (plenty of relevant memories), the fast path is unchanged. No config gate needed since the trigger conditions already limit when this fires.
 
 **Enhanced context format** (when answer is available):
 ```
@@ -109,8 +114,11 @@ New fields added to `HyperspellConfig`:
 |-------|------|---------|-------------|
 | `captureConversations` | boolean | `true` | Capture conversation turns to Hyperspell |
 | `recentContextHours` | number | `48` | Hours of recent history to fetch on session start |
+| `minRelevanceScore` | number | `0.30` | Minimum relevance score (0-1) before "try harder" fallback triggers |
 
 Added to `openclaw.plugin.json` config schema and UI hints.
+
+**Shared constant:** `CONVERSATION_COLLECTION = "openclaw_conversations"` defined in `config.ts`.
 
 ### 5. Registration (index.ts)
 
@@ -136,7 +144,8 @@ Session context uses the same `autoContext` gate since it's conceptually the sam
 
 | File | Change |
 |------|--------|
-| `config.ts` | Add `captureConversations`, `recentContextHours` to type, parser, and defaults |
+| `config.ts` | Add `captureConversations`, `recentContextHours`, `minRelevanceScore`, and `CONVERSATION_COLLECTION` constant |
+| `client.ts` | Fix `addMemory()` metadata merge so caller-provided keys take precedence over defaults |
 | `hooks/conversation-capture.ts` | **New** — `agent_end` handler for conversation capture |
 | `hooks/session-context.ts` | **New** — `session_start` handler for recent history injection |
 | `hooks/auto-context.ts` | Add "try harder" fallback with `searchWithAnswer()` |
@@ -146,8 +155,10 @@ Session context uses the same `autoContext` gate since it's conceptually the sam
 
 ## Edge Cases
 
-- **Long messages:** Truncate combined user+assistant content to a reasonable limit (e.g. 10,000 chars) before sending to `addMemory()` to avoid oversized payloads
-- **Tool-heavy turns:** Some turns are mostly tool calls with minimal text. Still capture them — the user prompt alone is valuable context
-- **Rapid-fire turns:** Each turn is captured independently. Hyperspell handles deduplication at the search layer
+- **Long messages:** Truncate combined user+assistant content to 10,000 chars before sending to `addMemory()`
+- **Tool-heavy turns:** Still captured — the user prompt alone is valuable context
+- **Duplicate captures:** Deterministic `resourceId` (`openclaw_conv_{sessionId}_{turnIndex}`) prevents duplicates on retries or plugin restarts
 - **API failures:** All Hyperspell calls in new hooks are wrapped in try/catch. Failures log warnings but never break the user's session
-- **`session_start` vs `before_agent_start`:** If `session_start` doesn't support returning `prependContext`, fall back to detecting "first turn" in `before_agent_start` (check if it's the first event in a session)
+- **Session-start context overflow:** Capped at 5 conversations, 500 chars each (~3,000 chars total)
+- **`session_start` vs `before_agent_start`:** If `session_start` doesn't support returning `prependContext`, fall back to detecting "first turn" in `before_agent_start` (track session IDs seen in a Set)
+- **`addMemory` metadata:** Caller-provided `openclaw_source` takes precedence over the default `"command"` value

--- a/docs/2026-03-26-conversation-capture-aggressive-context-design.md
+++ b/docs/2026-03-26-conversation-capture-aggressive-context-design.md
@@ -1,0 +1,153 @@
+# Conversation Capture & Aggressive Context Retrieval
+
+**Date:** 2026-03-26
+**Status:** Approved
+**Repo:** hyperspell-openclaw
+
+## Problem
+
+The Hyperspell OpenClaw plugin currently:
+
+1. Only reads from Hyperspell (auto-context search) but never writes conversation data back
+2. Starts every new session with a blank slate — no awareness of prior conversations
+3. Gives up too easily when searches return few or low-relevance results
+
+Users lose continuity between sessions and the agent lacks context that it discussed in previous interactions.
+
+## Goals
+
+1. **Capture every conversation turn** to Hyperspell so prior sessions become searchable context
+2. **Warm-start new sessions** with recent conversation history so the agent has continuity
+3. **Try harder on search** before deciding there's nothing relevant — broader fallback searches
+
+## Design
+
+### 1. Conversation Capture (`agent_end` hook)
+
+After every agent turn completes, capture the user prompt and assistant response as a single memory.
+
+**Handler:** New file `hooks/conversation-capture.ts`
+
+**Behavior:**
+- Registered on the `agent_end` event
+- Extracts user and assistant messages from `event.messages` (same structure the LanceDB plugin uses: array of `{ role, content }` objects)
+- Formats as a conversation transcript:
+  ```
+  User: <user message>
+
+  Assistant: <assistant message>
+  ```
+- Calls `client.addMemory()` with:
+  - `collection`: `"openclaw_conversations"`
+  - `title`: First ~80 chars of user prompt
+  - `metadata`: `{ source: "openclaw_conversation", session_id: event.sessionId }`
+- Fire-and-forget — errors are logged but don't block the user
+- Skipped if `event.success` is false or messages are empty
+- Gated by config: `captureConversations` (default: `true`)
+
+**Content extraction:** Handles both string content and array content blocks (same pattern as LanceDB plugin — type-guard for `{ type: "text", text: string }` blocks).
+
+### 2. Session Start Context (`session_start` hook)
+
+When a new session begins, fetch recent conversation history and inject it as context.
+
+**Handler:** New file `hooks/session-context.ts`
+
+**Behavior:**
+- Registered on `session_start` event
+- Searches Hyperspell for recent conversation memories:
+  1. First search: recent memories (within `recentContextHours`, default 48h) from `openclaw_conversations` collection
+  2. If no results: fall back to an unfiltered search across all collections for the most relevant memories
+- Formats results as prepended context with a section header indicating these are prior conversation summaries
+- Returns `{ prependContext: formattedString }`
+- Uses `maxResults` config for result count
+
+**Context format:**
+```
+<hyperspell-session-context>
+The following is a summary of your recent conversations with this user.
+Use this to maintain continuity — reference prior discussions naturally.
+
+## Recent Conversations
+- [time] title
+  content preview...
+...
+</hyperspell-session-context>
+```
+
+### 3. Enhanced Auto-Context ("try harder" fallback)
+
+Modify the existing `before_agent_start` handler to do a broader search when initial results are poor.
+
+**File:** `hooks/auto-context.ts` (modified)
+
+**Trigger conditions (OR):**
+- Fewer than 3 results returned
+- All returned results have relevance score below 30%
+
+**Fallback behavior:**
+- Run `client.searchWithAnswer()` with the same query — this does a broader search and generates an LLM-synthesized answer
+- Merge fallback results with initial results, deduplicating by `resourceId`
+- Include the synthesized answer in the context block if available
+- The merged + enhanced context replaces the original sparse context
+
+**Enhanced context format** (when answer is available):
+```
+<hyperspell-context>
+...existing format...
+
+## Synthesized Context
+<answer from searchWithAnswer>
+</hyperspell-context>
+```
+
+### 4. Configuration
+
+New fields added to `HyperspellConfig`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `captureConversations` | boolean | `true` | Capture conversation turns to Hyperspell |
+| `recentContextHours` | number | `48` | Hours of recent history to fetch on session start |
+
+Added to `openclaw.plugin.json` config schema and UI hints.
+
+### 5. Registration (index.ts)
+
+New hooks registered alongside existing ones:
+
+```typescript
+// Conversation capture
+if (cfg.captureConversations) {
+  const captureHandler = buildConversationCaptureHandler(client, cfg)
+  api.on("agent_end", captureHandler)
+}
+
+// Session start context
+if (cfg.autoContext) {
+  const sessionContextHandler = buildSessionContextHandler(client, cfg)
+  api.on("session_start", sessionContextHandler)
+}
+```
+
+Session context uses the same `autoContext` gate since it's conceptually the same feature (automatic context injection).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `config.ts` | Add `captureConversations`, `recentContextHours` to type, parser, and defaults |
+| `hooks/conversation-capture.ts` | **New** — `agent_end` handler for conversation capture |
+| `hooks/session-context.ts` | **New** — `session_start` handler for recent history injection |
+| `hooks/auto-context.ts` | Add "try harder" fallback with `searchWithAnswer()` |
+| `index.ts` | Register new hooks |
+| `openclaw.plugin.json` | Add new config fields to schema + uiHints |
+| `README.md` | Document new features and config options |
+
+## Edge Cases
+
+- **Long messages:** Truncate combined user+assistant content to a reasonable limit (e.g. 10,000 chars) before sending to `addMemory()` to avoid oversized payloads
+- **Tool-heavy turns:** Some turns are mostly tool calls with minimal text. Still capture them — the user prompt alone is valuable context
+- **Rapid-fire turns:** Each turn is captured independently. Hyperspell handles deduplication at the search layer
+- **API failures:** All Hyperspell calls in new hooks are wrapped in try/catch. Failures log warnings but never break the user's session
+- **`session_start` vs `before_agent_start`:** If `session_start` doesn't support returning `prependContext`, fall back to detecting "first turn" in `before_agent_start` (check if it's the first event in a session)

--- a/graph/cron.ts
+++ b/graph/cron.ts
@@ -1,9 +1,9 @@
-export const CRON_JOB_NAME = "Hyperspell Memory Network"
+export const CRON_JOB_NAME = "Hyperspell Memory Network";
 
 export function buildExtractionPrompt(workspaceDir: string): string {
-  const memoryDir = `${workspaceDir}/memory`
+	const memoryDir = `${workspaceDir}/memory`;
 
-  return `You are a memory network builder. Your job is to scan memories and extract structured entities into markdown files.
+	return `You are a memory network builder. Your job is to scan memories and extract structured entities into markdown files.
 
 ## How it works
 
@@ -350,15 +350,18 @@ Retrieval-Augmented Generation — technique for grounding LLM responses in retr
 - **Cross-reference**: Use relationships to connect people to organizations, projects to topics, etc.
 - **Contact info is critical**: For people, always capture email addresses from sender/participant data. For organizations, derive their domain from email addresses (e.g. alice@hyperspell.com → hyperspell.com).
 - **source_memories format**: JSON object with source provider as key and array of resource_ids as value.
-- **graph_entity: true**: Always include this — it prevents the scan from re-processing entity files that get synced back to Hyperspell.`
+- **graph_entity: true**: Always include this — it prevents the scan from re-processing entity files that get synced back to Hyperspell.`;
 }
 
-export function getCronSetupCommand(workspaceDir: string, interval: string = "1h"): string {
-  const prompt = buildExtractionPrompt(workspaceDir)
-  const escaped = prompt.replace(/'/g, "'\\''")
-  return `openclaw cron add --name '${CRON_JOB_NAME}' --every ${interval} --session isolated --message '${escaped}'`
+export function getCronSetupCommand(
+	workspaceDir: string,
+	interval: string = "1h",
+): string {
+	const prompt = buildExtractionPrompt(workspaceDir);
+	const escaped = prompt.replace(/'/g, "'\\''");
+	return `openclaw cron add --name '${CRON_JOB_NAME}' --every ${interval} --session isolated --message '${escaped}'`;
 }
 
 export function getCronRemoveCommand(): string {
-  return `openclaw cron remove --name '${CRON_JOB_NAME}'`
+	return `openclaw cron remove --name '${CRON_JOB_NAME}'`;
 }

--- a/graph/index.ts
+++ b/graph/index.ts
@@ -1,5 +1,21 @@
-export { NetworkStateManager } from "./state.ts"
-export { registerNetworkTools } from "./tools.ts"
-export { scanMemories, formatScanResults, writeEntity, completeMemories, slugify } from "./ops.ts"
-export type { EntityType, SourceMemories, ScannedMemory, WriteEntityParams } from "./ops.ts"
-export { buildExtractionPrompt, getCronSetupCommand, getCronRemoveCommand, CRON_JOB_NAME } from "./cron.ts"
+export {
+	buildExtractionPrompt,
+	CRON_JOB_NAME,
+	getCronRemoveCommand,
+	getCronSetupCommand,
+} from "./cron.ts";
+export type {
+	EntityType,
+	ScannedMemory,
+	SourceMemories,
+	WriteEntityParams,
+} from "./ops.ts";
+export {
+	completeMemories,
+	formatScanResults,
+	scanMemories,
+	slugify,
+	writeEntity,
+} from "./ops.ts";
+export { NetworkStateManager } from "./state.ts";
+export { registerNetworkTools } from "./tools.ts";

--- a/graph/ops.ts
+++ b/graph/ops.ts
@@ -1,253 +1,278 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import type { HyperspellClient } from "../client.ts"
-import { log } from "../logger.ts"
-import { NetworkStateManager } from "./state.ts"
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { HyperspellClient } from "../client.ts";
+import { log } from "../logger.ts";
+import type { NetworkStateManager } from "./state.ts";
 
-const ENTITY_TYPES = ["people", "projects", "organizations", "topics"] as const
-export type EntityType = (typeof ENTITY_TYPES)[number]
+const ENTITY_TYPES = ["people", "projects", "organizations", "topics"] as const;
+export type EntityType = (typeof ENTITY_TYPES)[number];
 
 export interface SourceMemories {
-  [source: string]: string[]
+	[source: string]: string[];
 }
 
 export interface ScannedMemory {
-  resourceId: string
-  source: string
-  title: string | null
-  summary: string
+	resourceId: string;
+	source: string;
+	title: string | null;
+	summary: string;
 }
 
 export interface WriteEntityParams {
-  type: EntityType
-  slug: string
-  name: string
-  description: string
-  relationships?: string[]
-  sourceMemories?: SourceMemories
-  email?: string
-  phone?: string
-  domain?: string
+	type: EntityType;
+	slug: string;
+	name: string;
+	description: string;
+	relationships?: string[];
+	sourceMemories?: SourceMemories;
+	email?: string;
+	phone?: string;
+	domain?: string;
 }
 
 export function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
+	return name
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
 }
 
 function summarizeMemoryData(data: unknown[], source: string): string {
-  if (!Array.isArray(data) || data.length === 0) return ""
+	if (!Array.isArray(data) || data.length === 0) return "";
 
-  const items = data as Array<Record<string, unknown>>
+	const items = data as Array<Record<string, unknown>>;
 
-  if (source === "slack" || source === "google_mail") {
-    const senders = new Map<string, string>()
-    const messages: string[] = []
-    for (const item of items) {
-      const sender = item.sender as Record<string, unknown> | undefined
-      if (sender?.name && sender?.email) {
-        senders.set(String(sender.email), String(sender.name))
-      }
-      if (item.content && messages.length < 5) {
-        messages.push(String(item.content).slice(0, 200))
-      }
-    }
-    const parts: string[] = []
-    if (senders.size > 0) {
-      parts.push(`Participants: ${[...senders.entries()].map(([e, n]) => `${n} <${e}>`).join(", ")}`)
-    }
-    if (messages.length > 0) {
-      parts.push(`Recent messages:\n${messages.join("\n---\n")}`)
-    }
-    return parts.join("\n\n")
-  }
+	if (source === "slack" || source === "google_mail") {
+		const senders = new Map<string, string>();
+		const messages: string[] = [];
+		for (const item of items) {
+			const sender = item.sender as Record<string, unknown> | undefined;
+			if (sender?.name && sender?.email) {
+				senders.set(String(sender.email), String(sender.name));
+			}
+			if (item.content && messages.length < 5) {
+				messages.push(String(item.content).slice(0, 200));
+			}
+		}
+		const parts: string[] = [];
+		if (senders.size > 0) {
+			parts.push(
+				`Participants: ${[...senders.entries()].map(([e, n]) => `${n} <${e}>`).join(", ")}`,
+			);
+		}
+		if (messages.length > 0) {
+			parts.push(`Recent messages:\n${messages.join("\n---\n")}`);
+		}
+		return parts.join("\n\n");
+	}
 
-  if (source === "notion") {
-    const parts: string[] = []
-    for (const item of items.slice(0, 10)) {
-      if (item.__type === "Title" && item.text) {
-        parts.push(`## ${item.text}`)
-      } else if (item.__type === "Markdown" && item.text) {
-        parts.push(String(item.text).slice(0, 300))
-      } else if (item.__type === "Table" && item.table_rows) {
-        const rows = item.table_rows as string[][]
-        if (rows[0]) parts.push(`Table: ${rows[0].join(" | ")}`)
-      }
-    }
-    return parts.join("\n")
-  }
+	if (source === "notion") {
+		const parts: string[] = [];
+		for (const item of items.slice(0, 10)) {
+			if (item.__type === "Title" && item.text) {
+				parts.push(`## ${item.text}`);
+			} else if (item.__type === "Markdown" && item.text) {
+				parts.push(String(item.text).slice(0, 300));
+			} else if (item.__type === "Table" && item.table_rows) {
+				const rows = item.table_rows as string[][];
+				if (rows[0]) parts.push(`Table: ${rows[0].join(" | ")}`);
+			}
+		}
+		return parts.join("\n");
+	}
 
-  const parts: string[] = []
-  for (const item of items.slice(0, 10)) {
-    if (item.text) {
-      parts.push(String(item.text).slice(0, 300))
-    }
-  }
-  return parts.join("\n")
+	const parts: string[] = [];
+	for (const item of items.slice(0, 10)) {
+		if (item.text) {
+			parts.push(String(item.text).slice(0, 300));
+		}
+	}
+	return parts.join("\n");
 }
 
 export async function scanMemories(
-  client: HyperspellClient,
-  stateManager: NetworkStateManager,
-  batchSize: number,
+	client: HyperspellClient,
+	stateManager: NetworkStateManager,
+	batchSize: number,
 ): Promise<ScannedMemory[]> {
-  const unprocessed: ScannedMemory[] = []
+	const unprocessed: ScannedMemory[] = [];
 
-  for await (const mem of client.listMemories()) {
-    if (stateManager.isProcessed(mem.resourceId)) continue
-    if (mem.metadata?.graph_entity === "true" || mem.metadata?.graph_entity === true) continue
-    if ((mem.metadata?.status as string) !== "completed") continue
+	for await (const mem of client.listMemories()) {
+		if (stateManager.isProcessed(mem.resourceId)) continue;
+		if (
+			mem.metadata?.graph_entity === "true" ||
+			mem.metadata?.graph_entity === true
+		)
+			continue;
+		if ((mem.metadata?.status as string) !== "completed") continue;
 
-    let summary = ""
-    try {
-      const full = await client.getMemory(mem.resourceId, mem.source)
-      const data = full.data as unknown[] | undefined
+		let summary = "";
+		try {
+			const full = await client.getMemory(mem.resourceId, mem.source);
+			const data = full.data as unknown[] | undefined;
 
-      const participants = full.participants as Array<{ name?: string; email?: string }> | undefined
-      const participantLine = participants?.length
-        ? `Participants: ${participants.map((p) => `${p.name || ""} <${p.email || ""}>`).join(", ")}`
-        : ""
+			const participants = full.participants as
+				| Array<{ name?: string; email?: string }>
+				| undefined;
+			const participantLine = participants?.length
+				? `Participants: ${participants.map((p) => `${p.name || ""} <${p.email || ""}>`).join(", ")}`
+				: "";
 
-      const dataSummary = data ? summarizeMemoryData(data, mem.source) : ""
-      summary = [participantLine, dataSummary].filter(Boolean).join("\n\n")
-    } catch {
-      summary = "(content unavailable)"
-    }
+			const dataSummary = data ? summarizeMemoryData(data, mem.source) : "";
+			summary = [participantLine, dataSummary].filter(Boolean).join("\n\n");
+		} catch {
+			summary = "(content unavailable)";
+		}
 
-    unprocessed.push({
-      resourceId: mem.resourceId,
-      source: mem.source,
-      title: mem.title,
-      summary: summary.slice(0, 1000),
-    })
+		unprocessed.push({
+			resourceId: mem.resourceId,
+			source: mem.source,
+			title: mem.title,
+			summary: summary.slice(0, 1000),
+		});
 
-    if (unprocessed.length >= batchSize) break
-  }
+		if (unprocessed.length >= batchSize) break;
+	}
 
-  return unprocessed
+	return unprocessed;
 }
 
-export function formatScanResults(memories: ScannedMemory[], processedCount: number, lastScan: string | null): string {
-  if (memories.length === 0) {
-    return `No unprocessed memories found. ${processedCount} memories already processed. Last scan: ${lastScan || "never"}`
-  }
+export function formatScanResults(
+	memories: ScannedMemory[],
+	processedCount: number,
+	lastScan: string | null,
+): string {
+	if (memories.length === 0) {
+		return `No unprocessed memories found. ${processedCount} memories already processed. Last scan: ${lastScan || "never"}`;
+	}
 
-  const formatted = memories
-    .map((m) => {
-      const lines = [`[${m.source}] ${m.title || "(untitled)"} (id: ${m.resourceId})`]
-      if (m.summary) lines.push(m.summary)
-      return lines.join("\n")
-    })
-    .join("\n\n---\n\n")
+	const formatted = memories
+		.map((m) => {
+			const lines = [
+				`[${m.source}] ${m.title || "(untitled)"} (id: ${m.resourceId})`,
+			];
+			if (m.summary) lines.push(m.summary);
+			return lines.join("\n");
+		})
+		.join("\n\n---\n\n");
 
-  return `Found ${memories.length} unprocessed memories:\n\n${formatted}`
+	return `Found ${memories.length} unprocessed memories:\n\n${formatted}`;
 }
 
-export function writeEntity(workspaceDir: string, params: WriteEntityParams): string {
-  const slug = slugify(params.slug)
-  const dir = path.join(workspaceDir, "memory", params.type)
-  const filePath = path.join(dir, `${slug}.md`)
+export function writeEntity(
+	workspaceDir: string,
+	params: WriteEntityParams,
+): string {
+	const slug = slugify(params.slug);
+	const dir = path.join(workspaceDir, "memory", params.type);
+	const filePath = path.join(dir, `${slug}.md`);
 
-  fs.mkdirSync(dir, { recursive: true })
+	fs.mkdirSync(dir, { recursive: true });
 
-  // Check for existing file and merge
-  let existingSourceMemories: SourceMemories = {}
-  let existingRelationships: string[] = []
-  let hyperspellId = ""
+	// Check for existing file and merge
+	let existingSourceMemories: SourceMemories = {};
+	let existingRelationships: string[] = [];
+	let hyperspellId = "";
 
-  if (fs.existsSync(filePath)) {
-    const existing = fs.readFileSync(filePath, "utf-8")
-    const fmMatch = existing.match(/^---\n([\s\S]*?)\n---\n?/)
-    if (fmMatch) {
-      const fmText = fmMatch[1]
-      for (const line of fmText.split("\n")) {
-        const idx = line.indexOf(":")
-        if (idx <= 0) continue
-        const key = line.slice(0, idx).trim()
-        const val = line.slice(idx + 1).trim()
-        if (key === "hyperspell_id") hyperspellId = val
-        if (key === "source_memories") {
-          try { existingSourceMemories = JSON.parse(val) } catch {}
-        }
-        if (key === "relationships") {
-          try { existingRelationships = JSON.parse(val) } catch {}
-        }
-      }
-    }
-  }
+	if (fs.existsSync(filePath)) {
+		const existing = fs.readFileSync(filePath, "utf-8");
+		const fmMatch = existing.match(/^---\n([\s\S]*?)\n---\n?/);
+		if (fmMatch) {
+			const fmText = fmMatch[1];
+			for (const line of fmText.split("\n")) {
+				const idx = line.indexOf(":");
+				if (idx <= 0) continue;
+				const key = line.slice(0, idx).trim();
+				const val = line.slice(idx + 1).trim();
+				if (key === "hyperspell_id") hyperspellId = val;
+				if (key === "source_memories") {
+					try {
+						existingSourceMemories = JSON.parse(val);
+					} catch {}
+				}
+				if (key === "relationships") {
+					try {
+						existingRelationships = JSON.parse(val);
+					} catch {}
+				}
+			}
+		}
+	}
 
-  // Merge source memories
-  const mergedSources: SourceMemories = { ...existingSourceMemories }
-  if (params.sourceMemories) {
-    for (const [source, ids] of Object.entries(params.sourceMemories)) {
-      const existing = mergedSources[source] || []
-      const merged = [...new Set([...existing, ...ids])]
-      mergedSources[source] = merged
-    }
-  }
+	// Merge source memories
+	const mergedSources: SourceMemories = { ...existingSourceMemories };
+	if (params.sourceMemories) {
+		for (const [source, ids] of Object.entries(params.sourceMemories)) {
+			const existing = mergedSources[source] || [];
+			const merged = [...new Set([...existing, ...ids])];
+			mergedSources[source] = merged;
+		}
+	}
 
-  // Merge relationships
-  const mergedRelationships = [
-    ...new Set([...existingRelationships, ...(params.relationships || [])]),
-  ]
+	// Merge relationships
+	const mergedRelationships = [
+		...new Set([...existingRelationships, ...(params.relationships || [])]),
+	];
 
-  // Build frontmatter
-  const fm: Record<string, string> = {
-    title: params.name,
-    type: params.type.slice(0, -1), // "people" → "person"
-    graph_entity: "true",
-    source_memories: JSON.stringify(mergedSources),
-    last_extracted: new Date().toISOString(),
-  }
-  if (hyperspellId) fm.hyperspell_id = hyperspellId
-  if (mergedRelationships.length > 0) {
-    fm.relationships = JSON.stringify(mergedRelationships)
-  }
-  if (params.email) fm.email = params.email
-  if (params.phone) fm.phone = params.phone
-  if (params.domain) fm.domain = params.domain
+	// Build frontmatter
+	const fm: Record<string, string> = {
+		title: params.name,
+		type: params.type.slice(0, -1), // "people" → "person"
+		graph_entity: "true",
+		source_memories: JSON.stringify(mergedSources),
+		last_extracted: new Date().toISOString(),
+	};
+	if (hyperspellId) fm.hyperspell_id = hyperspellId;
+	if (mergedRelationships.length > 0) {
+		fm.relationships = JSON.stringify(mergedRelationships);
+	}
+	if (params.email) fm.email = params.email;
+	if (params.phone) fm.phone = params.phone;
+	if (params.domain) fm.domain = params.domain;
 
-  // Build body
-  const bodyParts = [`# ${params.name}\n`, params.description]
+	// Build body
+	const bodyParts = [`# ${params.name}\n`, params.description];
 
-  const contactParts: string[] = []
-  if (params.email) contactParts.push(`- Email: ${params.email}`)
-  if (params.phone) contactParts.push(`- Phone: ${params.phone}`)
-  if (params.domain) contactParts.push(`- Domain: ${params.domain}`)
-  if (contactParts.length > 0) {
-    bodyParts.push("\n## Contact\n")
-    bodyParts.push(...contactParts)
-  }
+	const contactParts: string[] = [];
+	if (params.email) contactParts.push(`- Email: ${params.email}`);
+	if (params.phone) contactParts.push(`- Phone: ${params.phone}`);
+	if (params.domain) contactParts.push(`- Domain: ${params.domain}`);
+	if (contactParts.length > 0) {
+		bodyParts.push("\n## Contact\n");
+		bodyParts.push(...contactParts);
+	}
 
-  if (mergedRelationships.length > 0) {
-    bodyParts.push("\n## Relationships\n")
-    for (const rel of mergedRelationships) {
-      const [relationship, target] = rel.split(":")
-      if (target) {
-        const targetName = target.split("/").pop()?.replace(/-/g, " ") || target
-        bodyParts.push(`- ${relationship}: [${targetName}](../${target}.md)`)
-      } else {
-        bodyParts.push(`- ${rel}`)
-      }
-    }
-  }
+	if (mergedRelationships.length > 0) {
+		bodyParts.push("\n## Relationships\n");
+		for (const rel of mergedRelationships) {
+			const [relationship, target] = rel.split(":");
+			if (target) {
+				const targetName =
+					target.split("/").pop()?.replace(/-/g, " ") || target;
+				bodyParts.push(`- ${relationship}: [${targetName}](../${target}.md)`);
+			} else {
+				bodyParts.push(`- ${rel}`);
+			}
+		}
+	}
 
-  // Build file content
-  const fmLines = Object.entries(fm).map(([k, v]) => `${k}: ${v}`)
-  const content = `---\n${fmLines.join("\n")}\n---\n${bodyParts.join("\n")}\n`
+	// Build file content
+	const fmLines = Object.entries(fm).map(([k, v]) => `${k}: ${v}`);
+	const content = `---\n${fmLines.join("\n")}\n---\n${bodyParts.join("\n")}\n`;
 
-  fs.writeFileSync(filePath, content)
-  log.info(`Wrote entity: ${params.type}/${slug}.md`)
+	fs.writeFileSync(filePath, content);
+	log.info(`Wrote entity: ${params.type}/${slug}.md`);
 
-  return `${params.type}/${slug}.md`
+	return `${params.type}/${slug}.md`;
 }
 
-export function completeMemories(stateManager: NetworkStateManager, memoryIds: string[]): { newCount: number; totalCount: number } {
-  const newCount = stateManager.markProcessed(memoryIds)
-  stateManager.updateLastScan()
-  stateManager.save()
-  return { newCount, totalCount: stateManager.getProcessedCount() }
+export function completeMemories(
+	stateManager: NetworkStateManager,
+	memoryIds: string[],
+): { newCount: number; totalCount: number } {
+	const newCount = stateManager.markProcessed(memoryIds);
+	stateManager.updateLastScan();
+	stateManager.save();
+	return { newCount, totalCount: stateManager.getProcessedCount() };
 }

--- a/graph/state.ts
+++ b/graph/state.ts
@@ -1,79 +1,83 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { log } from "../logger.ts"
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { log } from "../logger.ts";
 
-const STATE_VERSION = 1
-const STATE_FILENAME = ".network-state.json"
+const STATE_VERSION = 1;
+const STATE_FILENAME = ".network-state.json";
 
 export interface NetworkState {
-  processedIds: Record<string, string> // resource_id → ISO timestamp
-  lastScanAt: string | null
-  version: number
+	processedIds: Record<string, string>; // resource_id → ISO timestamp
+	lastScanAt: string | null;
+	version: number;
 }
 
 export class NetworkStateManager {
-  private statePath: string
-  private state: NetworkState
+	private statePath: string;
+	private state: NetworkState;
 
-  constructor(workspaceDir: string) {
-    const memoryDir = path.join(workspaceDir, "memory")
-    fs.mkdirSync(memoryDir, { recursive: true })
-    this.statePath = path.join(memoryDir, STATE_FILENAME)
-    this.state = this.load()
-  }
+	constructor(workspaceDir: string) {
+		const memoryDir = path.join(workspaceDir, "memory");
+		fs.mkdirSync(memoryDir, { recursive: true });
+		this.statePath = path.join(memoryDir, STATE_FILENAME);
+		this.state = this.load();
+	}
 
-  private load(): NetworkState {
-    try {
-      if (fs.existsSync(this.statePath)) {
-        const raw = fs.readFileSync(this.statePath, "utf-8")
-        const parsed = JSON.parse(raw)
-        if (parsed.version === STATE_VERSION) {
-          return parsed
-        }
-        log.warn(`Network state version mismatch (got ${parsed.version}, want ${STATE_VERSION}), resetting`)
-      }
-    } catch (err) {
-      log.warn("Failed to load network state, starting fresh", err)
-    }
-    return { processedIds: {}, lastScanAt: null, version: STATE_VERSION }
-  }
+	private load(): NetworkState {
+		try {
+			if (fs.existsSync(this.statePath)) {
+				const raw = fs.readFileSync(this.statePath, "utf-8");
+				const parsed = JSON.parse(raw);
+				if (parsed.version === STATE_VERSION) {
+					return parsed;
+				}
+				log.warn(
+					`Network state version mismatch (got ${parsed.version}, want ${STATE_VERSION}), resetting`,
+				);
+			}
+		} catch (err) {
+			log.warn("Failed to load network state, starting fresh", err);
+		}
+		return { processedIds: {}, lastScanAt: null, version: STATE_VERSION };
+	}
 
-  save(): void {
-    const tmpPath = this.statePath + ".tmp"
-    try {
-      fs.writeFileSync(tmpPath, JSON.stringify(this.state, null, 2))
-      fs.renameSync(tmpPath, this.statePath)
-    } catch (err) {
-      log.error("Failed to save network state", err)
-      try { fs.unlinkSync(tmpPath) } catch {}
-    }
-  }
+	save(): void {
+		const tmpPath = this.statePath + ".tmp";
+		try {
+			fs.writeFileSync(tmpPath, JSON.stringify(this.state, null, 2));
+			fs.renameSync(tmpPath, this.statePath);
+		} catch (err) {
+			log.error("Failed to save network state", err);
+			try {
+				fs.unlinkSync(tmpPath);
+			} catch {}
+		}
+	}
 
-  isProcessed(resourceId: string): boolean {
-    return resourceId in this.state.processedIds
-  }
+	isProcessed(resourceId: string): boolean {
+		return resourceId in this.state.processedIds;
+	}
 
-  markProcessed(resourceIds: string[]): number {
-    let count = 0
-    const now = new Date().toISOString()
-    for (const id of resourceIds) {
-      if (!(id in this.state.processedIds)) {
-        this.state.processedIds[id] = now
-        count++
-      }
-    }
-    return count
-  }
+	markProcessed(resourceIds: string[]): number {
+		let count = 0;
+		const now = new Date().toISOString();
+		for (const id of resourceIds) {
+			if (!(id in this.state.processedIds)) {
+				this.state.processedIds[id] = now;
+				count++;
+			}
+		}
+		return count;
+	}
 
-  updateLastScan(): void {
-    this.state.lastScanAt = new Date().toISOString()
-  }
+	updateLastScan(): void {
+		this.state.lastScanAt = new Date().toISOString();
+	}
 
-  getProcessedCount(): number {
-    return Object.keys(this.state.processedIds).length
-  }
+	getProcessedCount(): number {
+		return Object.keys(this.state.processedIds).length;
+	}
 
-  getLastScanAt(): string | null {
-    return this.state.lastScanAt
-  }
+	getLastScanAt(): string | null {
+		return this.state.lastScanAt;
+	}
 }

--- a/graph/tools.ts
+++ b/graph/tools.ts
@@ -1,117 +1,188 @@
-import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { getWorkspaceDir } from "../config.ts"
-import { log } from "../logger.ts"
-import { NetworkStateManager } from "./state.ts"
-import { scanMemories, formatScanResults, writeEntity, completeMemories } from "./ops.ts"
-import type { EntityType, SourceMemories } from "./ops.ts"
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { getWorkspaceDir } from "../config.ts";
+import { log } from "../logger.ts";
+import type { EntityType, SourceMemories } from "./ops.ts";
+import {
+	completeMemories,
+	formatScanResults,
+	scanMemories,
+	writeEntity,
+} from "./ops.ts";
+import { NetworkStateManager } from "./state.ts";
 
-const ENTITY_TYPES = ["people", "projects", "organizations", "topics"] as const
+const ENTITY_TYPES = ["people", "projects", "organizations", "topics"] as const;
 
 export function registerNetworkTools(
-  api: OpenClawPluginApi,
-  client: HyperspellClient,
-  cfg: HyperspellConfig,
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
 ): void {
-  const workspaceDir = getWorkspaceDir()
-  const stateManager = new NetworkStateManager(workspaceDir)
+	const workspaceDir = getWorkspaceDir();
+	const stateManager = new NetworkStateManager(workspaceDir);
 
-  api.registerTool(
-    {
-      name: "hyperspell_network_scan",
-      label: "Memory Network Scan",
-      description:
-        "Scan Hyperspell memories and return a batch of unprocessed ones with their content summaries. Use this to find new memories that need entity extraction.",
-      parameters: Type.Object({
-        batchSize: Type.Optional(
-          Type.Number({ description: "Max memories to return (default: 20)" }),
-        ),
-      }),
-      async execute(_toolCallId: string, params: { batchSize?: number }) {
-        const batchSize = params.batchSize ?? cfg.knowledgeGraph.batchSize
-        try {
-          const memories = await scanMemories(client, stateManager, batchSize)
-          const text = formatScanResults(memories, stateManager.getProcessedCount(), stateManager.getLastScanAt())
-          return {
-            content: [{ type: "text" as const, text }],
-            details: { count: memories.length, memories },
-          }
-        } catch (err) {
-          log.error("network scan failed", err)
-          return {
-            content: [{ type: "text" as const, text: `Scan failed: ${err instanceof Error ? err.message : String(err)}` }],
-          }
-        }
-      },
-    },
-    { name: "hyperspell_network_scan" },
-  )
+	api.registerTool(
+		{
+			name: "hyperspell_network_scan",
+			label: "Memory Network Scan",
+			description:
+				"Scan Hyperspell memories and return a batch of unprocessed ones with their content summaries. Use this to find new memories that need entity extraction.",
+			parameters: Type.Object({
+				batchSize: Type.Optional(
+					Type.Number({ description: "Max memories to return (default: 20)" }),
+				),
+			}),
+			async execute(_toolCallId: string, params: { batchSize?: number }) {
+				const batchSize = params.batchSize ?? cfg.knowledgeGraph.batchSize;
+				try {
+					const memories = await scanMemories(client, stateManager, batchSize);
+					const text = formatScanResults(
+						memories,
+						stateManager.getProcessedCount(),
+						stateManager.getLastScanAt(),
+					);
+					return {
+						content: [{ type: "text" as const, text }],
+						details: { count: memories.length, memories },
+					};
+				} catch (err) {
+					log.error("network scan failed", err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Scan failed: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_network_scan" },
+	);
 
-  api.registerTool(
-    {
-      name: "hyperspell_network_write",
-      label: "Memory Network Write",
-      description:
-        "Write or update an entity file in the memory network. Creates markdown files in memory/people/, memory/projects/, memory/organizations/, or memory/topics/.",
-      parameters: Type.Object({
-        type: Type.Union(ENTITY_TYPES.map((t) => Type.Literal(t)), {
-          description: "Entity type: people, projects, organizations, or topics",
-        }),
-        slug: Type.String({ description: "URL-safe identifier (lowercase with hyphens, e.g. 'alice-chen')" }),
-        name: Type.String({ description: "Display name of the entity" }),
-        description: Type.String({ description: "Description of the entity" }),
-        relationships: Type.Optional(
-          Type.Array(Type.String(), {
-            description: "Relationships in format 'relationship:type/slug', e.g. 'works-at:organizations/hyperspell'",
-          }),
-        ),
-        sourceMemories: Type.Optional(
-          Type.Record(Type.String(), Type.Array(Type.String()), {
-            description: "Source memories by provider, e.g. { slack: ['C073WR69EPM'], google_mail: ['19bbe68026553623'] }",
-          }),
-        ),
-        email: Type.Optional(Type.String({ description: "Email address (for people)" })),
-        phone: Type.Optional(Type.String({ description: "Phone number (for people)" })),
-        domain: Type.Optional(Type.String({ description: "Domain/homepage (for organizations)" })),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { type: EntityType; slug: string; name: string; description: string; relationships?: string[]; sourceMemories?: SourceMemories; email?: string; phone?: string; domain?: string },
-      ) {
-        try {
-          const result = writeEntity(workspaceDir, params)
-          return { content: [{ type: "text" as const, text: `Wrote ${result} (${params.name})` }] }
-        } catch (err) {
-          log.error(`network write failed: ${params.type}/${params.slug}`, err)
-          return { content: [{ type: "text" as const, text: `Write failed: ${err instanceof Error ? err.message : String(err)}` }] }
-        }
-      },
-    },
-    { name: "hyperspell_network_write" },
-  )
+	api.registerTool(
+		{
+			name: "hyperspell_network_write",
+			label: "Memory Network Write",
+			description:
+				"Write or update an entity file in the memory network. Creates markdown files in memory/people/, memory/projects/, memory/organizations/, or memory/topics/.",
+			parameters: Type.Object({
+				type: Type.Union(
+					ENTITY_TYPES.map((t) => Type.Literal(t)),
+					{
+						description:
+							"Entity type: people, projects, organizations, or topics",
+					},
+				),
+				slug: Type.String({
+					description:
+						"URL-safe identifier (lowercase with hyphens, e.g. 'alice-chen')",
+				}),
+				name: Type.String({ description: "Display name of the entity" }),
+				description: Type.String({ description: "Description of the entity" }),
+				relationships: Type.Optional(
+					Type.Array(Type.String(), {
+						description:
+							"Relationships in format 'relationship:type/slug', e.g. 'works-at:organizations/hyperspell'",
+					}),
+				),
+				sourceMemories: Type.Optional(
+					Type.Record(Type.String(), Type.Array(Type.String()), {
+						description:
+							"Source memories by provider, e.g. { slack: ['C073WR69EPM'], google_mail: ['19bbe68026553623'] }",
+					}),
+				),
+				email: Type.Optional(
+					Type.String({ description: "Email address (for people)" }),
+				),
+				phone: Type.Optional(
+					Type.String({ description: "Phone number (for people)" }),
+				),
+				domain: Type.Optional(
+					Type.String({ description: "Domain/homepage (for organizations)" }),
+				),
+			}),
+			async execute(
+				_toolCallId: string,
+				params: {
+					type: EntityType;
+					slug: string;
+					name: string;
+					description: string;
+					relationships?: string[];
+					sourceMemories?: SourceMemories;
+					email?: string;
+					phone?: string;
+					domain?: string;
+				},
+			) {
+				try {
+					const result = writeEntity(workspaceDir, params);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Wrote ${result} (${params.name})`,
+							},
+						],
+					};
+				} catch (err) {
+					log.error(`network write failed: ${params.type}/${params.slug}`, err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Write failed: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_network_write" },
+	);
 
-  api.registerTool(
-    {
-      name: "hyperspell_network_complete",
-      label: "Memory Network Complete",
-      description: "Mark a batch of memory IDs as processed so they won't appear in future scans.",
-      parameters: Type.Object({
-        memoryIds: Type.Array(Type.String(), { description: "List of resource_ids to mark as processed" }),
-      }),
-      async execute(_toolCallId: string, params: { memoryIds: string[] }) {
-        try {
-          const { newCount, totalCount } = completeMemories(stateManager, params.memoryIds)
-          return {
-            content: [{ type: "text" as const, text: `Marked ${newCount} new memories as processed (${totalCount} total). Last scan: ${stateManager.getLastScanAt()}` }],
-          }
-        } catch (err) {
-          log.error("network complete failed", err)
-          return { content: [{ type: "text" as const, text: `Complete failed: ${err instanceof Error ? err.message : String(err)}` }] }
-        }
-      },
-    },
-    { name: "hyperspell_network_complete" },
-  )
+	api.registerTool(
+		{
+			name: "hyperspell_network_complete",
+			label: "Memory Network Complete",
+			description:
+				"Mark a batch of memory IDs as processed so they won't appear in future scans.",
+			parameters: Type.Object({
+				memoryIds: Type.Array(Type.String(), {
+					description: "List of resource_ids to mark as processed",
+				}),
+			}),
+			async execute(_toolCallId: string, params: { memoryIds: string[] }) {
+				try {
+					const { newCount, totalCount } = completeMemories(
+						stateManager,
+						params.memoryIds,
+					);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Marked ${newCount} new memories as processed (${totalCount} total). Last scan: ${stateManager.getLastScanAt()}`,
+							},
+						],
+					};
+				} catch (err) {
+					log.error("network complete failed", err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Complete failed: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_network_complete" },
+	);
 }

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -1,76 +1,79 @@
-import type { HyperspellClient, SearchResult } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { log } from "../logger.ts"
+import type { HyperspellClient, SearchResult } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { log } from "../logger.ts";
 
 function formatRelativeTime(isoTimestamp: string): string {
-  try {
-    const dt = new Date(isoTimestamp)
-    const now = new Date()
-    const seconds = (now.getTime() - dt.getTime()) / 1000
-    const minutes = seconds / 60
-    const hours = seconds / 3600
-    const days = seconds / 86400
+	try {
+		const dt = new Date(isoTimestamp);
+		const now = new Date();
+		const seconds = (now.getTime() - dt.getTime()) / 1000;
+		const minutes = seconds / 60;
+		const hours = seconds / 3600;
+		const days = seconds / 86400;
 
-    if (minutes < 30) return "just now"
-    if (minutes < 60) return `${Math.floor(minutes)}mins ago`
-    if (hours < 24) return `${Math.floor(hours)} hrs ago`
-    if (days < 7) return `${Math.floor(days)}d ago`
+		if (minutes < 30) return "just now";
+		if (minutes < 60) return `${Math.floor(minutes)}mins ago`;
+		if (hours < 24) return `${Math.floor(hours)} hrs ago`;
+		if (days < 7) return `${Math.floor(days)}d ago`;
 
-    const month = dt.toLocaleString("en", { month: "short" })
-    if (dt.getFullYear() === now.getFullYear()) {
-      return `${dt.getDate()} ${month}`
-    }
-    return `${dt.getDate()} ${month}, ${dt.getFullYear()}`
-  } catch {
-    return ""
-  }
+		const month = dt.toLocaleString("en", { month: "short" });
+		if (dt.getFullYear() === now.getFullYear()) {
+			return `${dt.getDate()} ${month}`;
+		}
+		return `${dt.getDate()} ${month}, ${dt.getFullYear()}`;
+	} catch {
+		return "";
+	}
 }
 
-function formatContext(results: SearchResult[], maxResults: number): string | null {
-  const limited = results.slice(0, maxResults)
+function formatContext(
+	results: SearchResult[],
+	maxResults: number,
+): string | null {
+	const limited = results.slice(0, maxResults);
 
-  if (limited.length === 0) return null
+	if (limited.length === 0) return null;
 
-  const lines = limited.map((r) => {
-    const title = r.title ?? `[${r.source}]`
-    const timeStr = r.createdAt ? formatRelativeTime(r.createdAt) : ""
-    const pct = r.score != null ? `[${Math.round(r.score * 100)}%]` : ""
-    const prefix = timeStr ? `[${timeStr}]` : ""
-    return `- ${prefix} ${title} ${pct}`.trim()
-  })
+	const lines = limited.map((r) => {
+		const title = r.title ?? `[${r.source}]`;
+		const timeStr = r.createdAt ? formatRelativeTime(r.createdAt) : "";
+		const pct = r.score != null ? `[${Math.round(r.score * 100)}%]` : "";
+		const prefix = timeStr ? `[${timeStr}]` : "";
+		return `- ${prefix} ${title} ${pct}`.trim();
+	});
 
-  const intro =
-    "The following is context from the user's connected sources. Reference it only when relevant to the conversation."
-  const disclaimer =
-    "Use this context naturally when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
+	const intro =
+		"The following is context from the user's connected sources. Reference it only when relevant to the conversation.";
+	const disclaimer =
+		"Use this context naturally when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated.";
 
-  return `<hyperspell-context>\n${intro}\n\n## Relevant Memories (with relevance %)\n${lines.join("\n")}\n\n${disclaimer}\n</hyperspell-context>`
+	return `<hyperspell-context>\n${intro}\n\n## Relevant Memories (with relevance %)\n${lines.join("\n")}\n\n${disclaimer}\n</hyperspell-context>`;
 }
 
 export function buildAutoContextHandler(
-  client: HyperspellClient,
-  cfg: HyperspellConfig,
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
 ) {
-  return async (event: Record<string, unknown>) => {
-    const prompt = event.prompt as string | undefined
-    if (!prompt || prompt.length < 5) return
+	return async (event: Record<string, unknown>) => {
+		const prompt = event.prompt as string | undefined;
+		if (!prompt || prompt.length < 5) return;
 
-    log.debug(`auto-context: searching for "${prompt.slice(0, 50)}..."`)
+		log.debug(`auto-context: searching for "${prompt.slice(0, 50)}..."`);
 
-    try {
-      const results = await client.search(prompt, { limit: cfg.maxResults })
-      const context = formatContext(results, cfg.maxResults)
+		try {
+			const results = await client.search(prompt, { limit: cfg.maxResults });
+			const context = formatContext(results, cfg.maxResults);
 
-      if (!context) {
-        log.debug("auto-context: no relevant memories found")
-        return
-      }
+			if (!context) {
+				log.debug("auto-context: no relevant memories found");
+				return;
+			}
 
-      log.debug(`auto-context: injecting ${results.length} memories`)
-      return { prependContext: context }
-    } catch (err) {
-      log.error("auto-context failed", err)
-      return
-    }
-  }
+			log.debug(`auto-context: injecting ${results.length} memories`);
+			return { prependContext: context };
+		} catch (err) {
+			log.error("auto-context failed", err);
+			return;
+		}
+	};
 }

--- a/hooks/conversation-capture.test.ts
+++ b/hooks/conversation-capture.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { buildConversationCaptureHandler } from "./conversation-capture.ts";
+
+const baseConfig: HyperspellConfig = {
+	apiKey: "test-key",
+	userId: "user@test.com",
+	autoContext: true,
+	syncMemories: false,
+	captureConversations: true,
+	sources: [],
+	maxResults: 10,
+	debug: false,
+	knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+};
+
+function makeFakeClient() {
+	const addMemory = vi.fn().mockResolvedValue({ resourceId: "stored_id" });
+	const client = { addMemory } as unknown as HyperspellClient;
+	return { client, addMemory };
+}
+
+describe("buildConversationCaptureHandler", () => {
+	it("captures the latest user+assistant turn to the openclaw_conversations collection", async () => {
+		const { client, addMemory } = makeFakeClient();
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+
+		await handler(
+			{
+				messages: [
+					{ role: "user", content: "what's the weather?" },
+					{ role: "assistant", content: "it's sunny" },
+				],
+				success: true,
+				durationMs: 150,
+			},
+			{ sessionKey: "main:session-abc" },
+		);
+
+		expect(addMemory).toHaveBeenCalledTimes(1);
+		const [text, opts] = addMemory.mock.calls[0] as [
+			string,
+			Record<string, unknown>,
+		];
+		expect(text).toContain("User: what's the weather?");
+		expect(text).toContain("Assistant: it's sunny");
+		expect(opts.collection).toBe("openclaw_conversations");
+		expect(typeof opts.resourceId).toBe("string");
+		expect((opts.resourceId as string).length).toBeGreaterThan(0);
+		const metadata = opts.metadata as Record<string, unknown>;
+		expect(metadata.openclaw_source).toBe("conversation");
+		expect(metadata.session_id).toBe("main:session-abc");
+	});
+
+	it("skips capture when the turn failed (success=false)", async () => {
+		const { client, addMemory } = makeFakeClient();
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+
+		await handler(
+			{
+				messages: [
+					{ role: "user", content: "hi" },
+					{ role: "assistant", content: "hello" },
+				],
+				success: false,
+				error: "prompt timed out",
+			},
+			{ sessionKey: "main:session-abc" },
+		);
+
+		expect(addMemory).not.toHaveBeenCalled();
+	});
+
+	it("extracts text from content-block arrays", async () => {
+		const { client, addMemory } = makeFakeClient();
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+
+		await handler(
+			{
+				messages: [
+					{ role: "user", content: [{ type: "text", text: "block-user" }] },
+					{
+						role: "assistant",
+						content: [
+							{ type: "text", text: "block-assistant-1" },
+							{ type: "tool_use", id: "t1" },
+							{ type: "text", text: "block-assistant-2" },
+						],
+					},
+				],
+				success: true,
+			},
+			{ sessionKey: "main:abc" },
+		);
+
+		expect(addMemory).toHaveBeenCalledTimes(1);
+		const text = addMemory.mock.calls[0][0] as string;
+		expect(text).toContain("User: block-user");
+		expect(text).toContain("Assistant: block-assistant-1");
+		expect(text).toContain("block-assistant-2");
+		expect(text).not.toContain("tool_use");
+	});
+
+	it("uses a deterministic resourceId so retries dedupe", async () => {
+		const { client, addMemory } = makeFakeClient();
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+
+		const event = {
+			messages: [
+				{ role: "user", content: "a" },
+				{ role: "assistant", content: "b" },
+			],
+			success: true,
+		};
+
+		await handler(event, { sessionKey: "main:sess42" });
+		await handler(event, { sessionKey: "main:sess42" });
+
+		expect(addMemory).toHaveBeenCalledTimes(2);
+		const id1 = (addMemory.mock.calls[0][1] as Record<string, unknown>)
+			.resourceId;
+		const id2 = (addMemory.mock.calls[1][1] as Record<string, unknown>)
+			.resourceId;
+		expect(id1).toBe(id2);
+		expect(id1).toContain("sess42");
+	});
+
+	it("does not throw when the client rejects (fire-and-forget)", async () => {
+		const { client, addMemory } = makeFakeClient();
+		addMemory.mockRejectedValueOnce(new Error("upstream boom"));
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+
+		await expect(
+			handler(
+				{
+					messages: [
+						{ role: "user", content: "a" },
+						{ role: "assistant", content: "b" },
+					],
+					success: true,
+				},
+				{ sessionKey: "main:abc" },
+			),
+		).resolves.not.toThrow();
+	});
+
+	it("truncates combined transcript to 10000 characters", async () => {
+		const { client, addMemory } = makeFakeClient();
+		const handler = buildConversationCaptureHandler(client, baseConfig);
+		const big = "x".repeat(20_000);
+
+		await handler(
+			{
+				messages: [
+					{ role: "user", content: big },
+					{ role: "assistant", content: big },
+				],
+				success: true,
+			},
+			{ sessionKey: "main:abc" },
+		);
+
+		const text = addMemory.mock.calls[0][0] as string;
+		expect(text.length).toBeLessThanOrEqual(10_000);
+	});
+});

--- a/hooks/conversation-capture.ts
+++ b/hooks/conversation-capture.ts
@@ -1,0 +1,82 @@
+import type { HyperspellClient } from "../client.ts";
+import { CONVERSATION_COLLECTION, type HyperspellConfig } from "../config.ts";
+import { log } from "../logger.ts";
+
+const MAX_TRANSCRIPT_CHARS = 10_000;
+
+function extractText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		const parts: string[] = [];
+		for (const block of content) {
+			if (
+				block &&
+				typeof block === "object" &&
+				(block as Record<string, unknown>).type === "text" &&
+				typeof (block as Record<string, unknown>).text === "string"
+			) {
+				parts.push((block as Record<string, unknown>).text as string);
+			}
+		}
+		return parts.join("\n");
+	}
+	return "";
+}
+
+function findLastMessage(
+	messages: ReadonlyArray<Record<string, unknown>>,
+	role: "user" | "assistant",
+): string | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (!msg || typeof msg !== "object") continue;
+		if (msg.role !== role) continue;
+		const text = extractText(msg.content);
+		if (text) return text;
+	}
+	return null;
+}
+
+export function buildConversationCaptureHandler(
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
+) {
+	return async (
+		event: Record<string, unknown>,
+		ctx?: Record<string, unknown>,
+	) => {
+		if (event.success === false) return;
+
+		const messages = event.messages as
+			| ReadonlyArray<Record<string, unknown>>
+			| undefined;
+		if (!messages || messages.length === 0) return;
+
+		const userText = findLastMessage(messages, "user");
+		const assistantText = findLastMessage(messages, "assistant");
+		if (!userText || !assistantText) return;
+
+		const full = `User: ${userText}\n\nAssistant: ${assistantText}`;
+		const transcript =
+			full.length > MAX_TRANSCRIPT_CHARS
+				? full.slice(0, MAX_TRANSCRIPT_CHARS)
+				: full;
+
+		const sessionKey = (ctx?.sessionKey as string | undefined) ?? "unknown";
+		const turnIndex = Math.floor(messages.length / 2);
+		const resourceId = `openclaw_conv_${sessionKey}_${turnIndex}`;
+
+		try {
+			await client.addMemory(transcript, {
+				collection: CONVERSATION_COLLECTION,
+				resourceId,
+				metadata: {
+					openclaw_source: "conversation",
+					session_id: sessionKey,
+				},
+			});
+		} catch (err) {
+			log.error("conversation-capture: addMemory failed", err);
+		}
+	};
+}

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -1,63 +1,66 @@
-import * as path from "node:path"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { getWorkspaceDir } from "../config.ts"
-import { log } from "../logger.ts"
-import { syncMarkdownFile, syncAllMemoryFiles } from "../sync/markdown.ts"
+import * as path from "node:path";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { getWorkspaceDir } from "../config.ts";
+import { log } from "../logger.ts";
+import { syncAllMemoryFiles, syncMarkdownFile } from "../sync/markdown.ts";
 
 /**
  * Build a handler for file change events that syncs markdown files to Hyperspell
  */
-export function buildFileSyncHandler(client: HyperspellClient, _cfg: HyperspellConfig) {
-  const workspaceDir = getWorkspaceDir()
-  const memoryDir = path.join(workspaceDir, "memory")
+export function buildFileSyncHandler(
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
+) {
+	const workspaceDir = getWorkspaceDir();
+	const memoryDir = path.join(workspaceDir, "memory");
 
-  return async (event: Record<string, unknown>) => {
-    const filePath = event.file_path as string | undefined
-    if (!filePath) return
+	return async (event: Record<string, unknown>) => {
+		const filePath = event.file_path as string | undefined;
+		if (!filePath) return;
 
-    // Only process markdown files in the workspace's memory directory
-    if (!filePath.startsWith(memoryDir) || !filePath.endsWith(".md")) {
-      return
-    }
+		// Only process markdown files in the workspace's memory directory
+		if (!filePath.startsWith(memoryDir) || !filePath.endsWith(".md")) {
+			return;
+		}
 
-    const fileName = path.basename(filePath)
-    log.info(`Memory file changed: ${fileName}`)
+		const fileName = path.basename(filePath);
+		log.info(`Memory file changed: ${fileName}`);
 
-    try {
-      const result = await syncMarkdownFile(client, filePath)
-      if (result.success) {
-        log.info(`Synced ${fileName} -> ${result.resourceId}`)
-      } else {
-        log.error(`Failed to sync ${fileName}: ${result.error}`)
-      }
-    } catch (err) {
-      log.error(`Error syncing ${fileName}`, err)
-    }
-  }
+		try {
+			const result = await syncMarkdownFile(client, filePath);
+			if (result.success) {
+				log.info(`Synced ${fileName} -> ${result.resourceId}`);
+			} else {
+				log.error(`Failed to sync ${fileName}: ${result.error}`);
+			}
+		} catch (err) {
+			log.error(`Error syncing ${fileName}`, err);
+		}
+	};
 }
 
 /**
  * Sync all existing memory files on startup
  */
 export async function syncMemoriesOnStartup(
-  client: HyperspellClient,
-  workspaceDir: string,
+	client: HyperspellClient,
+	workspaceDir: string,
 ): Promise<void> {
-  log.info("Syncing existing memory files...")
+	log.info("Syncing existing memory files...");
 
-  const result = await syncAllMemoryFiles(client, workspaceDir)
+	const result = await syncAllMemoryFiles(client, workspaceDir);
 
-  if (result.synced > 0) {
-    log.info(`Synced ${result.synced} memory files`)
-  }
-  if (result.failed > 0) {
-    log.error(`Failed to sync ${result.failed} files:`)
-    for (const error of result.errors) {
-      log.error(`  - ${error}`)
-    }
-  }
-  if (result.synced === 0 && result.failed === 0) {
-    log.info("No memory files found in memory/ directory")
-  }
+	if (result.synced > 0) {
+		log.info(`Synced ${result.synced} memory files`);
+	}
+	if (result.failed > 0) {
+		log.error(`Failed to sync ${result.failed} files:`);
+		for (const error of result.errors) {
+			log.error(`  - ${error}`);
+		}
+	}
+	if (result.synced === 0 && result.failed === 0) {
+		log.info("No memory files found in memory/ directory");
+	}
 }

--- a/index.ts
+++ b/index.ts
@@ -1,113 +1,136 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import { HyperspellClient } from "./client.ts"
-import { registerCommands } from "./commands/slash.ts"
-import { registerCliCommands } from "./commands/setup.ts"
-import { parseConfig, hyperspellConfigSchema, getWorkspaceDir } from "./config.ts"
-import { buildAutoContextHandler } from "./hooks/auto-context.ts"
-import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
-import { initLogger } from "./logger.ts"
-import { registerRememberTool } from "./tools/remember.ts"
-import { registerSearchTool } from "./tools/search.ts"
-import { registerNetworkTools } from "./graph/index.ts"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { HyperspellClient } from "./client.ts";
+import { registerCliCommands } from "./commands/setup.ts";
+import { registerCommands } from "./commands/slash.ts";
+import {
+	getWorkspaceDir,
+	hyperspellConfigSchema,
+	parseConfig,
+} from "./config.ts";
+import { registerNetworkTools } from "./graph/index.ts";
+import { buildAutoContextHandler } from "./hooks/auto-context.ts";
+import { buildConversationCaptureHandler } from "./hooks/conversation-capture.ts";
+import {
+	buildFileSyncHandler,
+	syncMemoriesOnStartup,
+} from "./hooks/memory-sync.ts";
+import { initLogger } from "./logger.ts";
+import { registerRememberTool } from "./tools/remember.ts";
+import { registerSearchTool } from "./tools/search.ts";
 
 export default {
-  id: "openclaw-hyperspell",
-  name: "Hyperspell",
-  description: "Hyperspell gives your Molty context and memory from all your existing data",
-  kind: "memory" as const,
-  configSchema: hyperspellConfigSchema,
+	id: "openclaw-hyperspell",
+	name: "Hyperspell",
+	description:
+		"Hyperspell gives your Molty context and memory from all your existing data",
+	kind: "memory" as const,
+	configSchema: hyperspellConfigSchema,
 
-  register(api: OpenClawPluginApi) {
-    // Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
-    api.registerCli(
-      (ctx) => {
-        registerCliCommands(ctx.program, api.pluginConfig)
-      },
-      { commands: ["openclaw-hyperspell"] },
-    )
+	register(api: OpenClawPluginApi) {
+		// Register CLI commands (openclaw openclaw-hyperspell setup|status|connect)
+		api.registerCli(
+			(ctx) => {
+				registerCliCommands(ctx.program, api.pluginConfig);
+			},
+			{ commands: ["openclaw-hyperspell"] },
+		);
 
-    // Check if configured
-    const rawConfig = api.pluginConfig as Record<string, unknown> | undefined
-    const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY
+		// Check if configured
+		const rawConfig = api.pluginConfig as Record<string, unknown> | undefined;
+		const hasConfig = rawConfig?.apiKey || process.env.HYPERSPELL_API_KEY;
 
-    if (!hasConfig) {
-      api.logger.info("hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'")
-      // Still register slash commands so they show up, but they'll return an error
-      api.registerCommand({
-        name: "getcontext",
-        description: "Search your memories for relevant context",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "remember",
-        description: "Save something to memory",
-        acceptsArgs: true,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      api.registerCommand({
-        name: "sync",
-        description: "Sync memory/*.md files with Hyperspell",
-        acceptsArgs: false,
-        requireAuth: false,
-        handler: async () => {
-          return { text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first." }
-        },
-      })
-      return
-    }
+		if (!hasConfig) {
+			api.logger.info(
+				"hyperspell: not configured - run 'openclaw openclaw-hyperspell setup'",
+			);
+			// Still register slash commands so they show up, but they'll return an error
+			api.registerCommand({
+				name: "getcontext",
+				description: "Search your memories for relevant context",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			api.registerCommand({
+				name: "remember",
+				description: "Save something to memory",
+				acceptsArgs: true,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			api.registerCommand({
+				name: "sync",
+				description: "Sync memory/*.md files with Hyperspell",
+				acceptsArgs: false,
+				requireAuth: false,
+				handler: async () => {
+					return {
+						text: "Hyperspell not configured. Run 'openclaw openclaw-hyperspell setup' first.",
+					};
+				},
+			});
+			return;
+		}
 
-    const cfg = parseConfig(api.pluginConfig)
+		const cfg = parseConfig(api.pluginConfig);
 
-    initLogger(api.logger, cfg.debug)
+		initLogger(api.logger, cfg.debug);
 
-    const client = new HyperspellClient(cfg)
+		const client = new HyperspellClient(cfg);
 
-    // Register AI tools
-    registerSearchTool(api, client, cfg)
-    registerRememberTool(api, client, cfg)
+		// Register AI tools
+		registerSearchTool(api, client, cfg);
+		registerRememberTool(api, client, cfg);
 
-    // Register auto-context hook
-    if (cfg.autoContext) {
-      const autoContextHandler = buildAutoContextHandler(client, cfg)
-      api.on("before_agent_start", autoContextHandler)
-    }
+		// Register auto-context hook
+		if (cfg.autoContext) {
+			const autoContextHandler = buildAutoContextHandler(client, cfg);
+			api.on("before_agent_start", autoContextHandler);
+		}
 
-    // Register memory sync hook
-    if (cfg.syncMemories) {
-      const fileSyncHandler = buildFileSyncHandler(client, cfg)
-      api.on("file_changed", fileSyncHandler)
-    }
+		// Register conversation capture hook
+		if (cfg.captureConversations) {
+			const captureHandler = buildConversationCaptureHandler(client, cfg);
+			api.on("agent_end", captureHandler);
+		}
 
-    // Register memory network tools
-    if (cfg.knowledgeGraph.enabled) {
-      registerNetworkTools(api, client, cfg)
-    }
+		// Register memory sync hook
+		if (cfg.syncMemories) {
+			const fileSyncHandler = buildFileSyncHandler(client, cfg);
+			api.on("file_changed", fileSyncHandler);
+		}
 
-    // Register slash commands
-    registerCommands(api, client, cfg)
+		// Register memory network tools
+		if (cfg.knowledgeGraph.enabled) {
+			registerNetworkTools(api, client, cfg);
+		}
 
-    // Register service for lifecycle management
-    api.registerService({
-      id: "openclaw-hyperspell",
-      start: async () => {
-        api.logger.info("hyperspell: connected")
+		// Register slash commands
+		registerCommands(api, client, cfg);
 
-        // Sync memories on startup if enabled
-        if (cfg.syncMemories) {
-          const workspaceDir = getWorkspaceDir()
-          await syncMemoriesOnStartup(client, workspaceDir)
-        }
-      },
-      stop: () => {
-        api.logger.info("hyperspell: stopped")
-      },
-    })
-  },
-}
+		// Register service for lifecycle management
+		api.registerService({
+			id: "openclaw-hyperspell",
+			start: async () => {
+				api.logger.info("hyperspell: connected");
+
+				// Sync memories on startup if enabled
+				if (cfg.syncMemories) {
+					const workspaceDir = getWorkspaceDir();
+					await syncMemoriesOnStartup(client, workspaceDir);
+				}
+			},
+			stop: () => {
+				api.logger.info("hyperspell: stopped");
+			},
+		});
+	},
+};

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1,27 +1,27 @@
-import { exec } from "node:child_process"
-import { platform } from "node:os"
+import { exec } from "node:child_process";
+import { platform } from "node:os";
 
 export function openInBrowser(url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let command: string
+	return new Promise((resolve, reject) => {
+		let command: string;
 
-    switch (platform()) {
-      case "darwin":
-        command = `open "${url}"`
-        break
-      case "win32":
-        command = `start "" "${url}"`
-        break
-      default:
-        command = `xdg-open "${url}"`
-    }
+		switch (platform()) {
+			case "darwin":
+				command = `open "${url}"`;
+				break;
+			case "win32":
+				command = `start "" "${url}"`;
+				break;
+			default:
+				command = `xdg-open "${url}"`;
+		}
 
-    exec(command, (error) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve()
-      }
-    })
-  })
+		exec(command, (error) => {
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		});
+	});
 }

--- a/logger.ts
+++ b/logger.ts
@@ -1,41 +1,41 @@
 type Logger = {
-  info: (message: string, ...args: unknown[]) => void
-  warn: (message: string, ...args: unknown[]) => void
-  error: (message: string, ...args: unknown[]) => void
-  debug: (message: string, ...args: unknown[]) => void
-}
+	info: (message: string, ...args: unknown[]) => void;
+	warn: (message: string, ...args: unknown[]) => void;
+	error: (message: string, ...args: unknown[]) => void;
+	debug: (message: string, ...args: unknown[]) => void;
+};
 
-let _logger: Logger = console
-let _debug = false
+let _logger: Logger = console;
+let _debug = false;
 
 export function initLogger(logger: Logger, debug: boolean): void {
-  _logger = logger
-  _debug = debug
+	_logger = logger;
+	_debug = debug;
 }
 
 export const log = {
-  info: (message: string, ...args: unknown[]) => {
-    _logger.info(`hyperspell: ${message}`, ...args)
-  },
-  warn: (message: string, ...args: unknown[]) => {
-    _logger.warn(`hyperspell: ${message}`, ...args)
-  },
-  error: (message: string, ...args: unknown[]) => {
-    _logger.error(`hyperspell: ${message}`, ...args)
-  },
-  debug: (message: string, ...args: unknown[]) => {
-    if (_debug) {
-      _logger.debug(`hyperspell: ${message}`, ...args)
-    }
-  },
-  debugRequest: (method: string, params: unknown) => {
-    if (_debug) {
-      _logger.debug(`hyperspell: [${method}] request`, params)
-    }
-  },
-  debugResponse: (method: string, result: unknown) => {
-    if (_debug) {
-      _logger.debug(`hyperspell: [${method}] response`, result)
-    }
-  },
-}
+	info: (message: string, ...args: unknown[]) => {
+		_logger.info(`hyperspell: ${message}`, ...args);
+	},
+	warn: (message: string, ...args: unknown[]) => {
+		_logger.warn(`hyperspell: ${message}`, ...args);
+	},
+	error: (message: string, ...args: unknown[]) => {
+		_logger.error(`hyperspell: ${message}`, ...args);
+	},
+	debug: (message: string, ...args: unknown[]) => {
+		if (_debug) {
+			_logger.debug(`hyperspell: ${message}`, ...args);
+		}
+	},
+	debugRequest: (method: string, params: unknown) => {
+		if (_debug) {
+			_logger.debug(`hyperspell: [${method}] request`, params);
+		}
+	},
+	debugResponse: (method: string, result: unknown) => {
+		if (_debug) {
+			_logger.debug(`hyperspell: [${method}] response`, result);
+		}
+	},
+};

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,88 +1,100 @@
 {
-  "id": "openclaw-hyperspell",
-  "kind": "memory",
-  "uiHints": {
-    "apiKey": {
-      "label": "Hyperspell API Key",
-      "sensitive": true,
-      "placeholder": "hs_...",
-      "help": "Your API key from app.hyperspell.com (or use ${HYPERSPELL_API_KEY})"
-    },
-    "userId": {
-      "label": "User ID",
-      "placeholder": "user_123",
-      "help": "User ID (can be your email)",
-      "advanced": false
-    },
-    "autoContext": {
-      "label": "Auto-Context",
-      "help": "Inject relevant memories before every AI turn",
-      "advanced": true
-    },
-    "sources": {
-      "label": "Sources",
-      "placeholder": "notion,slack,google_drive",
-      "help": "Comma-separated list of sources to search. Leave empty for all sources.",
-      "advanced": true
-    },
-    "maxResults": {
-      "label": "Max Results",
-      "placeholder": "10",
-      "help": "Maximum memories injected into context per turn",
-      "advanced": true
-    },
-    "debug": {
-      "label": "Debug Logging",
-      "help": "Enable verbose debug logs for API calls and responses",
-      "advanced": true
-    },
-    "syncMemories": {
-      "label": "Sync Memory Files",
-      "help": "Automatically sync markdown files in workspace/memory/ to Hyperspell",
-      "advanced": true
-    },
-    "knowledgeGraph": {
-      "label": "Memory Network",
-      "help": "Extract entities (people, projects, orgs, topics) from memories into structured markdown files. Requires a cron job for periodic scanning.",
-      "advanced": true
-    }
-  },
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-      "apiKey": {
-        "type": "string"
-      },
-      "userId": {
-        "type": "string"
-      },
-      "autoContext": {
-        "type": "boolean"
-      },
-      "sources": {
-        "type": "string"
-      },
-      "maxResults": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 20
-      },
-      "debug": {
-        "type": "boolean"
-      },
-      "syncMemories": {
-        "type": "boolean"
-      },
-      "knowledgeGraph": {
-        "type": "object",
-        "properties": {
-          "enabled": { "type": "boolean" },
-          "scanIntervalMinutes": { "type": "number", "minimum": 5, "maximum": 1440 },
-          "batchSize": { "type": "number", "minimum": 5, "maximum": 100 }
-        }
-      }
-    },
-    "required": []
-  }
+	"id": "openclaw-hyperspell",
+	"kind": "memory",
+	"uiHints": {
+		"apiKey": {
+			"label": "Hyperspell API Key",
+			"sensitive": true,
+			"placeholder": "hs_...",
+			"help": "Your API key from app.hyperspell.com (or use ${HYPERSPELL_API_KEY})"
+		},
+		"userId": {
+			"label": "User ID",
+			"placeholder": "user_123",
+			"help": "User ID (can be your email)",
+			"advanced": false
+		},
+		"autoContext": {
+			"label": "Auto-Context",
+			"help": "Inject relevant memories before every AI turn",
+			"advanced": true
+		},
+		"sources": {
+			"label": "Sources",
+			"placeholder": "notion,slack,google_drive",
+			"help": "Comma-separated list of sources to search. Leave empty for all sources.",
+			"advanced": true
+		},
+		"maxResults": {
+			"label": "Max Results",
+			"placeholder": "10",
+			"help": "Maximum memories injected into context per turn",
+			"advanced": true
+		},
+		"debug": {
+			"label": "Debug Logging",
+			"help": "Enable verbose debug logs for API calls and responses",
+			"advanced": true
+		},
+		"syncMemories": {
+			"label": "Sync Memory Files",
+			"help": "Automatically sync markdown files in workspace/memory/ to Hyperspell",
+			"advanced": true
+		},
+		"captureConversations": {
+			"label": "Capture Conversations",
+			"help": "Write every completed agent turn to Hyperspell as a searchable memory",
+			"advanced": true
+		},
+		"knowledgeGraph": {
+			"label": "Memory Network",
+			"help": "Extract entities (people, projects, orgs, topics) from memories into structured markdown files. Requires a cron job for periodic scanning.",
+			"advanced": true
+		}
+	},
+	"configSchema": {
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"apiKey": {
+				"type": "string"
+			},
+			"userId": {
+				"type": "string"
+			},
+			"autoContext": {
+				"type": "boolean"
+			},
+			"sources": {
+				"type": "string"
+			},
+			"maxResults": {
+				"type": "number",
+				"minimum": 1,
+				"maximum": 20
+			},
+			"debug": {
+				"type": "boolean"
+			},
+			"syncMemories": {
+				"type": "boolean"
+			},
+			"captureConversations": {
+				"type": "boolean"
+			},
+			"knowledgeGraph": {
+				"type": "object",
+				"properties": {
+					"enabled": { "type": "boolean" },
+					"scanIntervalMinutes": {
+						"type": "number",
+						"minimum": 5,
+						"maximum": 1440
+					},
+					"batchSize": { "type": "number", "minimum": 5, "maximum": 100 }
+				}
+			}
+		},
+		"required": []
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperspell/openclaw-hyperspell",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
@@ -14,7 +14,9 @@
         "hyperspell": "^0.30.0"
       },
       "devDependencies": {
-        "typescript": "^5.9.3"
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.3",
+        "vitest": "^2.1.0"
       },
       "peerDependencies": {
         "openclaw": ">=2026.1.29"
@@ -25,6 +27,7 @@
       "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.1.tgz",
       "integrity": "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
@@ -34,6 +37,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
       "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
       },
@@ -54,6 +58,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -68,6 +73,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -83,6 +89,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -95,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -108,6 +116,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -121,6 +130,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -135,6 +145,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -144,6 +155,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -155,6 +167,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -167,6 +180,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -180,6 +194,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -193,6 +208,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.980.0.tgz",
       "integrity": "sha512-slYj3C+su260ZWTrlEV9AM87YXUodB9wzXdQW8PCskNm28Am0u0AE7ro9E7nb5n6hq7RfrdWPkZkzZdtQE+BYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -244,6 +260,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.980.0.tgz",
       "integrity": "sha512-agRy8K543Q4WxCiup12JiSe4rO2gkw4wykaGXD+MEmzG2Nq4ODvKrNHT+XYCyTvk9ehJim/vpu+Stae3nEI0yw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -302,6 +319,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.980.0.tgz",
       "integrity": "sha512-AhNXQaJ46C1I+lQ+6Kj+L24il5K9lqqIanJd8lMszPmP7bLnmX0wTKK0dxywcvrLdij3zhWttjAKEBNgLtS8/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -351,6 +369,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.5.tgz",
       "integrity": "sha512-IMM7xGfLGW6lMvubsA4j6BHU5FPgGAxoQ/NA63KqNLMwTS+PeMBcx8DPHL12Vg6yqOZnqok9Mu4H2BdQyq7gSA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@aws-sdk/xml-builder": "^3.972.2",
@@ -375,6 +394,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.3.tgz",
       "integrity": "sha512-OBYNY4xQPq7Rx+oOhtyuyO0AQvdJSpXRg7JuPNBJH4a1XXIzJQl4UHQTPKZKwfJXmYLpv4+OkcFen4LYmDPd3g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/types": "^3.973.1",
@@ -391,6 +411,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.5.tgz",
       "integrity": "sha512-GpvBgEmSZPvlDekd26Zi+XsI27Qz7y0utUx0g2fSTSiDzhnd1FSa1owuodxR0BcUKNL7U2cOVhhDxgZ4iSoPVg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/types": "^3.973.1",
@@ -412,6 +433,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.3.tgz",
       "integrity": "sha512-rMQAIxstP7cLgYfsRGrGOlpyMl0l8JL2mcke3dsIPLWke05zKOFyR7yoJzWCsI/QiIxjRbxpvPiAeKEA6CoYkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/credential-provider-env": "^3.972.3",
@@ -437,6 +459,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.3.tgz",
       "integrity": "sha512-Gc3O91iVvA47kp2CLIXOwuo5ffo1cIpmmyIewcYjAcvurdFHQ8YdcBe1KHidnbbBO4/ZtywGBACsAX5vr3UdoA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/nested-clients": "3.980.0",
@@ -456,6 +479,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.4.tgz",
       "integrity": "sha512-UwerdzosMSY7V5oIZm3NsMDZPv2aSVzSkZxYxIOWHBeKTZlUqW7XpHtJMZ4PZpJ+HMRhgP+MDGQx4THndgqJfQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.3",
         "@aws-sdk/credential-provider-http": "^3.972.5",
@@ -479,6 +503,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.3.tgz",
       "integrity": "sha512-xkSY7zjRqeVc6TXK2xr3z1bTLm0wD8cj3lAkproRGaO4Ku7dPlKy843YKnHrUOUzOnMezdZ4xtmFc0eKIDTo2w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/types": "^3.973.1",
@@ -496,6 +521,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.3.tgz",
       "integrity": "sha512-8Ww3F5Ngk8dZ6JPL/V5LhCU1BwMfQd3tLdoEuzaewX8FdnT633tPr+KTHySz9FK7fFPcz5qG3R5edVEhWQD4AA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.980.0",
         "@aws-sdk/core": "^3.973.5",
@@ -515,6 +541,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.3.tgz",
       "integrity": "sha512-62VufdcH5rRfiRKZRcf1wVbbt/1jAntMj1+J0qAd+r5pQRg2t0/P9/Rz16B1o5/0Se9lVL506LRjrhIJAhYBfA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/nested-clients": "3.980.0",
@@ -533,6 +560,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.3.tgz",
       "integrity": "sha512-uQbkXcfEj4+TrxTmZkSwsYRE9nujx9b6WeLoQkDsldzEpcQhtKIz/RHSB4lWe7xzDMfGCLUkwmSJjetGVcrhCw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/eventstream-codec": "^4.2.8",
@@ -548,6 +576,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
       "integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
@@ -563,6 +592,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
       "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
@@ -578,6 +608,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
       "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -592,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
       "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@aws/lambda-invoke-store": "^0.2.2",
@@ -608,6 +640,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.5.tgz",
       "integrity": "sha512-TVZQ6PWPwQbahUI8V+Er+gS41ctIawcI/uMNmQtQ7RMcg3JYn6gyKAFKUb3HFYx2OjYlx1u11sETSwwEUxVHTg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/types": "^3.973.1",
@@ -626,6 +659,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.3.tgz",
       "integrity": "sha512-/BjMbtOM9lsgdNgRZWUL5oCV6Ocfx1vcK/C5xO5/t/gCk6IwR9JFWMilbk6K6Buq5F84/lkngqcCKU2SRkAmOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@aws-sdk/util-format-url": "^3.972.3",
@@ -647,6 +681,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.980.0.tgz",
       "integrity": "sha512-/dONY5xc5/CCKzOqHZCTidtAR4lJXWkGefXvTRKdSKMGaYbbKsxDckisd6GfnvPSLxWtvQzwgRGRutMRoYUApQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -696,6 +731,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
       "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
@@ -712,6 +748,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.980.0.tgz",
       "integrity": "sha512-1nFileg1wAgDmieRoj9dOawgr2hhlh7xdvcH57b1NnqfPaVlcqVJyPc6k3TLDUFPY69eEwNxdGue/0wIz58vjA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.5",
         "@aws-sdk/nested-clients": "3.980.0",
@@ -730,6 +767,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
       "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -743,6 +781,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.980.0.tgz",
       "integrity": "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -759,6 +798,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
       "integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/querystring-builder": "^4.2.8",
@@ -774,6 +814,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
       "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -786,6 +827,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
       "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -798,6 +840,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.3.tgz",
       "integrity": "sha512-gqG+02/lXQtO0j3US6EVnxtwwoXQC5l2qkhLCrqUrqdtcQxV7FDMbm9wLjKqoronSHyELGTjbFKK/xV5q1bZNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.5",
         "@aws-sdk/types": "^3.973.1",
@@ -822,6 +865,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.2.tgz",
       "integrity": "sha512-jGOOV/bV1DhkkUhHiZ3/1GZ67cZyOXaDb7d1rYD6ZiXf5V9tBNOcgqXwRRPvrCbYaFRa1pPMFb3ZjqjWpR3YfA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "fast-xml-parser": "5.2.5",
@@ -836,6 +880,7 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
       "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -845,6 +890,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -854,6 +900,7 @@
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
       "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
@@ -864,6 +911,7 @@
       "resolved": "https://registry.npmjs.org/@buape/carbon/-/carbon-0.14.0.tgz",
       "integrity": "sha512-mavllPK2iVpRNRtC4C8JOUdJ1hdV0+LDelFW+pjpJaM31MBLMfIJ+f/LlYTIK5QrEcQsXOC+6lU2e0gmgjWhIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^25.0.9",
         "discord-api-types": "0.38.37"
@@ -877,20 +925,39 @@
         "ws": "8.19.0"
       }
     },
+    "node_modules/@buape/carbon/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@buape/carbon/node_modules/discord-api-types": {
       "version": "0.38.37",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
       "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "scripts/actions/documentation"
       ]
+    },
+    "node_modules/@buape/carbon/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cacheable/memory": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
       "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "@keyv/bigmap": "^1.3.0",
@@ -903,6 +970,7 @@
       "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
       "integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cacheable": "^2.3.1",
         "hookified": "^1.14.0",
@@ -917,6 +985,7 @@
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.5.5"
@@ -943,41 +1012,395 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260120.0.tgz",
-      "integrity": "sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==",
-      "license": "MIT OR Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@discordjs/voice": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
-      "integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/ws": "^8.18.1",
-        "discord-api-types": "^0.38.16",
-        "prism-media": "^1.3.5",
-        "tslib": "^2.8.1",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@google/genai": {
@@ -985,6 +1408,7 @@
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.34.0.tgz",
       "integrity": "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "google-auth-library": "^10.3.0",
         "ws": "^8.18.0"
@@ -1006,6 +1430,7 @@
       "resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
       "integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0"
       },
@@ -1021,6 +1446,7 @@
       "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
       "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bottleneck": "^2.0.0"
       },
@@ -1035,13 +1461,15 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.23.0.tgz",
       "integrity": "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
       "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "9.x.x"
       }
@@ -1050,13 +1478,15 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
       "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.1",
         "fast-deep-equal": "^3.1.3",
@@ -1067,24 +1497,12 @@
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.4.tgz",
       "integrity": "sha512-VoQJywjpjy2D88Oj0BTHRuS8JCbUgoOg5t1UGgbtGh2fRia9Dx/k6Wf8FqrEWIvWK9fAkfJeeLB9fcSpCNPCpw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1094,464 +1512,9 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -1559,6 +1522,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
       "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -1568,6 +1532,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
       },
@@ -1580,6 +1545,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1596,13 +1562,15 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1620,6 +1588,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1627,11 +1596,19 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@keyv/bigmap": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
       "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hashery": "^1.4.0",
         "hookified": "^1.15.0"
@@ -1647,13 +1624,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1"
       }
@@ -1662,13 +1641,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@line/bot-sdk": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.6.0.tgz",
       "integrity": "sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^24.0.0"
       },
@@ -1684,6 +1665,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1693,6 +1675,7 @@
       "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.3.tgz",
       "integrity": "sha512-ngGAItlRhmJXrhspxt8kX13n1dVFqzETOq0m/+gqSkO8NJBvNMwP7FZckMwps2UFySdr4yxCXNGu/bumg5at6A==",
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "@lydell/node-pty-darwin-arm64": "1.2.0-beta.3",
         "@lydell/node-pty-darwin-x64": "1.2.0-beta.3",
@@ -1702,89 +1685,12 @@
         "@lydell/node-pty-win32-x64": "1.2.0-beta.3"
       }
     },
-    "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-owcv+e1/OSu3bf9ZBdUQqJsQF888KyuSIiPYFNn0fLhgkhm9F3Pvha76Kj5mCPnodf7hh3suDe7upw7GPRXftQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-k38O+UviWrWdxtqZBBc/D8NJU11Rey8Y2YMwSWNxLv3eXZZdF5IVpbBkI/2RmLsV5nCcciqLPbukxeZnEfPlwA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-HUwRpGu3O+4sv9DAQFKnyW5LYhyYu2SDUa/bdFO/t4dIFCM4uDJEq47wfRM7+aYtJTi1b3lakN8SlWeuFQqJQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-+RRY0PoCUeQaCvPR7/UnkGbxulwbFtoTWJfe+o4T1RcNtngrgaI55I9nl8CD8uqhGrB3smKuyvPM5UtwGhASUw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-UEDd9ASp2M3iIYpIzfmfBlpyn4+K1G4CAjYcHWStptCkefoSVXWTiUBIa1KjBjZi3/xmsHIDpBEYTkGWuvLt2Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-TpdqSFYx7/Rj+68tuP6F/lkRYrHCYAIJgaS1bx3SctTkb5QAQCFwOKHd4xlsivmEOMT2LdhkJggPxwX9PAO5pQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.0.tgz",
       "integrity": "sha512-tQrCRAtr58BLmWcvwCqlJo5GJgqBGb3zwOBFFBKCEKvRgD8y/EawhCyXsfOh9XOOde1NTAYsYuYyVOYw2tLnoQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1800,152 +1706,12 @@
         "@mariozechner/clipboard-win32-x64-msvc": "0.3.0"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.0.tgz",
-      "integrity": "sha512-7i4bitLzRSij0fj6q6tPmmf+JrwHqfBsBmf8mOcLVv0LVexD+4gEsyMait4i92exKYmCfna6uHKVS84G4nqehg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.0.tgz",
-      "integrity": "sha512-FVZLGdIkmvqtPQjD0GQwKLVheL+zV7DjA6I5NcsHGjBeWpG2nACS6COuelNf8ruMoPxJFw7RoB4fjw6mmjT+Nw==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.0.tgz",
-      "integrity": "sha512-KuurQYEqRhalvBji3CH5xIq1Ts23IgVRE3rjanhqFDI77luOhCnlNbDtqv3No5OxJhEBLykQNrAzfgjqPsPWdA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.0.tgz",
-      "integrity": "sha512-nWpGMlk43bch7ztGfnALcSi5ZREVziPYzrFKjoJimbwaiULrfY0fGce0gWBynP9ak0nHgDLp0nSa7b4cCl+cIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.0.tgz",
-      "integrity": "sha512-4BC08CIaOXSSAGRZLEjqJmQfioED8ohAzwt0k2amZPEbH96YKoBNorq5EdwPf5VT+odS0DeyCwhwtxokRLZIvQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.0.tgz",
-      "integrity": "sha512-GpNY5Y9nOzr0Vt0Qi5U88qwe6piiIHk44kSMexl8ns90LluN5UTNYmyfi7Xq3/lmPZCpnB2xvBTYbsXCxnopIA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.0.tgz",
-      "integrity": "sha512-+PnR48/x9GMY5Kh8BLjzHMx6trOegMtxAuqTM9X/bhV3QuW6sLLd7nojDHSGj/ZueK6i0tcQxvOrgNLozVtNDA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.0.tgz",
-      "integrity": "sha512-+dy2vZ1Ph4EYj0cotB+bVUVk/uKl2bh9LOp/zlnFqoCCYDN6sm+L0VyIOPPo3hjoEVdGpHe1MUxp3qG/OLwXgg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.0.tgz",
-      "integrity": "sha512-dfpHrUpKHl7ad3xVGE1+gIN3cEnjjPZa4I0BIYMuj2OKq07Gf1FKTXMypB41rDFv6XNzcfhYQnY+ZNgIu9FB8A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@mariozechner/jiti": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
       "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "std-env": "^3.10.0",
         "yoctocolors": "^2.1.2"
@@ -1959,6 +1725,7 @@
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.50.7.tgz",
       "integrity": "sha512-iSNh+7QQFVge3co0Au1X6sqXAr+X6e3XlRXM7oE3m6zMWj76A1YCciV2sLI/imBcoFLum8blIaM0empwL477dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mariozechner/pi-ai": "^0.50.7",
         "@mariozechner/pi-tui": "^0.50.7"
@@ -1972,6 +1739,7 @@
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.50.7.tgz",
       "integrity": "sha512-mVqaTE/Ulijd1olduEU02IfIP91aNt6F0UYJQNLR+m3b/6bsn21csZJZnkjYia0kHX7PnOLtikO2jG7dJpYY6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "0.71.2",
         "@aws-sdk/client-bedrock-runtime": "^3.966.0",
@@ -1999,6 +1767,7 @@
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.50.7.tgz",
       "integrity": "sha512-A3SK7VoVY/xVNoRyLWwKoLRBTJ1cBq8hfqIiKOuE9BPBimEONu7lr7BZF/ma8rbOakPfhJ5TvLHCegwW9RhnwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mariozechner/clipboard": "^0.3.0",
         "@mariozechner/jiti": "^2.6.2",
@@ -2029,6 +1798,7 @@
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.50.7.tgz",
       "integrity": "sha512-O8H8hXqoWdE+5eUUPiswq+WT+2eeshJHJmXKWMJMoSitNqdwzYZds9umAKdVLII6ZvjnFtd0awnf4VThYQBFIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
@@ -2045,6 +1815,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2054,6 +1825,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2069,6 +1841,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
       "integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
+      "peer": true,
       "dependencies": {
         "zod": "^3.20.0",
         "zod-to-json-schema": "^3.24.1"
@@ -2079,6 +1852,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2088,6 +1862,7 @@
       "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
       "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2122,443 +1897,12 @@
         "@napi-rs/canvas-win32-x64-msvc": "0.1.89"
       }
     },
-    "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.89.tgz",
-      "integrity": "sha512-CXxQTXsjtQqKGENS8Ejv9pZOFJhOPIl2goenS+aU8dY4DygvkyagDhy/I07D1YLqrDtPvLEX5zZHt8qUdnuIpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.89.tgz",
-      "integrity": "sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.89.tgz",
-      "integrity": "sha512-iUragqhBrA5FqU13pkhYBDbUD1WEAIlT8R2+fj6xHICY2nemzwMUI8OENDhRh7zuL06YDcRwENbjAVxOmaX9jg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.89.tgz",
-      "integrity": "sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.89.tgz",
-      "integrity": "sha512-NEoF9y8xq5fX8HG8aZunBom1ILdTwt7ayBzSBIwrmitk7snj4W6Fz/yN/ZOmlM1iyzHDNX5Xn0n+VgWCF8BEdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.89.tgz",
-      "integrity": "sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.89.tgz",
-      "integrity": "sha512-1/VmEoFaIO6ONeeEMGoWF17wOYZOl5hxDC1ios2Bkz/oQjbJJ8DY/X22vWTmvuUKWWhBVlo63pxLGZbjJU/heA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.89.tgz",
-      "integrity": "sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.89.tgz",
-      "integrity": "sha512-w+5qxHzplvA4BkHhCaizNMLLXiI+CfP84YhpHm/PqMub4u8J0uOAv+aaGv40rYEYra5hHRWr9LUd6cfW32o9/A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.89.tgz",
-      "integrity": "sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.89.tgz",
-      "integrity": "sha512-WMej0LZrIqIncQcx0JHaMXlnAG7sncwJh7obs/GBgp0xF9qABjwoRwIooMWCZkSansapKGNUHhamY6qEnFN7gA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-arm64": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.15.1.tgz",
-      "integrity": "sha512-g7JC/WwDyyBSmkIjSvRF2XLW+YA0z2ZVBSAKSv106mIPO4CzC078woTuTaPsykWgIaKcQRyXuW5v5XQMcT1OOA==",
-      "cpu": [
-        "arm64",
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-armv7l": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.15.1.tgz",
-      "integrity": "sha512-MSxR3A0vFSVWbmVSkNqNXQnI45L2Vg7/PRgJukcjChk7YzRxs9L+oQMeycVW3BsQ03mIZ0iORsZ9MNIBEbdS3g==",
-      "cpu": [
-        "arm",
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-x64": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.15.1.tgz",
-      "integrity": "sha512-w4SdxJaA9eJLVYWX+Jv48hTP4oO79BJQIFURMi7hXIFXbxyyOov/r6sVaQ1WiL83nVza37U5Qg4L9Gb/KRdNWQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-x64-cuda": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.15.1.tgz",
-      "integrity": "sha512-kngwoq1KdrqSr/b6+tn5jbtGHI0tZnW5wofKssZy+Il2ge3eN9FowKbXG4FH452g6qSSVoDccAoTvYOxyLyX+w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.15.1.tgz",
-      "integrity": "sha512-toepvLcXjgaQE/QGIThHBD58jbHGBWT1jhblJkCjYBRHfVOO+6n/PmVsJt+yMfu5Z93A2gF8YOvVyZXNXmGo5g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.15.1.tgz",
-      "integrity": "sha512-CMsyQkGKpHKeOH9+ZPxo0hO0usg8jabq5/aM3JwdX9CiuXhXUa3nu3NH4RObiNi596Zwn/zWzlps0HRwcpL8rw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/mac-arm64-metal": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.15.1.tgz",
-      "integrity": "sha512-ePTweqohcy6Gjs1agXWy4FxAw5W4Avr7NeqqiFWJ5ngZ1U3ZXdruUHB8L/vDxyn3FzKvstrFyN7UScbi0pzXrA==",
-      "cpu": [
-        "arm64",
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/mac-x64": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.15.1.tgz",
-      "integrity": "sha512-NAetSQONxpNXTBnEo7oOkKZ84wO2avBy6V9vV9ntjJLb/07g7Rar8s/jVaicc/rVl6C+8ljZNwqJeynirgAC5w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/win-arm64": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.15.1.tgz",
-      "integrity": "sha512-1O9tNSUgvgLL5hqgEuYiz7jRdA3+9yqzNJyPW1jExlQo442OA0eIpHBmeOtvXLwMkY7qv7wE75FdOPR7NVEnvg==",
-      "cpu": [
-        "arm64",
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/win-x64": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.15.1.tgz",
-      "integrity": "sha512-jtoXBa6h+VPsQgefrO7HDjYv4WvxfHtUO30ABwCUDuEgM0e05YYhxMZj1z2Ns47UrquNvd/LUPCyjHKqHUN+5Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/win-x64-cuda": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.15.1.tgz",
-      "integrity": "sha512-swoyx0/dY4ixiu3mEWrIAinx0ffHn9IncELDNREKG+iIXfx6w0OujOMQ6+X+lGj+sjE01yMUP/9fv6GEp2pmBw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.15.1.tgz",
-      "integrity": "sha512-mO3Tf6D3UlFkjQF5J96ynTkjdF7dac/f5f61cEh6oU4D3hdx+cwnmBWT1gVhDSLboJYzCHtx7U2EKPP6n8HoWA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@node-llama-cpp/win-x64-vulkan": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.15.1.tgz",
-      "integrity": "sha512-BPBjUEIkFTdcHSsQyblP0v/aPPypi6uqQIq27mo4A49CYjX22JDmk4ncdBLk6cru+UkvwEEe+F2RomjoMt32aQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@octokit/app": {
       "version": "16.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.2.tgz",
       "integrity": "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-app": "^8.1.2",
         "@octokit/auth-unauthenticated": "^7.0.3",
@@ -2577,6 +1921,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.1.2.tgz",
       "integrity": "sha512-db8VO0PqXxfzI6GdjtgEFHY9tzqUql5xMFXYA12juq8TeTgPAuiiP3zid4h50lwlIP457p5+56PnJOgd2GGBuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.3",
         "@octokit/auth-oauth-user": "^6.0.2",
@@ -2596,6 +1941,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
       "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
         "@octokit/auth-oauth-user": "^6.0.2",
@@ -2612,6 +1958,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
       "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/oauth-methods": "^6.0.2",
         "@octokit/request": "^10.0.6",
@@ -2627,6 +1974,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
       "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
         "@octokit/oauth-methods": "^6.0.2",
@@ -2643,6 +1991,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2652,6 +2001,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.3.tgz",
       "integrity": "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0"
@@ -2684,6 +2034,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
       "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "universal-user-agent": "^7.0.2"
@@ -2697,6 +2048,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^10.0.6",
         "@octokit/types": "^16.0.0",
@@ -2711,6 +2063,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.3.tgz",
       "integrity": "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.2",
         "@octokit/auth-oauth-user": "^6.0.1",
@@ -2730,6 +2083,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
       "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2739,6 +2093,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
       "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/oauth-authorization-url": "^8.0.0",
         "@octokit/request": "^10.0.6",
@@ -2753,19 +2108,22 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/openapi-webhooks-types": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
       "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
       "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       },
@@ -2778,6 +2136,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2793,6 +2152,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2808,6 +2168,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.3.tgz",
       "integrity": "sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
@@ -2825,6 +2186,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
       "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "bottleneck": "^2.15.3"
@@ -2841,6 +2203,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
       "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^11.0.2",
         "@octokit/request-error": "^7.0.2",
@@ -2857,6 +2220,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2869,6 +2233,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
@@ -2878,6 +2243,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
       "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-webhooks-types": "12.1.0",
         "@octokit/request-error": "^7.0.0",
@@ -2892,6 +2258,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
       "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2900,47 +2267,43 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
-      "license": "MIT"
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
+      "peer": true
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2950,185 +2313,393 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
-    "node_modules/@reflink/reflink": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
-      "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@reflink/reflink-darwin-arm64": "0.1.19",
-        "@reflink/reflink-darwin-x64": "0.1.19",
-        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
-        "@reflink/reflink-linux-arm64-musl": "0.1.19",
-        "@reflink/reflink-linux-x64-gnu": "0.1.19",
-        "@reflink/reflink-linux-x64-musl": "0.1.19",
-        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
-        "@reflink/reflink-win32-x64-msvc": "0.1.19"
-      }
+      "os": [
+        "android"
+      ]
     },
-    "node_modules/@reflink/reflink-darwin-arm64": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
-      "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@reflink/reflink-darwin-x64": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
-      "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@reflink/reflink-linux-arm64-gnu": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
-      "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+        "freebsd"
+      ]
     },
-    "node_modules/@reflink/reflink-linux-arm64-musl": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
-      "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@reflink/reflink-linux-x64-gnu": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
-      "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+        "freebsd"
+      ]
     },
-    "node_modules/@reflink/reflink-linux-x64-musl": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
-      "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
-        "x64"
+        "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@reflink/reflink-win32-arm64-msvc": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
-      "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
-    "node_modules/@reflink/reflink-win32-x64-msvc": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
-      "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
-        "x64"
+        "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
       ],
-      "engines": {
-        "node": ">= 10"
-      }
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -3141,6 +2712,7 @@
       "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.6.0.tgz",
       "integrity": "sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@slack/logger": "^4.0.0",
         "@slack/oauth": "^3.0.4",
@@ -3166,6 +2738,7 @@
       "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
       "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=18.0.0"
       },
@@ -3179,6 +2752,7 @@
       "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.4.tgz",
       "integrity": "sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@slack/logger": "^4",
         "@slack/web-api": "^7.10.0",
@@ -3196,6 +2770,7 @@
       "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.5.tgz",
       "integrity": "sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@slack/logger": "^4",
         "@slack/web-api": "^7.10.0",
@@ -3214,6 +2789,7 @@
       "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.19.0.tgz",
       "integrity": "sha512-7+QZ38HGcNh/b/7MpvPG6jnw7mliV6UmrquJLqgdxkzJgQEYUcEztvFWRU49z0x4vthF0ixL5lTK601AXrS8IA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
@@ -3224,6 +2800,7 @@
       "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.13.0.tgz",
       "integrity": "sha512-ERcExbWrnkDN8ovoWWe6Wgt/usanj1dWUd18dJLpctUI4mlPS0nKt81Joh8VI+OPbNnY1lIilVt9gdMBD9U2ig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@slack/logger": "^4.0.0",
         "@slack/types": "^2.18.0",
@@ -3248,6 +2825,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
       "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3261,6 +2839,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
       "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -3278,6 +2857,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.0.tgz",
       "integrity": "sha512-6vjCHD6vaY8KubeNw2Fg3EK0KLGQYdldG4fYgQmA0xSW0dJ8G2xFhSOdrlUakWVoP5JuWHtFODg3PNd/DN3FDA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/protocol-http": "^5.3.8",
@@ -3299,6 +2879,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
       "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
@@ -3315,6 +2896,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
       "integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.12.0",
@@ -3330,6 +2912,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
       "integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -3344,6 +2927,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
       "integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3357,6 +2941,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
       "integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -3371,6 +2956,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
       "integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -3385,6 +2971,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
       "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/querystring-builder": "^4.2.8",
@@ -3401,6 +2988,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
       "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "@smithy/util-buffer-from": "^4.2.0",
@@ -3416,6 +3004,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
       "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3429,6 +3018,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
       "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3441,6 +3031,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
       "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -3455,6 +3046,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.12.tgz",
       "integrity": "sha512-9JMKHVJtW9RysTNjcBZQHDwB0p3iTP6B1IfQV4m+uCevkVd/VuLgwfqk5cnI4RHcp4cPwoIvxQqN4B1sxeHo8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/core": "^3.22.0",
         "@smithy/middleware-serde": "^4.2.9",
@@ -3474,6 +3066,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.29.tgz",
       "integrity": "sha512-bmTn75a4tmKRkC5w61yYQLb3DmxNzB8qSVu9SbTYqW6GAL0WXO2bDZuMAn/GJSbOdHEdjZvWxe+9Kk015bw6Cg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
@@ -3494,6 +3087,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
       "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -3508,6 +3102,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
       "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3521,6 +3116,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
       "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -3536,6 +3132,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.8.tgz",
       "integrity": "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/abort-controller": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
@@ -3552,6 +3149,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
       "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3565,6 +3163,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
       "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3578,6 +3177,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
       "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "@smithy/util-uri-escape": "^4.2.0",
@@ -3592,6 +3192,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
       "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3605,6 +3206,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
       "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0"
       },
@@ -3617,6 +3219,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
       "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3630,6 +3233,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
       "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
         "@smithy/protocol-http": "^5.3.8",
@@ -3649,6 +3253,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.1.tgz",
       "integrity": "sha512-SERgNg5Z1U+jfR6/2xPYjSEHY1t3pyTHC/Ma3YQl6qWtmiL42bvNId3W/oMUWIwu7ekL2FMPdqAmwbQegM7HeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/core": "^3.22.0",
         "@smithy/middleware-endpoint": "^4.4.12",
@@ -3667,6 +3272,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
       "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3679,6 +3285,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
       "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -3693,6 +3300,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
       "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
@@ -3707,6 +3315,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
       "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3719,6 +3328,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
       "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3731,6 +3341,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
       "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3744,6 +3355,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
       "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3756,6 +3368,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.28.tgz",
       "integrity": "sha512-/9zcatsCao9h6g18p/9vH9NIi5PSqhCkxQ/tb7pMgRFnqYp9XUOyOlGPDMHzr8n5ih6yYgwJEY2MLEobUgi47w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
         "@smithy/smithy-client": "^4.11.1",
@@ -3771,6 +3384,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.31.tgz",
       "integrity": "sha512-JTvoApUXA5kbpceI2vuqQzRjeTbLpx1eoa5R/YEZbTgtxvIB7AQZxFJ0SEyfCpgPCyVV9IT7we+ytSeIB3CyWA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/credential-provider-imds": "^4.2.8",
@@ -3789,6 +3403,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
       "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -3803,6 +3418,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
       "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3815,6 +3431,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
       "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -3828,6 +3445,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
       "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/service-error-classification": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -3842,6 +3460,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.10.tgz",
       "integrity": "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/node-http-handler": "^4.4.8",
@@ -3861,6 +3480,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
       "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3873,6 +3493,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
       "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3886,6 +3507,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
       "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3898,6 +3520,7 @@
       "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.3.tgz",
       "integrity": "sha512-0nSvOgFHvq0a15+pZAdbAyHUk0+AGLX6oyo45b7fPdgWdPfHA19IfgUKRECYT0aw86ZP6ZDDLxGQ7FEA1fAVOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17.0"
       },
@@ -3911,6 +3534,7 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
       "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "token-types": "^6.1.1"
@@ -3927,38 +3551,32 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.160",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
       "integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/bun": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.6.tgz",
-      "integrity": "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bun-types": "1.3.6"
       }
     },
     "node_modules/@types/connect": {
@@ -3966,9 +3584,17 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -3987,6 +3613,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3998,13 +3625,15 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
       "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
@@ -4014,52 +3643,65 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4069,6 +3711,7 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -4079,8 +3722,122 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@whiskeysockets/baileys": {
@@ -4089,6 +3846,7 @@
       "integrity": "sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
@@ -4127,6 +3885,7 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
       "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^7.0.0"
@@ -4143,6 +3902,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -4155,6 +3915,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -4167,6 +3928,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -4180,6 +3942,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4189,6 +3952,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -4205,6 +3969,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -4214,6 +3979,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4230,6 +3996,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -4247,6 +4014,7 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
       "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -4259,6 +4027,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4271,6 +4040,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4282,13 +4052,15 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -4296,6 +4068,7 @@
       "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -4308,13 +4081,25 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -4327,6 +4112,7 @@
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4336,6 +4122,7 @@
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -4344,13 +4131,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4360,6 +4149,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
       "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -4370,7 +4160,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4390,13 +4181,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/basic-ftp": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
       "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4405,13 +4198,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4421,6 +4216,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -4444,25 +4240,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bowser": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
       "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4471,31 +4271,34 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
-    },
-    "node_modules/bun-types": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.6.tgz",
-      "integrity": "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
+      "peer": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacheable": {
@@ -4503,6 +4306,7 @@
       "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
       "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/memory": "^2.0.7",
         "@cacheable/utils": "^2.3.3",
@@ -4516,6 +4320,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -4529,6 +4334,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -4540,11 +4346,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -4552,17 +4376,29 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chmodrp": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
       "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -4578,6 +4414,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4593,6 +4430,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4602,6 +4440,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -4617,6 +4456,7 @@
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
       "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "highlight.js": "^10.7.1",
@@ -4638,6 +4478,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4647,6 +4488,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4662,6 +4504,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4678,6 +4521,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4689,6 +4533,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4701,6 +4546,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4718,6 +4564,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -4736,6 +4583,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4745,6 +4593,7 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -4757,6 +4606,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -4771,6 +4621,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4780,6 +4631,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4795,6 +4647,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4807,6 +4660,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4824,6 +4678,7 @@
       "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.4.0.tgz",
       "integrity": "sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "axios": "^1.6.5",
         "debug": "^4",
@@ -4849,13 +4704,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/cmake-js/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4871,6 +4728,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4882,13 +4740,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -4898,6 +4758,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4910,6 +4771,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4918,13 +4780,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4938,6 +4802,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4947,6 +4812,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4956,6 +4822,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -4964,13 +4831,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/croner": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
       "integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0"
       }
@@ -4980,6 +4849,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4993,13 +4863,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5015,6 +4887,7 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -5031,6 +4904,7 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       },
@@ -5042,19 +4916,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/curve25519-js": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
       "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5076,11 +4953,22 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5090,6 +4978,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -5104,6 +4993,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5112,13 +5002,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5128,6 +5020,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5137,6 +5030,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
       "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5146,6 +5040,7 @@
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.38.tgz",
       "integrity": "sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "scripts/actions/documentation"
       ]
@@ -5155,6 +5050,7 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -5174,13 +5070,15 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -5196,6 +5094,7 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -5210,6 +5109,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
       "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5222,6 +5122,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -5235,13 +5136,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -5250,19 +5153,22 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5272,6 +5178,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -5284,6 +5191,7 @@
       "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
       "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5293,6 +5201,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5302,15 +5211,24 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -5323,6 +5241,7 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -5333,11 +5252,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5346,13 +5305,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -5374,6 +5335,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -5387,8 +5349,19 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -5396,6 +5369,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5405,6 +5379,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5414,6 +5389,7 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5422,13 +5398,25 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5472,6 +5460,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5481,6 +5470,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5496,7 +5486,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
@@ -5512,13 +5503,15 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -5534,7 +5527,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -5547,6 +5541,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -5569,6 +5564,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -5582,6 +5578,7 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
       "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
         "strtok3": "^10.3.4",
@@ -5600,6 +5597,7 @@
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
       "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5612,6 +5610,7 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
       "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "filename-reserved-regex": "^3.0.0"
       },
@@ -5627,6 +5626,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -5654,6 +5654,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5668,6 +5669,7 @@
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -5684,6 +5686,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -5696,6 +5699,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5712,6 +5716,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5724,6 +5729,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5733,6 +5739,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5742,6 +5749,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5756,6 +5764,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5768,6 +5777,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5775,11 +5785,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5790,6 +5816,7 @@
       "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -5809,6 +5836,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5818,6 +5846,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5830,6 +5859,7 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -5845,6 +5875,7 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -5859,6 +5890,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5868,6 +5900,7 @@
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5880,6 +5913,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -5904,6 +5938,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5917,6 +5952,7 @@
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -5931,6 +5967,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -5940,6 +5977,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
       "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
@@ -5963,6 +6001,7 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
       "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -5981,6 +6020,7 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5990,6 +6030,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6001,7 +6042,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/grammy": {
       "version": "1.39.3",
@@ -6024,6 +6066,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6044,6 +6087,7 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "jws": "^4.0.0"
@@ -6057,6 +6101,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6066,6 +6111,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6078,6 +6124,7 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -6092,13 +6139,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/hashery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -6111,6 +6160,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -6123,6 +6173,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6131,13 +6182,15 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6151,6 +6204,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -6163,6 +6217,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -6175,6 +6230,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -6195,6 +6251,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -6208,6 +6265,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -6230,6 +6288,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -6259,13 +6318,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6274,25 +6335,29 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -6302,6 +6367,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -6311,6 +6377,7 @@
       "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.3.tgz",
       "integrity": "sha512-ZMkxaopfwKHwmEuGDYx7giNBdLxbHbRCWcQVA1D2eqE4crUguupfxej6s7UqbidYEwT69dkyumYkY8DPHIxF9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tinyhttp/content-disposition": "^2.2.0",
         "async-retry": "^1.3.3",
@@ -6350,13 +6417,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
       "integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ipull/node_modules/parse-ms": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
       "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6369,6 +6438,7 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
       "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-ms": "^3.0.0"
       },
@@ -6383,13 +6453,15 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
       },
@@ -6405,6 +6477,7 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6416,13 +6489,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6435,6 +6510,7 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6446,13 +6522,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -6462,6 +6540,7 @@
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
       "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -6477,6 +6556,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6486,6 +6566,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -6495,6 +6576,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -6507,13 +6589,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -6526,6 +6610,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6538,6 +6623,7 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
@@ -6560,6 +6646,7 @@
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -6572,6 +6659,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6586,13 +6674,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6602,6 +6692,7 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -6613,6 +6704,7 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6633,6 +6725,7 @@
       "version": "2.0.1",
       "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "curve25519-js": "^0.0.4",
         "protobufjs": "6.8.8"
@@ -6642,13 +6735,15 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/libsignal/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/libsignal/node_modules/protobufjs": {
       "version": "6.8.8",
@@ -6656,6 +6751,7 @@
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6681,6 +6777,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -6689,13 +6786,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.0.1.tgz",
       "integrity": "sha512-Qt/Jl5dsNIsyCAZsHB6x3mbwHFn0HJbdmvF49sVX/bHgX2cW7+G+U+I67Zw+TPM1Sr21Gb2nfJMd2g6iUcI1EQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/linkedom": {
       "version": "0.18.12",
       "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
       "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",
@@ -6720,6 +6819,7 @@
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -6728,55 +6828,64 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
       "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0",
         "yoctocolors": "^2.1.1"
@@ -6792,13 +6901,22 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lowdb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
       "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "steno": "^4.0.2"
       },
@@ -6814,8 +6932,19 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -6823,6 +6952,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -6840,6 +6970,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6852,6 +6983,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6860,13 +6992,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6876,6 +7010,7 @@
       "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
       "integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^3.4.0"
       }
@@ -6885,6 +7020,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6897,6 +7033,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6906,6 +7043,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6918,6 +7056,7 @@
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6930,6 +7069,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
       "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -6945,6 +7085,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6954,6 +7095,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6963,6 +7105,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -6976,6 +7119,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6988,6 +7132,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -7016,6 +7161,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
@@ -7037,6 +7183,7 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -7054,6 +7201,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -7066,6 +7214,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7075,6 +7224,7 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7084,6 +7234,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
       "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -7092,7 +7243,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
       "integrity": "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -7110,6 +7262,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7119,6 +7272,7 @@
       "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.9.tgz",
       "integrity": "sha512-fvfW1dUgJdZAdTniC6MzLTMwnNUFKGKaUdRJ1OsveOYlfnPUETBU973CG89565txvbBowCQ4Czdeu3qSX8bNOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "https-proxy-agent": "^7.0.1",
         "ws": "^8.13.0",
@@ -7133,6 +7287,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7225,6 +7380,7 @@
       "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -7240,6 +7396,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -7252,6 +7409,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7261,6 +7419,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7273,6 +7432,7 @@
       "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.5.tgz",
       "integrity": "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/app": "^16.1.2",
         "@octokit/core": "^7.0.6",
@@ -7295,6 +7455,7 @@
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7304,6 +7465,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -7316,6 +7478,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7325,6 +7488,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
       },
@@ -7340,6 +7504,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
       "integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -7362,6 +7527,7 @@
       "integrity": "sha512-oHpsfvxCTDnRWcaG7M5cP4iLJQ0WnpTqN+3d+VbD/auMLi7mmXAOESVOLab0m457CKwvOxIYYsAlrOfqtzp5Lg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@agentclientprotocol/sdk": "0.13.1",
         "@aws-sdk/client-bedrock": "^3.980.0",
@@ -7430,6 +7596,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7439,6 +7606,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7448,6 +7616,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -7460,6 +7629,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
       "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -7476,6 +7646,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7485,6 +7656,7 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
       "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -7507,13 +7679,15 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ora/node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "is-unicode-supported": "^1.3.0"
@@ -7530,6 +7704,7 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7542,6 +7717,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -7559,6 +7735,7 @@
       "resolved": "https://registry.npmjs.org/osc-progress/-/osc-progress-0.3.0.tgz",
       "integrity": "sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7568,6 +7745,7 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7577,6 +7755,7 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -7592,13 +7771,15 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -7612,6 +7793,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -7624,6 +7806,7 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -7643,6 +7826,7 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -7655,19 +7839,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "peer": true
     },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
+      "license": "(MIT AND Zlib)",
+      "peer": true
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7679,13 +7866,15 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^6.0.1"
       }
@@ -7694,13 +7883,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7709,13 +7900,15 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7725,6 +7918,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -7741,9 +7935,27 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pdfjs-dist": {
@@ -7751,6 +7963,7 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
       "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.16.0 || >=22.3.0"
       },
@@ -7769,6 +7982,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
       "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -7791,6 +8005,7 @@
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "split2": "^4.0.0"
       }
@@ -7799,13 +8014,15 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/playwright-core": {
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
       "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -7813,11 +8030,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
       "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       },
@@ -7830,6 +8096,7 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -7840,38 +8107,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prism-media": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
-      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peerDependencies": {
-        "@discordjs/opus": ">=0.8.0 <1.0.0",
-        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -7887,13 +8128,15 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -7905,6 +8148,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -7915,6 +8159,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -7938,6 +8183,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -7951,6 +8197,7 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -7970,6 +8217,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7978,13 +8226,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7994,6 +8244,7 @@
       "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
       "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -8005,6 +8256,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -8014,6 +8266,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -8028,13 +8281,15 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8044,6 +8299,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -8059,6 +8315,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8074,6 +8331,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8088,6 +8346,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -8101,6 +8360,7 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -8110,6 +8370,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8119,6 +8380,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8128,6 +8390,7 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -8144,6 +8407,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -8156,6 +8420,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -8165,6 +8430,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -8180,6 +8446,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -8200,6 +8467,7 @@
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -8214,13 +8482,15 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8236,6 +8506,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -8247,11 +8518,57 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -8281,13 +8598,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8296,13 +8615,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8315,6 +8636,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -8341,6 +8663,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8350,6 +8673,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -8366,6 +8690,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -8384,19 +8709,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -8448,6 +8776,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8460,6 +8789,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8469,6 +8799,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -8488,6 +8819,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -8504,6 +8836,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8522,6 +8855,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8536,11 +8870,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/signal-polyfill": {
       "version": "0.2.2",
@@ -8554,6 +8896,7 @@
       "resolved": "https://registry.npmjs.org/signal-utils/-/signal-utils-0.21.1.tgz",
       "integrity": "sha512-i9cdLSvVH4j8ql8mz2lyrA93xL499P8wEbIev3ldSriXeUwqh+wM4Q5VPhIZ19gPtIS4BOopJuKB8l1+wH9LCg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "signal-polyfill": "^0.2.0"
       }
@@ -8563,6 +8906,7 @@
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.30.0.tgz",
       "integrity": "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -8583,13 +8927,15 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
       "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^5.0.0"
@@ -8606,6 +8952,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -8616,6 +8963,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -8630,6 +8978,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8644,6 +8993,7 @@
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
       "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -8652,6 +9002,17 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8662,6 +9023,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8672,6 +9034,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -8681,6 +9044,7 @@
       "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.7-alpha.2.tgz",
       "integrity": "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==",
       "license": "MIT OR Apache",
+      "peer": true,
       "optionalDependencies": {
         "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
         "sqlite-vec-darwin-x64": "0.1.7-alpha.2",
@@ -8689,76 +9053,19 @@
         "sqlite-vec-windows-x64": "0.1.7-alpha.2"
       }
     },
-    "node_modules/sqlite-vec-darwin-arm64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-darwin-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-arm64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-windows-x64": {
-      "version": "0.1.7-alpha.2",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.7-alpha.2.tgz",
-      "integrity": "sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8774,6 +9081,7 @@
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8786,6 +9094,7 @@
       "resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
       "integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
         "ansi-styles": "^6.2.1",
@@ -8800,13 +9109,15 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stdout-update/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -8824,6 +9135,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
       "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8836,6 +9148,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8845,6 +9158,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8860,6 +9174,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8874,6 +9189,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8883,6 +9199,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8892,6 +9209,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8904,6 +9222,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8913,6 +9232,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8922,6 +9242,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8934,6 +9255,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -8950,6 +9272,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8962,6 +9285,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8971,6 +9295,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8985,13 +9310,15 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/strtok3": {
       "version": "10.3.4",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
       "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
       },
@@ -9008,6 +9335,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9021,6 +9349,7 @@
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -9038,6 +9367,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9047,6 +9377,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -9056,6 +9387,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -9068,8 +9400,53 @@
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -9077,6 +9454,7 @@
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
       "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9086,6 +9464,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -9095,6 +9474,7 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
       "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
@@ -9112,25 +9492,29 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tslog": {
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
       "integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -9143,6 +9527,7 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6.x"
       }
@@ -9152,6 +9537,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -9166,6 +9552,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9175,6 +9562,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -9192,7 +9580,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9205,19 +9592,22 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uhyphen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9230,6 +9620,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
       "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -9238,25 +9629,29 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
       "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -9266,6 +9661,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9274,19 +9670,22 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/validate-npm-package-name": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
       "integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -9296,8 +9695,158 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -9305,6 +9854,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -9313,13 +9863,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -9330,6 +9882,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -9340,11 +9893,29 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -9353,13 +9924,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -9378,6 +9951,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9395,6 +9969,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9404,6 +9979,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9419,6 +9995,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9430,13 +10007,15 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -9453,13 +10032,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9481,6 +10062,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9489,13 +10071,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9511,6 +10095,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -9529,6 +10114,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9538,6 +10124,7 @@
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9560,6 +10147,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -1,53 +1,57 @@
 {
-  "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.5.0",
-  "type": "module",
-  "description": "OpenClaw Hyperspell memory plugin",
-  "license": "MIT",
-  "main": "./index.ts",
-  "files": [
-    "*.ts",
-    "commands/",
-    "hooks/",
-    "tools/",
-    "sync/",
-    "graph/",
-    "lib/",
-    "types/",
-    "openclaw.plugin.json",
-    "README.md"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hyperspell/openclaw-hyperspell.git"
-  },
-  "keywords": [
-    "openclaw",
-    "hyperspell",
-    "memory",
-    "rag",
-    "ai",
-    "plugin"
-  ],
-  "dependencies": {
-    "@clack/prompts": "^1.0.0",
-    "@sinclair/typebox": "^0.34.0",
-    "hyperspell": "^0.30.0"
-  },
-  "peerDependencies": {
-    "openclaw": ">=2026.1.29"
-  },
-  "scripts": {
-    "check-types": "tsc --noEmit",
-    "lint": "bunx @biomejs/biome ci .",
-    "lint:fix": "bunx @biomejs/biome check --write ."
-  },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3"
-  }
+	"name": "@hyperspell/openclaw-hyperspell",
+	"version": "0.5.0",
+	"type": "module",
+	"description": "OpenClaw Hyperspell memory plugin",
+	"license": "MIT",
+	"main": "./index.ts",
+	"files": [
+		"*.ts",
+		"commands/",
+		"hooks/",
+		"tools/",
+		"sync/",
+		"graph/",
+		"lib/",
+		"types/",
+		"openclaw.plugin.json",
+		"README.md"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/hyperspell/openclaw-hyperspell.git"
+	},
+	"keywords": [
+		"openclaw",
+		"hyperspell",
+		"memory",
+		"rag",
+		"ai",
+		"plugin"
+	],
+	"dependencies": {
+		"@clack/prompts": "^1.0.0",
+		"@sinclair/typebox": "^0.34.0",
+		"hyperspell": "^0.30.0"
+	},
+	"peerDependencies": {
+		"openclaw": ">=2026.1.29"
+	},
+	"scripts": {
+		"check-types": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome ci .",
+		"lint:fix": "bunx @biomejs/biome check --write .",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"openclaw": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^2.1.0"
+	}
 }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -1,183 +1,190 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import type { HyperspellClient } from "../client.ts"
-import { log } from "../logger.ts"
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { HyperspellClient } from "../client.ts";
+import { log } from "../logger.ts";
 
-const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/;
 
 interface MarkdownFile {
-  filePath: string
-  title: string
-  content: string
-  hyperspellId: string | null
+	filePath: string;
+	title: string;
+	content: string;
+	hyperspellId: string | null;
 }
 
 /**
  * Parse frontmatter from markdown content
  */
-function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
-  const match = content.match(FRONTMATTER_REGEX)
-  if (!match) {
-    return { frontmatter: {}, body: content }
-  }
+function parseFrontmatter(content: string): {
+	frontmatter: Record<string, string>;
+	body: string;
+} {
+	const match = content.match(FRONTMATTER_REGEX);
+	if (!match) {
+		return { frontmatter: {}, body: content };
+	}
 
-  const frontmatterText = match[1]
-  const body = content.slice(match[0].length)
-  const frontmatter: Record<string, string> = {}
+	const frontmatterText = match[1];
+	const body = content.slice(match[0].length);
+	const frontmatter: Record<string, string> = {};
 
-  for (const line of frontmatterText.split("\n")) {
-    const colonIndex = line.indexOf(":")
-    if (colonIndex > 0) {
-      const key = line.slice(0, colonIndex).trim()
-      const value = line.slice(colonIndex + 1).trim()
-      frontmatter[key] = value
-    }
-  }
+	for (const line of frontmatterText.split("\n")) {
+		const colonIndex = line.indexOf(":");
+		if (colonIndex > 0) {
+			const key = line.slice(0, colonIndex).trim();
+			const value = line.slice(colonIndex + 1).trim();
+			frontmatter[key] = value;
+		}
+	}
 
-  return { frontmatter, body }
+	return { frontmatter, body };
 }
 
 /**
  * Serialize frontmatter back to string
  */
 function serializeFrontmatter(frontmatter: Record<string, string>): string {
-  const lines = Object.entries(frontmatter).map(([key, value]) => `${key}: ${value}`)
-  return `---\n${lines.join("\n")}\n---\n`
+	const lines = Object.entries(frontmatter).map(
+		([key, value]) => `${key}: ${value}`,
+	);
+	return `---\n${lines.join("\n")}\n---\n`;
 }
 
 /**
  * Read a markdown file and parse its content
  */
 function readMarkdownFile(filePath: string): MarkdownFile | null {
-  try {
-    const content = fs.readFileSync(filePath, "utf-8")
-    const { frontmatter, body } = parseFrontmatter(content)
-    const title = frontmatter.title || path.basename(filePath, ".md")
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		const { frontmatter, body } = parseFrontmatter(content);
+		const title = frontmatter.title || path.basename(filePath, ".md");
 
-    return {
-      filePath,
-      title,
-      content: body.trim(),
-      hyperspellId: frontmatter.hyperspell_id || null,
-    }
-  } catch (err) {
-    log.error(`Failed to read markdown file: ${filePath}`, err)
-    return null
-  }
+		return {
+			filePath,
+			title,
+			content: body.trim(),
+			hyperspellId: frontmatter.hyperspell_id || null,
+		};
+	} catch (err) {
+		log.error(`Failed to read markdown file: ${filePath}`, err);
+		return null;
+	}
 }
 
 /**
  * Update the hyperspell_id in the frontmatter of a markdown file
  */
 function updateFrontmatterId(filePath: string, hyperspellId: string): void {
-  try {
-    const content = fs.readFileSync(filePath, "utf-8")
-    const { frontmatter, body } = parseFrontmatter(content)
+	try {
+		const content = fs.readFileSync(filePath, "utf-8");
+		const { frontmatter, body } = parseFrontmatter(content);
 
-    frontmatter.hyperspell_id = hyperspellId
+		frontmatter.hyperspell_id = hyperspellId;
 
-    const newContent = serializeFrontmatter(frontmatter) + body
-    fs.writeFileSync(filePath, newContent)
+		const newContent = serializeFrontmatter(frontmatter) + body;
+		fs.writeFileSync(filePath, newContent);
 
-    log.debug(`Updated frontmatter in ${filePath} with hyperspell_id: ${hyperspellId}`)
-  } catch (err) {
-    log.error(`Failed to update frontmatter in ${filePath}`, err)
-  }
+		log.debug(
+			`Updated frontmatter in ${filePath} with hyperspell_id: ${hyperspellId}`,
+		);
+	} catch (err) {
+		log.error(`Failed to update frontmatter in ${filePath}`, err);
+	}
 }
 
 /**
  * Get all markdown files from the memory directory, including subdirectories
  */
 export function getMemoryFiles(workspaceDir: string): string[] {
-  const memoryDir = path.join(workspaceDir, "memory")
+	const memoryDir = path.join(workspaceDir, "memory");
 
-  if (!fs.existsSync(memoryDir)) {
-    return []
-  }
+	if (!fs.existsSync(memoryDir)) {
+		return [];
+	}
 
-  const results: string[] = []
+	const results: string[] = [];
 
-  function walk(dir: string): void {
-    try {
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = path.join(dir, entry.name)
-        if (entry.isDirectory()) {
-          walk(fullPath)
-        } else if (entry.name.endsWith(".md")) {
-          results.push(fullPath)
-        }
-      }
-    } catch (err) {
-      log.error(`Failed to read directory: ${dir}`, err)
-    }
-  }
+	function walk(dir: string): void {
+		try {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const fullPath = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(fullPath);
+				} else if (entry.name.endsWith(".md")) {
+					results.push(fullPath);
+				}
+			}
+		} catch (err) {
+			log.error(`Failed to read directory: ${dir}`, err);
+		}
+	}
 
-  walk(memoryDir)
-  return results
+	walk(memoryDir);
+	return results;
 }
 
 /**
  * Sync a single markdown file to Hyperspell
  */
 export async function syncMarkdownFile(
-  client: HyperspellClient,
-  filePath: string,
+	client: HyperspellClient,
+	filePath: string,
 ): Promise<{ success: boolean; resourceId?: string; error?: string }> {
-  const file = readMarkdownFile(filePath)
-  if (!file) {
-    return { success: false, error: "Failed to read file" }
-  }
+	const file = readMarkdownFile(filePath);
+	if (!file) {
+		return { success: false, error: "Failed to read file" };
+	}
 
-  if (!file.content) {
-    return { success: false, error: "File has no content" }
-  }
+	if (!file.content) {
+		return { success: false, error: "File has no content" };
+	}
 
-  try {
-    const result = await client.addMemory(file.content, {
-      title: file.title,
-      resourceId: file.hyperspellId || undefined,
-      collection: "openclaw",
-      metadata: {
-        openclaw_source: "memory_sync",
-        file_path: filePath,
-      },
-    })
+	try {
+		const result = await client.addMemory(file.content, {
+			title: file.title,
+			resourceId: file.hyperspellId || undefined,
+			collection: "openclaw",
+			metadata: {
+				openclaw_source: "memory_sync",
+				file_path: filePath,
+			},
+		});
 
-    // Update frontmatter with new resource ID if it changed or was newly created
-    if (result.resourceId !== file.hyperspellId) {
-      updateFrontmatterId(filePath, result.resourceId)
-    }
+		// Update frontmatter with new resource ID if it changed or was newly created
+		if (result.resourceId !== file.hyperspellId) {
+			updateFrontmatterId(filePath, result.resourceId);
+		}
 
-    return { success: true, resourceId: result.resourceId }
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
-    log.error(`Failed to sync ${filePath}`, err)
-    return { success: false, error: errorMsg }
-  }
+		return { success: true, resourceId: result.resourceId };
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		log.error(`Failed to sync ${filePath}`, err);
+		return { success: false, error: errorMsg };
+	}
 }
 
 /**
  * Sync all markdown files in the memory directory
  */
 export async function syncAllMemoryFiles(
-  client: HyperspellClient,
-  workspaceDir: string,
+	client: HyperspellClient,
+	workspaceDir: string,
 ): Promise<{ synced: number; failed: number; errors: string[] }> {
-  const files = getMemoryFiles(workspaceDir)
-  let synced = 0
-  let failed = 0
-  const errors: string[] = []
+	const files = getMemoryFiles(workspaceDir);
+	let synced = 0;
+	let failed = 0;
+	const errors: string[] = [];
 
-  for (const filePath of files) {
-    const result = await syncMarkdownFile(client, filePath)
-    if (result.success) {
-      synced++
-      log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`)
-    } else {
-      failed++
-      errors.push(`${path.basename(filePath)}: ${result.error}`)
-    }
-  }
+	for (const filePath of files) {
+		const result = await syncMarkdownFile(client, filePath);
+		if (result.success) {
+			synced++;
+			log.info(`Synced: ${path.basename(filePath)} -> ${result.resourceId}`);
+		} else {
+			failed++;
+			errors.push(`${path.basename(filePath)}: ${result.error}`);
+		}
+	}
 
-  return { synced, failed, errors }
+	return { synced, failed, errors };
 }

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -1,56 +1,58 @@
-import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { log } from "../logger.ts"
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { log } from "../logger.ts";
 
 export function registerRememberTool(
-  api: OpenClawPluginApi,
-  client: HyperspellClient,
-  _cfg: HyperspellConfig,
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
 ): void {
-  api.registerTool(
-    {
-      name: "hyperspell_remember",
-      label: "Memory Store",
-      description: "Save important information to the user's memory.",
-      parameters: Type.Object({
-        text: Type.String({ description: "Information to remember" }),
-        title: Type.Optional(
-          Type.String({ description: "Optional title for the memory" }),
-        ),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { text: string; title?: string },
-      ) {
-        log.debug(`remember tool: "${params.text.slice(0, 50)}..."`)
+	api.registerTool(
+		{
+			name: "hyperspell_remember",
+			label: "Memory Store",
+			description: "Save important information to the user's memory.",
+			parameters: Type.Object({
+				text: Type.String({ description: "Information to remember" }),
+				title: Type.Optional(
+					Type.String({ description: "Optional title for the memory" }),
+				),
+			}),
+			async execute(
+				_toolCallId: string,
+				params: { text: string; title?: string },
+			) {
+				log.debug(`remember tool: "${params.text.slice(0, 50)}..."`);
 
-        try {
-          await client.addMemory(params.text, {
-            title: params.title,
-            metadata: { source: "openclaw_tool" },
-          })
+				try {
+					await client.addMemory(params.text, {
+						title: params.title,
+						metadata: { source: "openclaw_tool" },
+					});
 
-          const preview =
-            params.text.length > 80 ? `${params.text.slice(0, 80)}…` : params.text
+					const preview =
+						params.text.length > 80
+							? `${params.text.slice(0, 80)}…`
+							: params.text;
 
-          return {
-            content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
-          }
-        } catch (err) {
-          log.error("remember tool failed", err)
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Failed to store memory: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-          }
-        }
-      },
-    },
-    { name: "hyperspell_remember" },
-  )
+					return {
+						content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
+					};
+				} catch (err) {
+					log.error("remember tool failed", err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Failed to store memory: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_remember" },
+	);
 }

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -1,92 +1,92 @@
-import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import type { HyperspellClient } from "../client.ts"
-import type { HyperspellConfig } from "../config.ts"
-import { log } from "../logger.ts"
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { log } from "../logger.ts";
 
 export function registerSearchTool(
-  api: OpenClawPluginApi,
-  client: HyperspellClient,
-  _cfg: HyperspellConfig,
+	api: OpenClawPluginApi,
+	client: HyperspellClient,
+	_cfg: HyperspellConfig,
 ): void {
-  api.registerTool(
-    {
-      name: "hyperspell_search",
-      label: "Memory Search",
-      description:
-        "Search through the user's connected sources (Notion, Slack, Gmail, Google Drive, etc.) for relevant information.",
-      parameters: Type.Object({
-        query: Type.String({ description: "Search query" }),
-        limit: Type.Optional(
-          Type.Number({ description: "Max results (default: 5)" }),
-        ),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { query: string; limit?: number },
-      ) {
-        const limit = params.limit ?? 5
-        log.debug(`search tool: query="${params.query}" limit=${limit}`)
+	api.registerTool(
+		{
+			name: "hyperspell_search",
+			label: "Memory Search",
+			description:
+				"Search through the user's connected sources (Notion, Slack, Gmail, Google Drive, etc.) for relevant information.",
+			parameters: Type.Object({
+				query: Type.String({ description: "Search query" }),
+				limit: Type.Optional(
+					Type.Number({ description: "Max results (default: 5)" }),
+				),
+			}),
+			async execute(
+				_toolCallId: string,
+				params: { query: string; limit?: number },
+			) {
+				const limit = params.limit ?? 5;
+				log.debug(`search tool: query="${params.query}" limit=${limit}`);
 
-        try {
-          const response = await client.searchRaw(params.query, { limit })
-          const documents = (response.documents ?? []) as Array<{
-            source: string
-            resource_id: string
-            score?: number
-            summary?: string
-            title?: string
-            metadata?: Record<string, unknown>
-            highlights?: Array<{ text: string }>
-            data?: Array<{ text: string }>
-          }>
+				try {
+					const response = await client.searchRaw(params.query, { limit });
+					const documents = (response.documents ?? []) as Array<{
+						source: string;
+						resource_id: string;
+						score?: number;
+						summary?: string;
+						title?: string;
+						metadata?: Record<string, unknown>;
+						highlights?: Array<{ text: string }>;
+						data?: Array<{ text: string }>;
+					}>;
 
-          if (documents.length === 0) {
-            return {
-              content: [
-                { type: "text" as const, text: "No relevant memories found." },
-              ],
-            }
-          }
+					if (documents.length === 0) {
+						return {
+							content: [
+								{ type: "text" as const, text: "No relevant memories found." },
+							],
+						};
+					}
 
-          const formattedDocs = documents
-            .map((doc, i) => {
-              const relevance = doc.score
-                ? `${Math.round(doc.score * 100)}%`
-                : "N/A"
-              const title = doc.title || "(untitled)"
-              const summary = doc.summary || "(no summary)"
-              return `${i + 1}. Source: ${doc.source}\n   Title: ${title}\n   Summary: ${summary}\n   Relevance: ${relevance}`
-            })
-            .join("\n\n")
+					const formattedDocs = documents
+						.map((doc, i) => {
+							const relevance = doc.score
+								? `${Math.round(doc.score * 100)}%`
+								: "N/A";
+							const title = doc.title || "(untitled)";
+							const summary = doc.summary || "(no summary)";
+							return `${i + 1}. Source: ${doc.source}\n   Title: ${title}\n   Summary: ${summary}\n   Relevance: ${relevance}`;
+						})
+						.join("\n\n");
 
-          const text = `Found ${documents.length} memories:\n\n${formattedDocs}`
+					const text = `Found ${documents.length} memories:\n\n${formattedDocs}`;
 
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text,
-              },
-            ],
-            details: {
-              count: documents.length,
-              documents,
-            },
-          }
-        } catch (err) {
-          log.error("search tool failed", err)
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-          }
-        }
-      },
-    },
-    { name: "hyperspell_search" },
-  )
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text,
+							},
+						],
+						details: {
+							count: documents.length,
+							documents,
+						},
+					};
+				} catch (err) {
+					log.error("search tool failed", err);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+					};
+				}
+			},
+		},
+		{ name: "hyperspell_search" },
+	);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "outDir": "./dist",
-    "rootDir": ".",
-    "types": ["node"],
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
-    "typeRoots": ["./types", "./node_modules/@types"]
-  },
-  "include": ["*.ts", "**/*.ts", "types/**/*.d.ts"],
-  "exclude": ["node_modules", "dist"]
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": ".",
+		"types": ["node"],
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"typeRoots": ["./types", "./node_modules/@types"]
+	},
+	"include": ["*.ts", "**/*.ts", "types/**/*.d.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/types/openclaw.d.ts
+++ b/types/openclaw.d.ts
@@ -1,60 +1,75 @@
 declare module "openclaw/plugin-sdk" {
-  import type { Command } from "commander"
+	import type { Command } from "commander";
 
-  export interface OpenClawPluginCliContext {
-    program: Command
-    config: unknown
-    workspaceDir?: string
-    logger: {
-      info: (message: string, ...args: unknown[]) => void
-      warn: (message: string, ...args: unknown[]) => void
-      error: (message: string, ...args: unknown[]) => void
-      debug: (message: string, ...args: unknown[]) => void
-    }
-  }
+	export interface OpenClawPluginCliContext {
+		program: Command;
+		config: unknown;
+		workspaceDir?: string;
+		logger: {
+			info: (message: string, ...args: unknown[]) => void;
+			warn: (message: string, ...args: unknown[]) => void;
+			error: (message: string, ...args: unknown[]) => void;
+			debug: (message: string, ...args: unknown[]) => void;
+		};
+	}
 
-  export type OpenClawPluginCliRegistrar = (ctx: OpenClawPluginCliContext) => void | Promise<void>
+	export type OpenClawPluginCliRegistrar = (
+		ctx: OpenClawPluginCliContext,
+	) => void | Promise<void>;
 
-  export interface OpenClawPluginApi {
-    pluginConfig: unknown
-    workspaceDir?: string
-    logger: {
-      info: (message: string, ...args: unknown[]) => void
-      warn: (message: string, ...args: unknown[]) => void
-      error: (message: string, ...args: unknown[]) => void
-      debug: (message: string, ...args: unknown[]) => void
-    }
-    registerCommand(options: {
-      name: string
-      description: string
-      acceptsArgs: boolean
-      requireAuth: boolean
-      handler: (ctx: { args?: string; senderId?: string; channel?: string }) => Promise<{ text: string }>
-    }): void
-    registerCli(registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }): void
-    registerTool<T = unknown>(
-      options: {
-        name: string
-        label: string
-        description: string
-        parameters: unknown
-        execute: (
-          toolCallId: string,
-          params: T,
-        ) => Promise<{
-          content: Array<{ type: "text"; text: string }>
-          details?: Record<string, unknown>
-        }>
-      },
-      meta: { name: string },
-    ): void
-    on(event: string, handler: (event: Record<string, unknown>, ctx?: Record<string, unknown>) => Promise<{ prependContext?: string } | void> | void): void
-    registerService(options: {
-      id: string
-      start: () => void
-      stop: () => void
-    }): void
-  }
+	export interface OpenClawPluginApi {
+		pluginConfig: unknown;
+		workspaceDir?: string;
+		logger: {
+			info: (message: string, ...args: unknown[]) => void;
+			warn: (message: string, ...args: unknown[]) => void;
+			error: (message: string, ...args: unknown[]) => void;
+			debug: (message: string, ...args: unknown[]) => void;
+		};
+		registerCommand(options: {
+			name: string;
+			description: string;
+			acceptsArgs: boolean;
+			requireAuth: boolean;
+			handler: (ctx: {
+				args?: string;
+				senderId?: string;
+				channel?: string;
+			}) => Promise<{ text: string }>;
+		}): void;
+		registerCli(
+			registrar: OpenClawPluginCliRegistrar,
+			opts?: { commands?: string[] },
+		): void;
+		registerTool<T = unknown>(
+			options: {
+				name: string;
+				label: string;
+				description: string;
+				parameters: unknown;
+				execute: (
+					toolCallId: string,
+					params: T,
+				) => Promise<{
+					content: Array<{ type: "text"; text: string }>;
+					details?: Record<string, unknown>;
+				}>;
+			},
+			meta: { name: string },
+		): void;
+		on(
+			event: string,
+			handler: (
+				event: Record<string, unknown>,
+				ctx?: Record<string, unknown>,
+			) => Promise<{ prependContext?: string } | void> | void,
+		): void;
+		registerService(options: {
+			id: string;
+			start: () => void;
+			stop: () => void;
+		}): void;
+	}
 
-  export function stringEnum<T extends string>(values: readonly T[]): unknown
+	export function stringEnum<T extends string>(values: readonly T[]): unknown;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["**/*.test.ts"],
+		exclude: ["node_modules/**", "dist/**"],
+	},
+});


### PR DESCRIPTION
## Summary

- New `agent_end` hook writes every completed OpenClaw turn to a dedicated `openclaw_conversations` collection in Hyperspell — prior sessions become searchable context. Gated by `captureConversations` (default `true`).
- Fix `client.addMemory()` so caller-provided `metadata.openclaw_source` wins over the hardcoded `"command"` default — lets the capture hook tag its writes as `"conversation"`.
- Scaffolding: add `vitest`, `.github/workflows/ci.yml` (Node 20/22 matrix running `check-types`, `lint`, `test`), and 8 unit tests covering the handler and the metadata fix.

Implements the capture piece of `docs/2026-03-26-conversation-capture-aggressive-context-design.md`. Session-start replay and the "try harder" auto-context fallback are deferred to follow-ups.

## What's in each commit

1. **`docs: add conversation capture and aggressive context retrieval design spec`** (already on local `main`, pushed here for the first time)
2. **`docs: address spec review feedback`** (same)
3. **`style: apply biome formatting to pre-existing files`** — pure formatting, no logic changes. The existing `lint` script was never enforced by CI so the repo had drifted from biome's default style. Reformatted to unblock the new CI lint step.
4. **`feat: capture every agent turn to Hyperspell`** — the actual feature. Review this commit for the real changes.

## Design notes

- **Deterministic `resourceId`** (`openclaw_conv_{sessionKey}_{turnIndex}` where `turnIndex = Math.floor(messages.length / 2)`) so retries and plugin restarts dedupe at the Hyperspell layer instead of producing duplicates.
- **Fire-and-forget** — `client.addMemory` failures are logged and swallowed so a Hyperspell outage can never break a user's session.
- **10k char transcript cap** — protects against pathological turns with multi-MB tool output.
- **Content extraction handles both shapes** — string `content` and content-block arrays (`[{ type: "text", text }, ...]`), skipping `tool_use`/etc. blocks. Pattern matches the existing LanceDB plugin.

## Test plan

- [x] `npm test` — 8/8 pass (happy path, `success: false` skip, content-block extraction, deterministic id, fire-and-forget, 10k truncation, metadata default + override)
- [x] `npm run check-types` — clean
- [x] `npx @biomejs/biome ci .` — 0 errors (matches the lint CI step)
- [ ] Smoke test against a live Hyperspell instance to confirm the hook actually writes when an agent turn completes
- [ ] Verify retries produce the same `resourceId` end-to-end (Hyperspell-side dedup behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)