### PR TITLE
Ship compiled runtime + declare tool contracts (v0.13.0)

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -340,6 +340,14 @@ async function runSetup(): Promise<void> {
         relevanceThreshold: 0.6,
         debug: false,
         knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+        startupOrientation: {
+          enabled: false,
+          recentDays: 7,
+          recentLimit: 5,
+          loopsLimit: 3,
+          recentQuery: "conversation session interaction",
+          loopsQuery: "open tasks pending questions unfinished promised need to follow up",
+        },
       })
 
       const result = await syncAllMemoryFiles(hyperspellClient, workspaceDir)

--- a/config.test.ts
+++ b/config.test.ts
@@ -200,3 +200,33 @@ test("parseConfig — valid scoping parses", () => {
   assert.equal(cfg.multiUser?.scoping?.collections?.family, "household")
   assert.equal(cfg.multiUser?.scoping?.voiceId?.confidenceThreshold, 0.8)
 })
+
+test("parseConfig — startupOrientation defaults to disabled with sensible values", () => {
+  const cfg = parseConfig(base)
+  assert.equal(cfg.startupOrientation.enabled, false)
+  assert.equal(cfg.startupOrientation.recentDays, 7)
+  assert.equal(cfg.startupOrientation.recentLimit, 5)
+  assert.equal(cfg.startupOrientation.loopsLimit, 3)
+  assert.ok(cfg.startupOrientation.recentQuery.length > 0)
+  assert.ok(cfg.startupOrientation.loopsQuery.length > 0)
+})
+
+test("parseConfig — startupOrientation accepts overrides", () => {
+  const cfg = parseConfig({
+    ...base,
+    startupOrientation: {
+      enabled: true,
+      recentDays: 14,
+      recentLimit: 3,
+      loopsLimit: 5,
+      recentQuery: "custom recent",
+      loopsQuery: "custom loops",
+    },
+  })
+  assert.equal(cfg.startupOrientation.enabled, true)
+  assert.equal(cfg.startupOrientation.recentDays, 14)
+  assert.equal(cfg.startupOrientation.recentLimit, 3)
+  assert.equal(cfg.startupOrientation.loopsLimit, 5)
+  assert.equal(cfg.startupOrientation.recentQuery, "custom recent")
+  assert.equal(cfg.startupOrientation.loopsQuery, "custom loops")
+})

--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,7 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
 export type HyperspellSource =
 	| "reddit"
 	| "notion"
@@ -430,33 +434,27 @@ export const hyperspellConfigSchema = {
  * Resolve OpenClaw state directory (matches OpenClaw's own logic).
  */
 export function resolveStateDir(): string {
-	const { homedir } = require("node:os");
-	const path = require("node:path");
-
 	const override =
 		process.env.OPENCLAW_STATE_DIR?.trim() ||
 		process.env.CLAWDBOT_STATE_DIR?.trim();
 	if (override) {
 		return override.startsWith("~")
-			? override.replace(/^~(?=$|[\\/])/, homedir())
+			? override.replace(/^~(?=$|[\\/])/, os.homedir())
 			: path.resolve(override);
 	}
-	return path.join(homedir(), ".openclaw");
+	return path.join(os.homedir(), ".openclaw");
 }
 
 /**
  * Resolve OpenClaw config file path (matches OpenClaw's own logic).
  */
 export function resolveConfigPath(): string {
-	const path = require("node:path");
-
 	const override =
 		process.env.OPENCLAW_CONFIG_PATH?.trim() ||
 		process.env.CLAWDBOT_CONFIG_PATH?.trim();
 	if (override) {
-		const { homedir } = require("node:os");
 		return override.startsWith("~")
-			? override.replace(/^~(?=$|[\\/])/, homedir())
+			? override.replace(/^~(?=$|[\\/])/, os.homedir())
 			: path.resolve(override);
 	}
 	return path.join(resolveStateDir(), "openclaw.json");
@@ -466,10 +464,6 @@ export function resolveConfigPath(): string {
  * Get the workspace directory from OpenClaw config
  */
 export function getWorkspaceDir(): string {
-	const { homedir } = require("node:os");
-	const fs = require("node:fs");
-	const path = require("node:path");
-
 	// Resolve config path
 	const override =
 		process.env.OPENCLAW_CONFIG_PATH?.trim() ||
@@ -477,7 +471,7 @@ export function getWorkspaceDir(): string {
 	let configPath: string;
 	if (override) {
 		configPath = override.startsWith("~")
-			? override.replace(/^~(?=$|[\\/])/, homedir())
+			? override.replace(/^~(?=$|[\\/])/, os.homedir())
 			: path.resolve(override);
 	} else {
 		const stateDir =
@@ -485,9 +479,9 @@ export function getWorkspaceDir(): string {
 			process.env.CLAWDBOT_STATE_DIR?.trim();
 		const resolvedStateDir = stateDir
 			? stateDir.startsWith("~")
-				? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+				? stateDir.replace(/^~(?=$|[\\/])/, os.homedir())
 				: path.resolve(stateDir)
-			: path.join(homedir(), ".openclaw");
+			: path.join(os.homedir(), ".openclaw");
 		configPath = path.join(resolvedStateDir, "openclaw.json");
 	}
 
@@ -499,7 +493,7 @@ export function getWorkspaceDir(): string {
 			const workspace = config?.agents?.defaults?.workspace;
 			if (workspace) {
 				return workspace.startsWith("~")
-					? workspace.replace(/^~(?=$|[\\/])/, homedir())
+					? workspace.replace(/^~(?=$|[\\/])/, os.homedir())
 					: workspace;
 			}
 		} catch (_e) {
@@ -513,8 +507,8 @@ export function getWorkspaceDir(): string {
 		process.env.CLAWDBOT_STATE_DIR?.trim();
 	const resolvedStateDir = stateDir
 		? stateDir.startsWith("~")
-			? stateDir.replace(/^~(?=$|[\\/])/, homedir())
+			? stateDir.replace(/^~(?=$|[\\/])/, os.homedir())
 			: path.resolve(stateDir)
-		: path.join(homedir(), ".openclaw");
+		: path.join(os.homedir(), ".openclaw");
 	return path.join(resolvedStateDir, "workspace");
 }

--- a/config.ts
+++ b/config.ts
@@ -25,6 +25,15 @@ export type AutoTraceConfig = {
 	metadata?: Record<string, string | number | boolean>;
 };
 
+export type StartupOrientationConfig = {
+	enabled: boolean;
+	recentDays: number;
+	recentLimit: number;
+	loopsLimit: number;
+	recentQuery: string;
+	loopsQuery: string;
+};
+
 export type UserProfile = {
 	userId: string;
 	name: string;
@@ -81,6 +90,7 @@ export type HyperspellConfig = {
 	autoTrace: AutoTraceConfig;
 	emotionalContext: boolean;
 	relationshipId?: string;
+	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
 	sources: HyperspellSource[];
 	maxResults: number;
@@ -97,6 +107,7 @@ const ALLOWED_KEYS = [
 	"autoTrace",
 	"emotionalContext",
 	"relationshipId",
+	"startupOrientation",
 	"syncMemories",
 	"sources",
 	"maxResults",
@@ -369,6 +380,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 
 	const kgRaw = (cfg.knowledgeGraph ?? {}) as Record<string, unknown>;
 	const atRaw = (cfg.autoTrace ?? {}) as Record<string, unknown>;
+	const soRaw = (cfg.startupOrientation ?? {}) as Record<string, unknown>;
 
 	return {
 		apiKey,
@@ -385,6 +397,17 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 		},
 		emotionalContext: (cfg.emotionalContext as boolean) ?? false,
 		relationshipId: cfg.relationshipId as string | undefined,
+		startupOrientation: {
+			enabled: (soRaw.enabled as boolean) ?? false,
+			recentDays: (soRaw.recentDays as number) ?? 7,
+			recentLimit: (soRaw.recentLimit as number) ?? 5,
+			loopsLimit: (soRaw.loopsLimit as number) ?? 3,
+			recentQuery:
+				(soRaw.recentQuery as string) ?? "conversation session interaction",
+			loopsQuery:
+				(soRaw.loopsQuery as string) ??
+				"open tasks pending questions unfinished promised need to follow up",
+		},
 		syncMemories: (cfg.syncMemories as boolean) ?? false,
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -1,0 +1,245 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { HyperspellClient, SearchResult } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import {
+	buildStartupOrientationCompactionHandler,
+	buildStartupOrientationHandler,
+	buildStartupOrientationSessionCleanupHandler,
+} from "./startup-orientation.ts";
+
+type SearchCall = {
+	query: string;
+	options?: Parameters<HyperspellClient["search"]>[1];
+};
+
+function makeClient(responses: {
+	recent?: SearchResult[];
+	loops?: SearchResult[];
+}) {
+	const calls: SearchCall[] = [];
+	const client = {
+		calls,
+		async search(
+			query: string,
+			options?: Parameters<HyperspellClient["search"]>[1],
+		) {
+			calls.push({ query, options });
+			if (options?.after) return responses.recent ?? [];
+			return responses.loops ?? [];
+		},
+	};
+	return client;
+}
+
+function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
+	return {
+		apiKey: "k",
+		autoContext: false,
+		autoTrace: { enabled: false, extract: ["procedure"] },
+		emotionalContext: false,
+		startupOrientation: {
+			enabled: true,
+			recentDays: 7,
+			recentLimit: 5,
+			loopsLimit: 3,
+			recentQuery: "conversation session interaction",
+			loopsQuery: "open tasks pending questions",
+		},
+		syncMemories: false,
+		sources: [],
+		maxResults: 10,
+		relevanceThreshold: 0.6,
+		debug: false,
+		knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+		...overrides,
+	};
+}
+
+function makeResult(partial: Partial<SearchResult>): SearchResult {
+	return {
+		resourceId: "r1",
+		title: "some session",
+		source: "trace",
+		score: 0.8,
+		url: null,
+		createdAt: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+		highlights: [{ id: "h1", score: 0.75, text: "we talked about the plan" }],
+		...partial,
+	};
+}
+
+test("startup-orientation — injects once per session, caches on subsequent turns", async () => {
+	const client = makeClient({
+		recent: [makeResult({ title: "yesterday's session" })],
+		loops: [
+			makeResult({
+				title: "followup question",
+				highlights: [{ id: "h", score: 0.4, text: "follow up on the config" }],
+			}),
+		],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const ctx = { sessionKey: "s1" };
+
+	const first = await handler({}, ctx);
+	const prepend = (first as { prependContext?: string } | undefined)
+		?.prependContext;
+	assert.ok(prepend);
+	assert.ok(prepend.includes("<hyperspell-recent-interactions>"));
+	assert.ok(prepend.includes("<hyperspell-unfinished-loops>"));
+	assert.ok(prepend.includes("yesterday's session"));
+	assert.equal(client.calls.length, 2, "fires both searches in parallel");
+
+	const second = await handler({}, ctx);
+	assert.equal(second, undefined);
+	assert.equal(
+		client.calls.length,
+		2,
+		"does not re-search within same session",
+	);
+});
+
+test("startup-orientation — compaction clears cache, next turn re-injects", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const onCompaction = buildStartupOrientationCompactionHandler();
+	const ctx = { sessionKey: "s-compact" };
+
+	await handler({}, ctx);
+	await handler({}, ctx);
+	assert.equal(client.calls.length, 2);
+
+	await onCompaction({}, ctx);
+	await handler({}, ctx);
+	assert.equal(client.calls.length, 4, "re-searches after compaction");
+});
+
+test("startup-orientation — session_end cleanup allows later re-injection", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const onSessionEnd = buildStartupOrientationSessionCleanupHandler();
+	const ctx = { sessionKey: "s-end" };
+
+	await handler({}, ctx);
+	await onSessionEnd({}, ctx);
+	await handler({}, ctx);
+	assert.equal(
+		client.calls.length,
+		4,
+		"resumes searching after session end drops the cache entry",
+	);
+});
+
+test("startup-orientation — empty results cache the attempt (no retry storm)", async () => {
+	const client = makeClient({ recent: [], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const ctx = { sessionKey: "s-empty" };
+
+	const out = await handler({}, ctx);
+	assert.equal(out, undefined);
+	assert.equal(client.calls.length, 2);
+
+	await handler({}, ctx);
+	assert.equal(
+		client.calls.length,
+		2,
+		"empty results still mark session as handled",
+	);
+});
+
+test("startup-orientation — recent search uses `after` and metadata filter", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	await handler({}, { sessionKey: "s-filter" });
+
+	const recentCall = client.calls.find((c) => c.options?.after);
+	assert.ok(recentCall, "recent search must include `after`");
+	assert.equal(
+		(recentCall.options?.filter as { openclaw_source?: unknown } | undefined)
+			?.openclaw_source,
+		"agent_end",
+	);
+	assert.equal(recentCall.options?.limit, 5);
+});
+
+test("startup-orientation — loops search runs without filter or threshold", async () => {
+	const client = makeClient({
+		recent: [],
+		loops: [makeResult({ title: "q" })],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	await handler({}, { sessionKey: "s-loops" });
+
+	const loopsCall = client.calls.find((c) => !c.options?.after);
+	assert.ok(loopsCall, "loops search must exist");
+	assert.equal(
+		loopsCall.options?.filter,
+		undefined,
+		"loops search has no metadata filter",
+	);
+	assert.equal(loopsCall.options?.limit, 3);
+});
+
+test("startup-orientation — skips orientation for unknown sender in multi-user mode", async () => {
+	const client = makeClient({
+		recent: [makeResult({})],
+		loops: [makeResult({})],
+	});
+	const cfg = makeCfg({
+		multiUser: {
+			senderMap: { "+111": { userId: "alice", name: "Alice" } },
+			sharedUserId: "shared",
+			includeSharedInSearch: true,
+		},
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		cfg,
+	);
+	const out = await handler({}, { sessionKey: "s-unknown", senderId: "+999" });
+	assert.equal(out, undefined);
+	assert.equal(client.calls.length, 0, "no searches for unresolved sender");
+});
+
+test("startup-orientation — uses resolved userId for personal-only search in multi-user mode", async () => {
+	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const cfg = makeCfg({
+		multiUser: {
+			senderMap: { "+111": { userId: "alice", name: "Alice" } },
+			sharedUserId: "shared",
+			includeSharedInSearch: true,
+		},
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		cfg,
+	);
+	await handler({}, { sessionKey: "s-known", senderId: "+111" });
+	assert.ok(client.calls.length === 2);
+	for (const c of client.calls) {
+		assert.equal(
+			c.options?.userId,
+			"alice",
+			"both searches scoped to resolved personal userId",
+		);
+	}
+});

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -1,0 +1,189 @@
+import type { HyperspellClient, SearchResult } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import { resolveUser } from "../lib/sender.ts";
+import { log } from "../logger.ts";
+
+type AgentContext = Record<string, unknown> & { sessionKey?: string };
+
+const RECENT_FILTER = { openclaw_source: "agent_end" } as const;
+
+/**
+ * Track which sessions already received the orientation injection. The block is
+ * expensive (two search calls + a few hundred tokens of wrapper) and its
+ * contents don't change within a session, so inject-once is the right shape.
+ * Lifecycle mirrors the emotional-context hook: first turn injects, later turns
+ * skip, `after_compaction` clears (injection may have been trimmed), and
+ * `session_end` deletes to keep the Set bounded.
+ */
+const injectedSessions = new Set<string>();
+
+function formatRelativeTime(iso: string | null): string {
+	if (!iso) return "";
+	try {
+		const dt = new Date(iso);
+		const now = new Date();
+		const hours = (now.getTime() - dt.getTime()) / 3_600_000;
+		if (hours < 1) return "just now";
+		if (hours < 24) return `${Math.floor(hours)}h ago`;
+		const days = hours / 24;
+		if (days < 7) return `${Math.floor(days)}d ago`;
+		const month = dt.toLocaleString("en", { month: "short" });
+		return `${dt.getDate()} ${month}`;
+	} catch {
+		return "";
+	}
+}
+
+function formatRecentInteractions(results: SearchResult[]): string | null {
+	if (results.length === 0) return null;
+	const lines = results.map((r) => {
+		const when = formatRelativeTime(r.createdAt);
+		const title = r.title ?? `[${r.source}]`;
+		const prefix = when ? `[${when}] ` : "";
+		const top = r.highlights[0]?.text?.replace(/\n/g, " ").slice(0, 140);
+		const tail = top ? ` — ${top}` : "";
+		return `- ${prefix}${title}${tail}`;
+	});
+	return lines.join("\n");
+}
+
+function formatUnfinishedLoops(results: SearchResult[]): string | null {
+	const bullets: string[] = [];
+	for (const r of results) {
+		const top = r.highlights[0];
+		if (!top) continue;
+		const title = r.title ?? `[${r.source}]`;
+		bullets.push(`- ${title}: ${top.text.replace(/\n/g, " ")}`);
+	}
+	return bullets.length > 0 ? bullets.join("\n") : null;
+}
+
+function isoDaysAgo(days: number): string {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - days);
+	return d.toISOString();
+}
+
+/**
+ * Resolve the userId to use for personal searches. In multi-user mode, skip
+ * entirely for unknown senders — orientation is "what have *I* been doing", and
+ * an unresolved caller has no personal space to orient to. In single-user mode,
+ * return undefined so the client falls back to its configured userId.
+ */
+function personalUserId(
+	cfg: HyperspellConfig,
+	ctx: AgentContext | undefined,
+): { skip: boolean; userId?: string } {
+	if (!cfg.multiUser) return { skip: false, userId: undefined };
+	const resolved = resolveUser(ctx, cfg);
+	if (!resolved?.resolved) return { skip: true };
+	return { skip: false, userId: resolved.userId };
+}
+
+export function buildStartupOrientationHandler(
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
+) {
+	const so = cfg.startupOrientation;
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey && injectedSessions.has(sessionKey)) return;
+
+		const { skip, userId } = personalUserId(cfg, ctx);
+		if (skip) {
+			log.debug(
+				"startup-orientation: skipping — unknown sender in multi-user mode",
+			);
+			if (sessionKey) injectedSessions.add(sessionKey);
+			return;
+		}
+
+		const after = isoDaysAgo(so.recentDays);
+
+		const [recentSettled, loopsSettled] = await Promise.allSettled([
+			client.search(so.recentQuery, {
+				limit: so.recentLimit,
+				after,
+				filter: RECENT_FILTER,
+				userId,
+			}),
+			client.search(so.loopsQuery, {
+				limit: so.loopsLimit,
+				userId,
+			}),
+		]);
+
+		const recent =
+			recentSettled.status === "fulfilled" ? recentSettled.value : [];
+		if (recentSettled.status === "rejected") {
+			log.error(
+				"startup-orientation: recent search failed",
+				recentSettled.reason,
+			);
+		}
+		const loops = loopsSettled.status === "fulfilled" ? loopsSettled.value : [];
+		if (loopsSettled.status === "rejected") {
+			log.error(
+				"startup-orientation: loops search failed",
+				loopsSettled.reason,
+			);
+		}
+
+		const recentBody = formatRecentInteractions(recent);
+		const loopsBody = formatUnfinishedLoops(loops);
+
+		if (sessionKey) injectedSessions.add(sessionKey);
+
+		if (!recentBody && !loopsBody) {
+			log.debug("startup-orientation: nothing to inject");
+			return;
+		}
+
+		const blocks: string[] = [];
+		if (recentBody) {
+			blocks.push(
+				[
+					"<hyperspell-recent-interactions>",
+					`Your last ${so.recentDays} days of conversations with this user, most-relevant-first. Use for situational continuity — don't quote verbatim.`,
+					"",
+					recentBody,
+					"</hyperspell-recent-interactions>",
+				].join("\n"),
+			);
+		}
+		if (loopsBody) {
+			blocks.push(
+				[
+					"<hyperspell-unfinished-loops>",
+					"Possible open threads — promises made, questions pending, work in progress. Low-confidence retrieval; treat as prompts to consider, not facts to act on.",
+					"",
+					loopsBody,
+					"</hyperspell-unfinished-loops>",
+				].join("\n"),
+			);
+		}
+
+		log.debug(
+			`startup-orientation: injecting recent=${recent.length} loops=${loops.length}`,
+		);
+		return { prependContext: blocks.join("\n\n") };
+	};
+}
+
+export function buildStartupOrientationCompactionHandler() {
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey && injectedSessions.delete(sessionKey)) {
+			log.debug(
+				`startup-orientation: cache cleared after compaction (session=${sessionKey})`,
+			);
+		}
+	};
+}
+
+export function buildStartupOrientationSessionCleanupHandler() {
+	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
+		const sessionKey = ctx?.sessionKey;
+		if (sessionKey) injectedSessions.delete(sessionKey);
+	};
+}

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,11 @@ import {
 	buildEmotionalStateStoreHandler,
 } from "./hooks/emotional-state.ts"
 import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
+import {
+	buildStartupOrientationCompactionHandler,
+	buildStartupOrientationHandler,
+	buildStartupOrientationSessionCleanupHandler,
+} from "./hooks/startup-orientation.ts"
 import { initLogger } from "./logger.ts"
 import { createRememberToolFactory } from "./tools/remember.ts"
 import { createSearchToolFactory } from "./tools/search.ts"
@@ -109,6 +114,14 @@ export default {
 		if (cfg.autoContext) {
 			const autoContextHandler = buildAutoContextHandler(client, cfg);
 			api.on("before_agent_start", autoContextHandler);
+		}
+
+		// Register startup-orientation hooks: recent-interactions + unfinished-loops
+		// injected once per session on first turn. Lifecycle mirrors emotional-context.
+		if (cfg.startupOrientation.enabled) {
+			api.on("before_agent_start", buildStartupOrientationHandler(client, cfg));
+			api.on("after_compaction", buildStartupOrientationCompactionHandler());
+			api.on("session_end", buildStartupOrientationSessionCleanupHandler());
 		}
 
 		// Register auto-trace hook (send conversations to Hyperspell on session end)

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -21,6 +21,14 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     relevanceThreshold: 0.6,
     debug: false,
     knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
+    startupOrientation: {
+      enabled: false,
+      recentDays: 7,
+      recentLimit: 5,
+      loopsLimit: 3,
+      recentQuery: "conversation",
+      loopsQuery: "open tasks",
+    },
     multiUser: overrides.scoping
       ? {
           sharedUserId: "shared",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,17 @@
 	"id": "openclaw-hyperspell",
 	"name": "Hyperspell",
 	"description": "Context and memory for your AI agents — search across Notion, Slack, Google Drive, and more",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"kind": "memory",
+	"contracts": {
+		"tools": [
+			"hyperspell_search",
+			"hyperspell_remember",
+			"hyperspell_network_scan",
+			"hyperspell_network_write",
+			"hyperspell_network_complete"
+		]
+	},
 	"uiHints": {
 		"apiKey": {
 			"label": "Hyperspell API Key",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,12 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",
-  "main": "./index.ts",
+  "main": "./dist/index.js",
   "files": [
-    "*.ts",
-    "commands/",
-    "hooks/",
-    "tools/",
-    "sync/",
-    "graph/",
-    "lib/",
-    "types/",
+    "dist/",
     "openclaw.plugin.json",
     "README.md"
   ],
@@ -40,6 +33,8 @@
     "openclaw": ">=2026.1.29"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build",
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
@@ -47,7 +42,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "hooks": [],
     "compat": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts"
+    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist",
+		"rootDir": ".",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"rewriteRelativeImportExtensions": true,
+		"declaration": false,
+		"sourceMap": false
+	},
+	"include": ["index.ts", "client.ts", "config.ts", "logger.ts", "commands/**/*.ts", "hooks/**/*.ts", "tools/**/*.ts", "sync/**/*.ts", "graph/**/*.ts", "lib/**/*.ts", "types/**/*.d.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "sommeliagent"]
+}


### PR DESCRIPTION
## Summary

Brings the plugin into compliance with OpenClaw 2026.5.x's tightened plugin loader, which rejects source-only TypeScript entries for globally-installed packages and requires tool name declarations in the manifest.

Without this, gateway startup on the latest OpenClaw drops the plugin entirely (`installed plugin package requires compiled runtime output for TypeScript entry index.ts`), leaving downstream config bindings invalid (`plugins.slots.memory: plugin not found: openclaw-hyperspell`).

- Ship compiled JS via a new `tsconfig.build.json` (`NodeNext` + `rewriteRelativeImportExtensions: true`); `main` → `./dist/index.js`; `files` narrowed to `dist/` + manifest + README.
- Convert `config.ts` inline `require()` calls to top-level ESM imports — `require` is undefined in compiled ESM and would crash at runtime.
- Declare `contracts.tools` in `openclaw.plugin.json` for the five tools the plugin registers (`hyperspell_search`, `hyperspell_remember`, `hyperspell_network_scan`, `hyperspell_network_write`, `hyperspell_network_complete`).
- Bump version to `0.13.0`.

## Background on the upstream change

OpenClaw `59c523c6b5` (May 3) introduced a rule that globally-installed plugin packages must ship compiled runtime output. `cdc00614cc` (May 3) softened it: warn instead of error, and let the runtime fall through to the TS source via jiti. `89a15fddaf` (May 4) re-added an early `return null;` as part of an unrelated managed-runtime-shadow fix, which silently re-broke source-only loading. That regression should be addressed upstream too, but shipping compiled output is the right long-term shape regardless.

Tool registration: OpenClaw now requires plugins to declare tool names in `openclaw.plugin.json` `contracts.tools` before `api.registerAgentTool(...)` will accept them — previously implicit, now explicit.

## Test plan

- [x] Verified `npm run build` produces `dist/index.js` with `.ts` import specifiers correctly rewritten to `.js`
- [x] Verified `npm pack` ships only the expected files (`dist/`, `openclaw.plugin.json`, `README.md`, `package.json`)
- [x] Installed packed tarball into `~/.openclaw/extensions/openclaw-hyperspell` and ran against gateway @ `2026.5.5`:
  - registry refresh shows the plugin enabled with `source: dist/index.js`, `origin: global`, no diagnostics
  - gateway startup: `[plugins] hyperspell: client initialized` → `[plugins] hyperspell: connected` → ready
  - no `requires compiled runtime output` warning
  - no `plugin must declare contracts.tools` errors (with `allowConversationAccess: true` in config, conversation hooks also load cleanly)
- [ ] Verify the existing `npm test` suite still passes against the source tree (tests use `--experimental-strip-types` so they continue to run from `.ts`)