### PR TITLE
Accept dreaming config key in parseConfig

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -119,6 +119,7 @@ const ALLOWED_KEYS = [
 	"debug",
 	"knowledgeGraph",
 	"multiUser",
+	"dreaming",
 ];
 
 const VALID_SOURCES: HyperspellSource[] = [


### PR DESCRIPTION
## Summary

Closes a manifest/runtime drift introduced in v0.12.0 (#20).

The manifest declares \`dreaming\` as a valid config key — memory-core reads \`plugins.entries.openclaw-hyperspell.config.dreaming\` to schedule the dreaming cron when this plugin owns the memory slot. But the runtime \`parseConfig\`'s \`ALLOWED_KEYS\` array (\`config.ts\`) was never updated to match.

Effect: any user whose Control UI legitimately wrote \`dreaming.enabled = true\` would see their hyperspell plugin fail to register at gateway startup with:

\`\`\`
Error: hyperspell config has unknown keys: dreaming
\`\`\`

…and silently fall through to the bundled memory-core fallback (no Hyperspell auto-context, auto-trace, emotional-state, etc).

The change is one line — adding \`\"dreaming\"\` to \`ALLOWED_KEYS\` so the manifest schema and runtime parser agree.

## Test plan

- [x] Reproduced on OpenClaw 2026.5.5 with \`config.dreaming = {enabled: true}\` → gateway logs \`hyperspell config has unknown keys: dreaming\` and the slot binding falls back to memory-core.
- [x] After this fix: gateway startup shows \`5 plugins: discord, memory-core, openclaw-hyperspell, slack, voice-call\` with hyperspell registering cleanly and dreaming cron scheduled.