### PR TITLE
fix: harden startup-orientation — sanitize, list, retry, schema (v0.13.1)

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -345,7 +345,6 @@ async function runSetup(): Promise<void> {
           recentDays: 7,
           recentLimit: 5,
           loopsLimit: 3,
-          recentQuery: "conversation session interaction",
           loopsQuery: "open tasks pending questions unfinished promised need to follow up",
         },
       })

--- a/config.test.ts
+++ b/config.test.ts
@@ -207,7 +207,6 @@ test("parseConfig — startupOrientation defaults to disabled with sensible valu
   assert.equal(cfg.startupOrientation.recentDays, 7)
   assert.equal(cfg.startupOrientation.recentLimit, 5)
   assert.equal(cfg.startupOrientation.loopsLimit, 3)
-  assert.ok(cfg.startupOrientation.recentQuery.length > 0)
   assert.ok(cfg.startupOrientation.loopsQuery.length > 0)
 })
 
@@ -219,7 +218,6 @@ test("parseConfig — startupOrientation accepts overrides", () => {
       recentDays: 14,
       recentLimit: 3,
       loopsLimit: 5,
-      recentQuery: "custom recent",
       loopsQuery: "custom loops",
     },
   })
@@ -227,6 +225,5 @@ test("parseConfig — startupOrientation accepts overrides", () => {
   assert.equal(cfg.startupOrientation.recentDays, 14)
   assert.equal(cfg.startupOrientation.recentLimit, 3)
   assert.equal(cfg.startupOrientation.loopsLimit, 5)
-  assert.equal(cfg.startupOrientation.recentQuery, "custom recent")
   assert.equal(cfg.startupOrientation.loopsQuery, "custom loops")
 })

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
-import * as fs from "node:fs"
-import * as os from "node:os"
-import * as path from "node:path"
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 export type HyperspellSource =
 	| "reddit"
@@ -34,7 +34,6 @@ export type StartupOrientationConfig = {
 	recentDays: number;
 	recentLimit: number;
 	loopsLimit: number;
-	recentQuery: string;
 	loopsQuery: string;
 };
 
@@ -407,8 +406,6 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			recentDays: (soRaw.recentDays as number) ?? 7,
 			recentLimit: (soRaw.recentLimit as number) ?? 5,
 			loopsLimit: (soRaw.loopsLimit as number) ?? 3,
-			recentQuery:
-				(soRaw.recentQuery as string) ?? "conversation session interaction",
 			loopsQuery:
 				(soRaw.loopsQuery as string) ??
 				"open tasks pending questions unfinished promised need to follow up",

--- a/hooks/auto-trace.test.ts
+++ b/hooks/auto-trace.test.ts
@@ -14,6 +14,18 @@ test("sanitizeTraceText — strips hyperspell-emotional-context wrapper", () => 
 	assert.equal(sanitizeTraceText(input), "real content");
 });
 
+test("sanitizeTraceText — strips hyperspell-recent-interactions wrapper", () => {
+	const input =
+		"<hyperspell-recent-interactions>\n- [2h ago] yesterday's session — talked about plans\n</hyperspell-recent-interactions>\nreal content";
+	assert.equal(sanitizeTraceText(input), "real content");
+});
+
+test("sanitizeTraceText — strips hyperspell-unfinished-loops wrapper", () => {
+	const input =
+		"<hyperspell-unfinished-loops>\n- followup: pending question\n</hyperspell-unfinished-loops>\nreal content";
+	assert.equal(sanitizeTraceText(input), "real content");
+});
+
 test("sanitizeTraceText — strips Sender untrusted envelope", () => {
 	const input =
 		'Sender (untrusted metadata):\n```json\n{"label": "x"}\n```\n\nreal message';
@@ -27,8 +39,7 @@ test("sanitizeTraceText — strips Bootstrap pending block", () => {
 });
 
 test("sanitizeTraceText — strips System timestamp line", () => {
-	const input =
-		"System: [2026-04-17 14:31:25 PDT] Node: machine\nreal line";
+	const input = "System: [2026-04-17 14:31:25 PDT] Node: machine\nreal line";
 	assert.equal(sanitizeTraceText(input), "real line");
 });
 
@@ -41,6 +52,14 @@ test("sanitizeTraceText — strips nested pollution cascade", () => {
 		"<hyperspell-context>",
 		"memories",
 		"</hyperspell-context>",
+		"",
+		"<hyperspell-recent-interactions>",
+		"- [2h ago] some session",
+		"</hyperspell-recent-interactions>",
+		"",
+		"<hyperspell-unfinished-loops>",
+		"- topic: open thread",
+		"</hyperspell-unfinished-loops>",
 		"",
 		"Sender (untrusted metadata):",
 		"```json",

--- a/hooks/auto-trace.ts
+++ b/hooks/auto-trace.ts
@@ -27,6 +27,14 @@ export function sanitizeTraceText(input: string): string {
 		"",
 	);
 	out = out.replace(
+		/<hyperspell-recent-interactions>[\s\S]*?<\/hyperspell-recent-interactions>\n?/g,
+		"",
+	);
+	out = out.replace(
+		/<hyperspell-unfinished-loops>[\s\S]*?<\/hyperspell-unfinished-loops>\n?/g,
+		"",
+	);
+	out = out.replace(
 		/Sender \(untrusted metadata\):\s*```json[\s\S]*?```\n?/g,
 		"",
 	);

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -12,21 +12,41 @@ type SearchCall = {
 	query: string;
 	options?: Parameters<HyperspellClient["search"]>[1];
 };
+type ListCall = { options?: Parameters<HyperspellClient["listMemories"]>[0] };
+type ListedMemory = {
+	resourceId: string;
+	source: "trace";
+	title: string | null;
+	metadata: Record<string, unknown>;
+};
 
-function makeClient(responses: {
-	recent?: SearchResult[];
+type ClientResponses = {
+	traces?: ListedMemory[];
 	loops?: SearchResult[];
-}) {
-	const calls: SearchCall[] = [];
+	listError?: Error;
+	loopsError?: Error;
+};
+
+function makeClient(responses: ClientResponses) {
+	const searchCalls: SearchCall[] = [];
+	const listCalls: ListCall[] = [];
 	const client = {
-		calls,
+		searchCalls,
+		listCalls,
 		async search(
 			query: string,
 			options?: Parameters<HyperspellClient["search"]>[1],
 		) {
-			calls.push({ query, options });
-			if (options?.after) return responses.recent ?? [];
+			searchCalls.push({ query, options });
+			if (responses.loopsError) throw responses.loopsError;
 			return responses.loops ?? [];
+		},
+		async *listMemories(
+			options?: Parameters<HyperspellClient["listMemories"]>[0],
+		) {
+			listCalls.push({ options });
+			if (responses.listError) throw responses.listError;
+			for (const m of responses.traces ?? []) yield m;
 		},
 	};
 	return client;
@@ -43,7 +63,6 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 			recentDays: 7,
 			recentLimit: 5,
 			loopsLimit: 3,
-			recentQuery: "conversation session interaction",
 			loopsQuery: "open tasks pending questions",
 		},
 		syncMemories: false,
@@ -56,25 +75,45 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 	};
 }
 
-function makeResult(partial: Partial<SearchResult>): SearchResult {
+function makeTrace(
+	partial: Partial<ListedMemory> & { ageDays?: number },
+): ListedMemory {
+	const ageDays = partial.ageDays ?? 1;
+	const created = new Date(
+		Date.now() - ageDays * 24 * 3600 * 1000,
+	).toISOString();
+	const meta: Record<string, unknown> = {
+		openclaw_source: "agent_end",
+		created_at: created,
+		...(partial.metadata ?? {}),
+	};
 	return {
-		resourceId: "r1",
-		title: "some session",
+		resourceId: partial.resourceId ?? "r1",
 		source: "trace",
-		score: 0.8,
+		title: partial.title ?? "some session",
+		metadata: meta,
+	};
+}
+
+function makeSearchResult(partial: Partial<SearchResult>): SearchResult {
+	return {
+		resourceId: "s1",
+		title: "loop title",
+		source: "trace",
+		score: 0.6,
 		url: null,
-		createdAt: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
-		highlights: [{ id: "h1", score: 0.75, text: "we talked about the plan" }],
+		createdAt: new Date().toISOString(),
+		highlights: [{ id: "h1", score: 0.5, text: "open thread text" }],
 		...partial,
 	};
 }
 
 test("startup-orientation — injects once per session, caches on subsequent turns", async () => {
 	const client = makeClient({
-		recent: [makeResult({ title: "yesterday's session" })],
+		traces: [makeTrace({ title: "yesterday's session", ageDays: 1 })],
 		loops: [
-			makeResult({
-				title: "followup question",
+			makeSearchResult({
+				title: "followup",
 				highlights: [{ id: "h", score: 0.4, text: "follow up on the config" }],
 			}),
 		],
@@ -92,19 +131,102 @@ test("startup-orientation — injects once per session, caches on subsequent tur
 	assert.ok(prepend.includes("<hyperspell-recent-interactions>"));
 	assert.ok(prepend.includes("<hyperspell-unfinished-loops>"));
 	assert.ok(prepend.includes("yesterday's session"));
-	assert.equal(client.calls.length, 2, "fires both searches in parallel");
+	assert.equal(client.listCalls.length, 1, "list runs once for recent");
+	assert.equal(client.searchCalls.length, 1, "search runs once for loops");
 
 	const second = await handler({}, ctx);
 	assert.equal(second, undefined);
+	assert.equal(client.listCalls.length, 1, "no re-fetch within same session");
+	assert.equal(client.searchCalls.length, 1);
+});
+
+test("startup-orientation — recent path filters non-agent_end traces and out-of-window items", async () => {
+	const client = makeClient({
+		traces: [
+			makeTrace({ title: "in-window agent_end", ageDays: 2 }),
+			makeTrace({
+				title: "non-agent_end",
+				ageDays: 1,
+				metadata: {
+					openclaw_source: "command",
+					created_at: new Date(Date.now() - 1 * 86400000).toISOString(),
+				},
+			}),
+			makeTrace({ title: "too old", ageDays: 30 }),
+		],
+		loops: [],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const out = await handler({}, { sessionKey: "s-filter" });
+	const prepend =
+		(out as { prependContext?: string } | undefined)?.prependContext ?? "";
+	assert.ok(prepend.includes("in-window agent_end"));
+	assert.ok(!prepend.includes("non-agent_end"));
+	assert.ok(!prepend.includes("too old"));
+});
+
+test("startup-orientation — recent results sorted desc by created_at, capped at recentLimit", async () => {
+	// Inserted out-of-order to verify sort, not iteration order. With recentLimit=3,
+	// expected output (desc): newest (0.1d), middle (2d), thirdNewest (3d).
+	// "older" (4d) and "trimmed" (5d) get dropped past the limit.
+	const client = makeClient({
+		traces: [
+			makeTrace({ title: "older", ageDays: 4 }),
+			makeTrace({ title: "newest", ageDays: 0.1 }),
+			makeTrace({ title: "middle", ageDays: 2 }),
+			makeTrace({ title: "thirdNewest", ageDays: 3 }),
+			makeTrace({ title: "trimmed", ageDays: 5 }),
+		],
+		loops: [],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg({
+			startupOrientation: {
+				enabled: true,
+				recentDays: 7,
+				recentLimit: 3,
+				loopsLimit: 3,
+				loopsQuery: "q",
+			},
+		}),
+	);
+	const out = await handler({}, { sessionKey: "s-sort" });
+	const prepend =
+		(out as { prependContext?: string } | undefined)?.prependContext ?? "";
+	const block = prepend.split("</hyperspell-recent-interactions>")[0];
+	const newestPos = block.indexOf("newest");
+	const middlePos = block.indexOf("middle");
+	const thirdPos = block.indexOf("thirdNewest");
+	assert.ok(
+		newestPos > -1 && middlePos > newestPos && thirdPos > middlePos,
+		"ordered desc by recency",
+	);
+	assert.ok(!block.includes("older"), "items beyond recentLimit are dropped");
+	assert.ok(!block.includes("trimmed"));
+});
+
+test("startup-orientation — list call passes source:trace and userId", async () => {
+	const client = makeClient({ traces: [makeTrace({})], loops: [] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	await handler({}, { sessionKey: "s-list" });
+
+	assert.equal(client.listCalls[0]?.options?.source, "trace");
 	assert.equal(
-		client.calls.length,
-		2,
-		"does not re-search within same session",
+		client.listCalls[0]?.options?.userId,
+		undefined,
+		"single-user mode passes undefined",
 	);
 });
 
-test("startup-orientation — compaction clears cache, next turn re-injects", async () => {
-	const client = makeClient({ recent: [makeResult({})], loops: [] });
+test("startup-orientation — compaction clears cache, next turn re-fetches", async () => {
+	const client = makeClient({ traces: [makeTrace({})], loops: [] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg(),
@@ -114,15 +236,17 @@ test("startup-orientation — compaction clears cache, next turn re-injects", as
 
 	await handler({}, ctx);
 	await handler({}, ctx);
-	assert.equal(client.calls.length, 2);
+	assert.equal(client.listCalls.length, 1);
+	assert.equal(client.searchCalls.length, 1);
 
 	await onCompaction({}, ctx);
 	await handler({}, ctx);
-	assert.equal(client.calls.length, 4, "re-searches after compaction");
+	assert.equal(client.listCalls.length, 2, "list re-fetches after compaction");
+	assert.equal(client.searchCalls.length, 2);
 });
 
 test("startup-orientation — session_end cleanup allows later re-injection", async () => {
-	const client = makeClient({ recent: [makeResult({})], loops: [] });
+	const client = makeClient({ traces: [makeTrace({})], loops: [] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg(),
@@ -134,14 +258,14 @@ test("startup-orientation — session_end cleanup allows later re-injection", as
 	await onSessionEnd({}, ctx);
 	await handler({}, ctx);
 	assert.equal(
-		client.calls.length,
-		4,
-		"resumes searching after session end drops the cache entry",
+		client.listCalls.length,
+		2,
+		"resumes fetching after session_end drop",
 	);
 });
 
-test("startup-orientation — empty results cache the attempt (no retry storm)", async () => {
-	const client = makeClient({ recent: [], loops: [] });
+test("startup-orientation — empty results still mark session as handled (no retry storm)", async () => {
+	const client = makeClient({ traces: [], loops: [] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg(),
@@ -150,59 +274,74 @@ test("startup-orientation — empty results cache the attempt (no retry storm)",
 
 	const out = await handler({}, ctx);
 	assert.equal(out, undefined);
-	assert.equal(client.calls.length, 2);
+	assert.equal(client.listCalls.length, 1);
+	assert.equal(client.searchCalls.length, 1);
 
 	await handler({}, ctx);
 	assert.equal(
-		client.calls.length,
-		2,
-		"empty results still mark session as handled",
+		client.listCalls.length,
+		1,
+		"empty result counts as a successful attempt",
 	);
 });
 
-test("startup-orientation — recent search uses `after` and metadata filter", async () => {
-	const client = makeClient({ recent: [makeResult({})], loops: [] });
-	const handler = buildStartupOrientationHandler(
-		client as unknown as HyperspellClient,
-		makeCfg(),
-	);
-	await handler({}, { sessionKey: "s-filter" });
-
-	const recentCall = client.calls.find((c) => c.options?.after);
-	assert.ok(recentCall, "recent search must include `after`");
-	assert.equal(
-		(recentCall.options?.filter as { openclaw_source?: unknown } | undefined)
-			?.openclaw_source,
-		"agent_end",
-	);
-	assert.equal(recentCall.options?.limit, 5);
-});
-
-test("startup-orientation — loops search runs without filter or threshold", async () => {
+test("startup-orientation — retries on total failure up to MAX_ATTEMPTS, then gives up", async () => {
 	const client = makeClient({
-		recent: [],
-		loops: [makeResult({ title: "q" })],
+		traces: [],
+		loops: [],
+		listError: new Error("transient list outage"),
+		loopsError: new Error("transient search outage"),
 	});
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg(),
 	);
-	await handler({}, { sessionKey: "s-loops" });
+	const ctx = { sessionKey: "s-retry" };
 
-	const loopsCall = client.calls.find((c) => !c.options?.after);
-	assert.ok(loopsCall, "loops search must exist");
+	await handler({}, ctx);
+	assert.equal(client.listCalls.length, 1, "1st turn attempts");
+
+	await handler({}, ctx);
 	assert.equal(
-		loopsCall.options?.filter,
-		undefined,
-		"loops search has no metadata filter",
+		client.listCalls.length,
+		2,
+		"2nd turn retries after total failure",
 	);
-	assert.equal(loopsCall.options?.limit, 3);
+
+	await handler({}, ctx);
+	assert.equal(client.listCalls.length, 2, "gives up after MAX_ATTEMPTS=2");
+});
+
+test("startup-orientation — partial failure (recent fails, loops succeeds) marks injected and surfaces what worked", async () => {
+	const client = makeClient({
+		traces: [],
+		loops: [makeSearchResult({ title: "still-known loop" })],
+		listError: new Error("recent list down"),
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg(),
+	);
+	const ctx = { sessionKey: "s-partial" };
+
+	const out = await handler({}, ctx);
+	const prepend =
+		(out as { prependContext?: string } | undefined)?.prependContext ?? "";
+	assert.ok(prepend.includes("<hyperspell-unfinished-loops>"));
+	assert.ok(!prepend.includes("<hyperspell-recent-interactions>"));
+
+	await handler({}, ctx);
+	assert.equal(
+		client.searchCalls.length,
+		1,
+		"no retry — partial success counts as injected",
+	);
 });
 
 test("startup-orientation — skips orientation for unknown sender in multi-user mode", async () => {
 	const client = makeClient({
-		recent: [makeResult({})],
-		loops: [makeResult({})],
+		traces: [makeTrace({})],
+		loops: [makeSearchResult({})],
 	});
 	const cfg = makeCfg({
 		multiUser: {
@@ -217,11 +356,12 @@ test("startup-orientation — skips orientation for unknown sender in multi-user
 	);
 	const out = await handler({}, { sessionKey: "s-unknown", senderId: "+999" });
 	assert.equal(out, undefined);
-	assert.equal(client.calls.length, 0, "no searches for unresolved sender");
+	assert.equal(client.listCalls.length, 0);
+	assert.equal(client.searchCalls.length, 0);
 });
 
-test("startup-orientation — uses resolved userId for personal-only search in multi-user mode", async () => {
-	const client = makeClient({ recent: [makeResult({})], loops: [] });
+test("startup-orientation — uses resolved userId for both calls in multi-user mode", async () => {
+	const client = makeClient({ traces: [makeTrace({})], loops: [] });
 	const cfg = makeCfg({
 		multiUser: {
 			senderMap: { "+111": { userId: "alice", name: "Alice" } },
@@ -234,12 +374,6 @@ test("startup-orientation — uses resolved userId for personal-only search in m
 		cfg,
 	);
 	await handler({}, { sessionKey: "s-known", senderId: "+111" });
-	assert.ok(client.calls.length === 2);
-	for (const c of client.calls) {
-		assert.equal(
-			c.options?.userId,
-			"alice",
-			"both searches scoped to resolved personal userId",
-		);
-	}
+	assert.equal(client.listCalls[0]?.options?.userId, "alice");
+	assert.equal(client.searchCalls[0]?.options?.userId, "alice");
 });

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -5,17 +5,25 @@ import { log } from "../logger.ts";
 
 type AgentContext = Record<string, unknown> & { sessionKey?: string };
 
-const RECENT_FILTER = { openclaw_source: "agent_end" } as const;
+const MAX_ATTEMPTS = 2;
+const RECENT_BUFFER_LIMIT = 100;
 
 /**
- * Track which sessions already received the orientation injection. The block is
- * expensive (two search calls + a few hundred tokens of wrapper) and its
- * contents don't change within a session, so inject-once is the right shape.
- * Lifecycle mirrors the emotional-context hook: first turn injects, later turns
- * skip, `after_compaction` clears (injection may have been trimmed), and
- * `session_end` deletes to keep the Set bounded.
+ * Sessions where the orientation block was already injected (or where we
+ * deliberately decided not to inject — unknown sender, exhausted retries).
+ * Re-checked at the top of every turn; on hit, we skip.
+ *
+ * Lifecycle mirrors the emotional-context hook: `after_compaction` clears
+ * (the original injection may have been trimmed out of history) and
+ * `session_end` cleans up to keep both structures bounded.
  */
 const injectedSessions = new Set<string>();
+/**
+ * Counts attempts for sessions where every call has failed so far. We only
+ * count failures here, so a session that succeeds on retry will never appear.
+ * Capped at MAX_ATTEMPTS — past that we give up and add to injectedSessions.
+ */
+const failedAttempts = new Map<string, number>();
 
 function formatRelativeTime(iso: string | null): string {
 	if (!iso) return "";
@@ -38,7 +46,7 @@ function formatRecentInteractions(results: SearchResult[]): string | null {
 	if (results.length === 0) return null;
 	const lines = results.map((r) => {
 		const when = formatRelativeTime(r.createdAt);
-		const title = r.title ?? `[${r.source}]`;
+		const title = r.title || `[${r.source}]`;
 		const prefix = when ? `[${when}] ` : "";
 		const top = r.highlights[0]?.text?.replace(/\n/g, " ").slice(0, 140);
 		const tail = top ? ` — ${top}` : "";
@@ -52,16 +60,16 @@ function formatUnfinishedLoops(results: SearchResult[]): string | null {
 	for (const r of results) {
 		const top = r.highlights[0];
 		if (!top) continue;
-		const title = r.title ?? `[${r.source}]`;
+		const title = r.title || `[${r.source}]`;
 		bullets.push(`- ${title}: ${top.text.replace(/\n/g, " ")}`);
 	}
 	return bullets.length > 0 ? bullets.join("\n") : null;
 }
 
-function isoDaysAgo(days: number): string {
+function isoDaysAgo(days: number): Date {
 	const d = new Date();
 	d.setUTCDate(d.getUTCDate() - days);
-	return d.toISOString();
+	return d;
 }
 
 /**
@@ -80,6 +88,65 @@ function personalUserId(
 	return { skip: false, userId: resolved.userId };
 }
 
+/**
+ * Pull recent agent_end traces via listMemories, sorted chronologically.
+ *
+ * Why list, not search: a date-window + relevance search ranks results by
+ * lexical similarity to a generic query, which is approximately random
+ * within a 7-day slice and can easily exclude yesterday in favor of a
+ * 5-day-old session. listMemories gives us true chronological recall.
+ *
+ * The SDK's list endpoint doesn't expose date or metadata filters in our
+ * wrapper, so we filter client-side. Buffer is capped at
+ * RECENT_BUFFER_LIMIT to bound wire cost; if a user has more than that
+ * many traces in the cutoff window we'll still get the newest ones,
+ * since the underlying API returns recency-ordered pages.
+ */
+async function fetchRecentTraces(
+	client: HyperspellClient,
+	cutoff: Date,
+	limit: number,
+	userId: string | undefined,
+): Promise<SearchResult[]> {
+	const buffer: SearchResult[] = [];
+	let scanned = 0;
+	const cutoffMs = cutoff.getTime();
+
+	for await (const memory of client.listMemories({
+		source: "trace",
+		userId,
+		pageSize: 50,
+	})) {
+		scanned++;
+		if (scanned > RECENT_BUFFER_LIMIT) break;
+
+		const meta = memory.metadata;
+		if (meta.openclaw_source !== "agent_end") continue;
+
+		const createdRaw = meta.created_at;
+		if (typeof createdRaw !== "string") continue;
+		const createdMs = new Date(createdRaw).getTime();
+		if (Number.isNaN(createdMs) || createdMs < cutoffMs) continue;
+
+		buffer.push({
+			resourceId: memory.resourceId,
+			title: memory.title,
+			source: memory.source,
+			score: null,
+			url: null,
+			createdAt: createdRaw,
+			highlights: [],
+		});
+	}
+
+	buffer.sort((a, b) => {
+		const at = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+		const bt = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+		return bt - at;
+	});
+	return buffer.slice(0, limit);
+}
+
 export function buildStartupOrientationHandler(
 	client: HyperspellClient,
 	cfg: HyperspellConfig,
@@ -88,6 +155,18 @@ export function buildStartupOrientationHandler(
 	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
 		const sessionKey = ctx?.sessionKey;
 		if (sessionKey && injectedSessions.has(sessionKey)) return;
+
+		const tries = (sessionKey && failedAttempts.get(sessionKey)) || 0;
+		if (tries >= MAX_ATTEMPTS) {
+			log.debug(
+				`startup-orientation: giving up after ${tries} failed attempt(s)`,
+			);
+			if (sessionKey) {
+				injectedSessions.add(sessionKey);
+				failedAttempts.delete(sessionKey);
+			}
+			return;
+		}
 
 		const { skip, userId } = personalUserId(cfg, ctx);
 		if (skip) {
@@ -98,41 +177,49 @@ export function buildStartupOrientationHandler(
 			return;
 		}
 
-		const after = isoDaysAgo(so.recentDays);
+		const cutoff = isoDaysAgo(so.recentDays);
 
 		const [recentSettled, loopsSettled] = await Promise.allSettled([
-			client.search(so.recentQuery, {
-				limit: so.recentLimit,
-				after,
-				filter: RECENT_FILTER,
-				userId,
-			}),
+			fetchRecentTraces(client, cutoff, so.recentLimit, userId),
 			client.search(so.loopsQuery, {
 				limit: so.loopsLimit,
 				userId,
 			}),
 		]);
 
-		const recent =
-			recentSettled.status === "fulfilled" ? recentSettled.value : [];
-		if (recentSettled.status === "rejected") {
+		const recentOk = recentSettled.status === "fulfilled";
+		const loopsOk = loopsSettled.status === "fulfilled";
+		const recent = recentOk ? recentSettled.value : [];
+		const loops = loopsOk ? loopsSettled.value : [];
+
+		if (!recentOk) {
 			log.error(
-				"startup-orientation: recent search failed",
-				recentSettled.reason,
+				"startup-orientation: recent listMemories failed",
+				(recentSettled as PromiseRejectedResult).reason,
 			);
 		}
-		const loops = loopsSettled.status === "fulfilled" ? loopsSettled.value : [];
-		if (loopsSettled.status === "rejected") {
+		if (!loopsOk) {
 			log.error(
 				"startup-orientation: loops search failed",
-				loopsSettled.reason,
+				(loopsSettled as PromiseRejectedResult).reason,
 			);
+		}
+
+		if (!recentOk && !loopsOk) {
+			if (sessionKey) failedAttempts.set(sessionKey, tries + 1);
+			log.debug(
+				`startup-orientation: both calls failed (attempt ${tries + 1}/${MAX_ATTEMPTS}); will retry next turn`,
+			);
+			return;
+		}
+
+		if (sessionKey) {
+			injectedSessions.add(sessionKey);
+			failedAttempts.delete(sessionKey);
 		}
 
 		const recentBody = formatRecentInteractions(recent);
 		const loopsBody = formatUnfinishedLoops(loops);
-
-		if (sessionKey) injectedSessions.add(sessionKey);
 
 		if (!recentBody && !loopsBody) {
 			log.debug("startup-orientation: nothing to inject");
@@ -144,7 +231,7 @@ export function buildStartupOrientationHandler(
 			blocks.push(
 				[
 					"<hyperspell-recent-interactions>",
-					`Your last ${so.recentDays} days of conversations with this user, most-relevant-first. Use for situational continuity — don't quote verbatim.`,
+					`Your last ${so.recentDays} days of conversations with this user, most-recent-first. Use for situational continuity — don't quote verbatim.`,
 					"",
 					recentBody,
 					"</hyperspell-recent-interactions>",
@@ -173,7 +260,10 @@ export function buildStartupOrientationHandler(
 export function buildStartupOrientationCompactionHandler() {
 	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
 		const sessionKey = ctx?.sessionKey;
-		if (sessionKey && injectedSessions.delete(sessionKey)) {
+		if (!sessionKey) return;
+		const dropped = injectedSessions.delete(sessionKey);
+		failedAttempts.delete(sessionKey);
+		if (dropped) {
 			log.debug(
 				`startup-orientation: cache cleared after compaction (session=${sessionKey})`,
 			);
@@ -184,6 +274,8 @@ export function buildStartupOrientationCompactionHandler() {
 export function buildStartupOrientationSessionCleanupHandler() {
 	return async (_event: Record<string, unknown>, ctx?: AgentContext) => {
 		const sessionKey = ctx?.sessionKey;
-		if (sessionKey) injectedSessions.delete(sessionKey);
+		if (!sessionKey) return;
+		injectedSessions.delete(sessionKey);
+		failedAttempts.delete(sessionKey);
 	};
 }

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -26,7 +26,6 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
       recentDays: 7,
       recentLimit: 5,
       loopsLimit: 3,
-      recentQuery: "conversation",
       loopsQuery: "open tasks",
     },
     multiUser: overrides.scoping

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,6 +41,11 @@
 			"help": "Maintain emotional continuity across sessions — remembers not just what happened, but how it felt",
 			"advanced": true
 		},
+		"startupOrientation": {
+			"label": "Startup Orientation",
+			"help": "Inject recent-interactions and unfinished-loops blocks once per session at startup. Costs two extra calls + ~500–800 tokens of injection per session; off by default.",
+			"advanced": true
+		},
 		"relationshipId": {
 			"label": "Relationship ID",
 			"placeholder": "partner-anna",
@@ -116,6 +121,16 @@
 			},
 			"relationshipId": {
 				"type": "string"
+			},
+			"startupOrientation": {
+				"type": "object",
+				"properties": {
+					"enabled": { "type": "boolean" },
+					"recentDays": { "type": "number", "minimum": 1, "maximum": 90 },
+					"recentLimit": { "type": "number", "minimum": 1, "maximum": 20 },
+					"loopsLimit": { "type": "number", "minimum": 1, "maximum": 20 },
+					"loopsQuery": { "type": "string" }
+				}
 			},
 			"sources": {
 				"type": "string"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Four hardening fixes to the startup-orientation feature shipped via #24. PR #22 was opened separately for review but its content landed early through #24's multi-commit merge before these issues were caught.

- **Sanitize the new injection markers in outgoing traces.** `<hyperspell-recent-interactions>` and `<hyperspell-unfinished-loops>` were not in `sanitizeTraceText` (`hooks/auto-trace.ts`), so a session's prepended block got captured into the auto-trace, indexed as an `agent_end` trace, then retrieved on the next session by the recent-interactions search itself — a self-amplifying pollution loop matching the class fixed in #19.
- **Replace the recent-interactions search with `listMemories`.** A relevance search over a date window with a generic query was approximately a random sort within that window — a worst-case had yesterday's session excluded in favor of an older session that happened to mention the word "session" more. Now uses `client.listMemories({source:"trace"})` with client-side filtering for `openclaw_source=agent_end` and the date window, then sorts desc by `created_at`. True chronological recall. Drops the now-unused `recentQuery` config field.
- **Add a retry budget for total-failure first turns.** Previously, any first-turn outcome (including a transient API hiccup) marked the session as injected, locking out orientation for the rest of the session. Now tracks failed attempts separately and only marks injected when at least one of the two calls succeeds. Capped at `MAX_ATTEMPTS=2`.
- **Declare `startupOrientation` in the plugin schema.** `openclaw.plugin.json` had `additionalProperties: false` and didn't list the key, so OpenClaw's loader would reject configs including it — same class of footgun the `dreaming` key hit in #20.

Closes #22.

## Test plan

- [x] `npm run check-types` clean
- [x] `npm test` — 59/59 pass (8 new lifecycle/retry/sort tests, 2 sanitizer tests, replaces the search-mock tests with list-mock equivalents)
- [x] `npx @biomejs/biome ci` clean on touched files
- [ ] Smoke against a real Hyperspell user with auto-trace traces: confirm recent-interactions block is chronological and matches expectation, retry path triggers on simulated outage, sanitizer prevents the recursion in next-session traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)