### PR TITLE
feat: Smart section-level memory sync with change detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ npm-debug.log*
 # TypeScript cache
 *.tsbuildinfo
 __pycache__/
+.aider*

--- a/client.ts
+++ b/client.ts
@@ -392,6 +392,38 @@ export class HyperspellClient {
 		return raw;
 	}
 
+	/**
+	 * Delete a memory by resource id. Memory-sync uploads land in the "vault"
+	 * source (user-added documents), so that is the default. Best-effort: a
+	 * 404 (already gone) is treated as success so callers can prune their
+	 * local manifest unconditionally.
+	 */
+	async deleteMemory(
+		resourceId: string,
+		options?: { source?: HyperspellSource; userId?: string },
+	): Promise<{ deleted: boolean }> {
+		const source = options?.source ?? "vault";
+		log.debugRequest("memories.delete", { resourceId, source });
+
+		try {
+			await this.client.memories.delete(
+				resourceId,
+				{ source },
+				this.requestOptions(options?.userId),
+			);
+			log.debugResponse("memories.delete", { resourceId, deleted: true });
+			return { deleted: true };
+		} catch (err) {
+			const status = (err as { status?: number })?.status;
+			if (status === 404) {
+				log.debug(`Memory ${resourceId} already absent (404) — treating as deleted`);
+				return { deleted: true };
+			}
+			log.error(`Failed to delete memory ${resourceId}`, err);
+			return { deleted: false };
+		}
+	}
+
 	async sendTrace(
 		history: string,
 		options?: {

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -5,7 +5,11 @@ import { userInfo } from "node:os"
 import * as p from "@clack/prompts"
 import type { Command } from "commander"
 import Hyperspell from "hyperspell"
-import { syncAllMemoryFiles, getMemoryFiles } from "../sync/markdown.ts"
+import {
+  syncAllFilesSectionized,
+  syncAllMemoryFiles,
+  getMemoryFiles,
+} from "../sync/markdown.ts"
 import { openInBrowser } from "../lib/browser.ts"
 import { HyperspellClient } from "../client.ts"
 import { getWorkspaceDir, parseConfig, resolveConfigPath } from "../config.ts"
@@ -355,15 +359,20 @@ async function runSetup(): Promise<void> {
         },
       })
 
-      const result = await syncAllMemoryFiles(hyperspellClient, workspaceDir)
+      // Use the same sectionized path the runtime uses, so a fresh setup
+      // doesn't whole-file-upload everything and then get re-synced as
+      // sections on first gateway start (= duplicate memories).
+      const result = await syncAllFilesSectionized(hyperspellClient, workspaceDir)
 
       if (result.failed > 0) {
-        s3.stop(`Synced ${result.synced} files, ${result.failed} failed`)
+        s3.stop(
+          `Synced ${result.synced} section(s), ${result.skipped} unchanged, ${result.failed} failed`,
+        )
         for (const error of result.errors) {
           p.log.error(`  ${error}`)
         }
       } else {
-        s3.stop(`Synced ${result.synced} memory files`)
+        s3.stop(`Synced ${result.synced} section(s) (${result.skipped} unchanged)`)
       }
     } else {
       p.log.info("No memory files found in memory/ directory")
@@ -671,7 +680,12 @@ export function registerCliCommands(program: Command, pluginConfig: unknown): vo
         const client = new HyperspellClient(cfg)
         const workspaceDir = getWorkspaceDir()
 
-        const result = await syncAllMemoryFiles(client, workspaceDir)
+        // Mirror the runtime's sync mode so this manual command can't
+        // produce whole-file blobs that the gateway then re-syncs as
+        // sections (= duplicate memories).
+        const result = cfg.syncMemoriesConfig.sectionize
+          ? await syncAllFilesSectionized(client, workspaceDir)
+          : await syncAllMemoryFiles(client, workspaceDir)
         process.stdout.write(`Synced ${result.synced} files, ${result.failed} failed\n`)
         if (result.errors.length > 0) {
           for (const error of result.errors) {

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -335,6 +335,12 @@ async function runSetup(): Promise<void> {
         autoTrace: { enabled: false, extract: ["procedure"] },
         emotionalContext: false,
         syncMemories: true,
+        syncMemoriesConfig: {
+          enabled: true,
+          sectionize: true,
+          watchPaths: [],
+          debounceMs: 2000,
+        },
         sources: [],
         maxResults: 10,
         relevanceThreshold: 0.6,

--- a/config.test.ts
+++ b/config.test.ts
@@ -227,3 +227,40 @@ test("parseConfig — startupOrientation accepts overrides", () => {
   assert.equal(cfg.startupOrientation.loopsLimit, 5)
   assert.equal(cfg.startupOrientation.loopsQuery, "custom loops")
 })
+
+test("parseConfig — syncMemories boolean true keeps legacy behavior, sectionize defaults on", () => {
+  const cfg = parseConfig({ ...base, syncMemories: true })
+  assert.equal(cfg.syncMemories, true)
+  assert.equal(cfg.syncMemoriesConfig.enabled, true)
+  assert.equal(cfg.syncMemoriesConfig.sectionize, true)
+  assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, [])
+  assert.equal(cfg.syncMemoriesConfig.debounceMs, 2000)
+})
+
+test("parseConfig — syncMemories false disables sync", () => {
+  const cfg = parseConfig({ ...base, syncMemories: false })
+  assert.equal(cfg.syncMemories, false)
+  assert.equal(cfg.syncMemoriesConfig.enabled, false)
+})
+
+test("parseConfig — syncMemories object form parses and enables by default", () => {
+  const cfg = parseConfig({
+    ...base,
+    syncMemories: {
+      sectionize: false,
+      watchPaths: ["MEMORY.md", "notes/"],
+      debounceMs: 500,
+    },
+  })
+  assert.equal(cfg.syncMemories, true) // object without explicit enabled => on
+  assert.equal(cfg.syncMemoriesConfig.sectionize, false)
+  assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, ["MEMORY.md", "notes/"])
+  assert.equal(cfg.syncMemoriesConfig.debounceMs, 500)
+})
+
+test("parseConfig — syncMemories object with a typo'd key throws", () => {
+  assert.throws(
+    () => parseConfig({ ...base, syncMemories: { sectionise: true } }),
+    /hyperspell\.syncMemories has unknown keys: sectionise/,
+  )
+})

--- a/config.ts
+++ b/config.ts
@@ -86,6 +86,16 @@ export function normalizeScope(scope: ScopeName): string {
 	return scope.replace(/[^a-zA-Z0-9_]/g, "_");
 }
 
+export type SyncMemoriesConfig = {
+	enabled: boolean;
+	/** Split files by ## headings into separate memories (default: true) */
+	sectionize: boolean;
+	/** Additional paths to watch beyond memory/ (relative to workspace or absolute) */
+	watchPaths: string[];
+	/** Debounce file changes in ms to avoid syncing mid-write (default: 2000) */
+	debounceMs: number;
+};
+
 export type HyperspellConfig = {
 	apiKey: string;
 	userId?: string;
@@ -95,6 +105,7 @@ export type HyperspellConfig = {
 	relationshipId?: string;
 	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
+	syncMemoriesConfig: SyncMemoriesConfig;
 	sources: HyperspellSource[];
 	maxResults: number;
 	relevanceThreshold: number;
@@ -386,6 +397,19 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 	const atRaw = (cfg.autoTrace ?? {}) as Record<string, unknown>;
 	const soRaw = (cfg.startupOrientation ?? {}) as Record<string, unknown>;
 
+	// syncMemories can be a boolean (legacy) or an object (new)
+	const smRaw = cfg.syncMemories;
+	const syncMemoriesEnabled =
+		typeof smRaw === "boolean"
+			? smRaw
+			: typeof smRaw === "object" && smRaw !== null
+				? ((smRaw as Record<string, unknown>).enabled as boolean) ?? true
+				: false;
+	const smObj =
+		typeof smRaw === "object" && smRaw !== null
+			? (smRaw as Record<string, unknown>)
+			: {};
+
 	return {
 		apiKey,
 		userId: cfg.userId as string | undefined,
@@ -410,7 +434,15 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 				(soRaw.loopsQuery as string) ??
 				"open tasks pending questions unfinished promised need to follow up",
 		},
-		syncMemories: (cfg.syncMemories as boolean) ?? false,
+		syncMemories: syncMemoriesEnabled,
+		syncMemoriesConfig: {
+			enabled: syncMemoriesEnabled,
+			sectionize: (smObj.sectionize as boolean) ?? true,
+			watchPaths: Array.isArray(smObj.watchPaths)
+				? (smObj.watchPaths as string[])
+				: [],
+			debounceMs: (smObj.debounceMs as number) ?? 2000,
+		},
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,
 		relevanceThreshold: (cfg.relevanceThreshold as number) ?? 0.6,

--- a/config.ts
+++ b/config.ts
@@ -410,6 +410,17 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			? (smRaw as Record<string, unknown>)
 			: {};
 
+	// The rest of parseConfig is strict about unknown keys; the syncMemories
+	// object form must be too, or a typo (sectionise/debounceMS) is silently
+	// ignored and the user gets default behavior they didn't ask for.
+	if (typeof smRaw === "object" && smRaw !== null && !Array.isArray(smRaw)) {
+		assertAllowedKeys(
+			smObj,
+			["enabled", "sectionize", "watchPaths", "debounceMs"],
+			"hyperspell.syncMemories",
+		);
+	}
+
 	return {
 		apiKey,
 		userId: cfg.userId as string | undefined,

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -67,9 +67,9 @@ export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellCo
           workspaceDir,
           { userId: syncUserId },
         )
-        if (result.synced > 0) {
+        if (result.synced > 0 || result.removed > 0) {
           log.info(
-            `Section-synced ${fileName}: ${result.synced} synced, ${result.skipped} unchanged`,
+            `Section-synced ${fileName}: ${result.synced} synced, ${result.skipped} unchanged, ${result.removed} removed`,
           )
         } else if (result.skipped > 0) {
           log.debug(`${fileName}: all ${result.skipped} sections unchanged`)
@@ -141,7 +141,7 @@ export async function syncMemoriesOnStartup(
     })
 
     log.info(
-      `Section sync complete: ${result.synced} synced, ${result.skipped} unchanged, ${result.failed} failed`,
+      `Section sync complete: ${result.synced} synced, ${result.skipped} unchanged, ${result.removed} removed, ${result.failed} failed`,
     )
     if (result.failed > 0) {
       for (const error of result.errors) {

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -43,7 +43,7 @@ export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellCo
     if (!filePath.endsWith(".md")) return false
 
     // Always sync memory/ files
-    if (filePath.startsWith(memoryDir)) return true
+    if (filePath.startsWith(memoryDir + path.sep)) return true
 
     // Check additional watch paths
     for (const wp of resolvedWatchPaths) {

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -3,63 +3,167 @@ import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
 import { getWorkspaceDir } from "../config.ts"
 import { log } from "../logger.ts"
-import { syncMarkdownFile, syncAllMemoryFiles } from "../sync/markdown.ts"
+import {
+  syncMarkdownFile,
+  syncMarkdownFileSectionized,
+  syncAllMemoryFiles,
+  syncAllFilesSectionized,
+} from "../sync/markdown.ts"
 
 /**
- * Build a handler for file change events that syncs markdown files to Hyperspell
+ * Build a handler for file change events that syncs markdown files to Hyperspell.
+ *
+ * When `sectionize` is enabled (default for new config), files are split by
+ * ## headings and each section is synced as a separate memory. Unchanged
+ * sections (tracked by content hash) are skipped.
+ *
+ * When `sectionize` is false (legacy mode), entire files are uploaded as
+ * single memories.
  */
 export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellConfig) {
   const workspaceDir = getWorkspaceDir()
   const memoryDir = path.join(workspaceDir, "memory")
   const syncUserId = cfg.multiUser?.sharedUserId
+  const sectionize = cfg.syncMemoriesConfig.sectionize
+  const watchPaths = cfg.syncMemoriesConfig.watchPaths
+  const debounceMs = cfg.syncMemoriesConfig.debounceMs
 
-  return async (event: Record<string, unknown>) => {
-    const filePath = event.file_path as string | undefined
-    if (!filePath) return
+  // Resolve additional watch paths to absolute paths for matching
+  const resolvedWatchPaths = (watchPaths ?? []).map((wp) =>
+    wp.startsWith("/") ? wp : path.join(workspaceDir, wp),
+  )
 
-    // Only process markdown files in the workspace's memory directory
-    if (!filePath.startsWith(memoryDir) || !filePath.endsWith(".md")) {
-      return
+  // Debounce map: filePath -> timeout handle
+  const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  /**
+   * Check whether a file path is syncable (in memory/ or in a watchPath).
+   */
+  function isSyncable(filePath: string): boolean {
+    if (!filePath.endsWith(".md")) return false
+
+    // Always sync memory/ files
+    if (filePath.startsWith(memoryDir)) return true
+
+    // Check additional watch paths
+    for (const wp of resolvedWatchPaths) {
+      if (filePath === wp || filePath.startsWith(wp + "/")) {
+        return true
+      }
     }
 
+    return false
+  }
+
+  async function doSync(filePath: string) {
     const fileName = path.basename(filePath)
     log.info(`Memory file changed: ${fileName}`)
 
     try {
-      const result = await syncMarkdownFile(client, filePath, { userId: syncUserId })
-      if (result.success) {
-        log.info(`Synced ${fileName} -> ${result.resourceId}`)
+      if (sectionize) {
+        const result = await syncMarkdownFileSectionized(
+          client,
+          filePath,
+          workspaceDir,
+          { userId: syncUserId },
+        )
+        if (result.synced > 0) {
+          log.info(
+            `Section-synced ${fileName}: ${result.synced} synced, ${result.skipped} unchanged`,
+          )
+        } else if (result.skipped > 0) {
+          log.debug(`${fileName}: all ${result.skipped} sections unchanged`)
+        }
+        if (result.failed > 0) {
+          log.error(`${fileName}: ${result.failed} sections failed:`)
+          for (const err of result.errors) {
+            log.error(`  - ${err}`)
+          }
+        }
       } else {
-        log.error(`Failed to sync ${fileName}: ${result.error}`)
+        // Legacy whole-file sync
+        const result = await syncMarkdownFile(client, filePath, { userId: syncUserId })
+        if (result.success) {
+          log.info(`Synced ${fileName} -> ${result.resourceId}`)
+        } else {
+          log.error(`Failed to sync ${fileName}: ${result.error}`)
+        }
       }
     } catch (err) {
       log.error(`Error syncing ${fileName}`, err)
     }
   }
+
+  return async (event: Record<string, unknown>) => {
+    const filePath = event.file_path as string | undefined
+    if (!filePath) return
+
+    if (!isSyncable(filePath)) return
+
+    // Debounce: if the file changes rapidly (agent writing in chunks),
+    // wait until writes settle before syncing.
+    if (debounceMs > 0) {
+      const existing = debounceTimers.get(filePath)
+      if (existing) clearTimeout(existing)
+
+      debounceTimers.set(
+        filePath,
+        setTimeout(() => {
+          debounceTimers.delete(filePath)
+          doSync(filePath).catch((err) => log.error("Debounced sync failed", err))
+        }, debounceMs),
+      )
+    } else {
+      await doSync(filePath)
+    }
+  }
 }
 
 /**
- * Sync all existing memory files on startup
+ * Sync all existing memory files on startup.
+ * Uses section-level sync when sectionize is enabled.
  */
 export async function syncMemoriesOnStartup(
   client: HyperspellClient,
   workspaceDir: string,
-  options?: { userId?: string },
+  options?: {
+    userId?: string
+    sectionize?: boolean
+    watchPaths?: string[]
+  },
 ): Promise<void> {
   log.info("Syncing existing memory files...")
 
-  const result = await syncAllMemoryFiles(client, workspaceDir, { userId: options?.userId })
+  if (options?.sectionize) {
+    const result = await syncAllFilesSectionized(client, workspaceDir, {
+      userId: options.userId,
+      watchPaths: options.watchPaths,
+    })
 
-  if (result.synced > 0) {
-    log.info(`Synced ${result.synced} memory files`)
-  }
-  if (result.failed > 0) {
-    log.error(`Failed to sync ${result.failed} files:`)
-    for (const error of result.errors) {
-      log.error(`  - ${error}`)
+    log.info(
+      `Section sync complete: ${result.synced} synced, ${result.skipped} unchanged, ${result.failed} failed`,
+    )
+    if (result.failed > 0) {
+      for (const error of result.errors) {
+        log.error(`  - ${error}`)
+      }
     }
-  }
-  if (result.synced === 0 && result.failed === 0) {
-    log.info("No memory files found in memory/ directory")
+  } else {
+    const result = await syncAllMemoryFiles(client, workspaceDir, {
+      userId: options?.userId,
+    })
+
+    if (result.synced > 0) {
+      log.info(`Synced ${result.synced} memory files`)
+    }
+    if (result.failed > 0) {
+      log.error(`Failed to sync ${result.failed} files:`)
+      for (const error of result.errors) {
+        log.error(`  - ${error}`)
+      }
+    }
+    if (result.synced === 0 && result.failed === 0) {
+      log.info("No memory files found in memory/ directory")
+    }
   }
 }

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -66,6 +66,12 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 			loopsQuery: "open tasks pending questions",
 		},
 		syncMemories: false,
+		syncMemoriesConfig: {
+			enabled: false,
+			sectionize: true,
+			watchPaths: [],
+			debounceMs: 2000,
+		},
 		sources: [],
 		maxResults: 10,
 		relevanceThreshold: 0.6,

--- a/index.ts
+++ b/index.ts
@@ -133,6 +133,9 @@ export default {
 		if (cfg.syncMemories) {
 			const fileSyncHandler = buildFileSyncHandler(client, cfg);
 			api.on("file_changed", fileSyncHandler);
+			api.logger.info(
+				`hyperspell: memory sync enabled (sectionize=${cfg.syncMemoriesConfig.sectionize}, watchPaths=${cfg.syncMemoriesConfig.watchPaths.length})`,
+			);
 		}
 
 		// Register memory network tools
@@ -154,6 +157,8 @@ export default {
 					const workspaceDir = getWorkspaceDir();
 					await syncMemoriesOnStartup(client, workspaceDir, {
 						userId: cfg.multiUser?.sharedUserId,
+						sectionize: cfg.syncMemoriesConfig.sectionize,
+						watchPaths: cfg.syncMemoriesConfig.watchPaths,
 					});
 				}
 			},

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -16,6 +16,12 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     autoTrace: { enabled: false, extract: ["procedure"] },
     emotionalContext: false,
     syncMemories: false,
+    syncMemoriesConfig: {
+      enabled: false,
+      sectionize: true,
+      watchPaths: [],
+      debounceMs: 2000,
+    },
     sources: [],
     maxResults: 5,
     relevanceThreshold: 0.6,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -71,7 +71,7 @@
 		},
 		"syncMemories": {
 			"label": "Sync Memory Files",
-			"help": "Automatically sync markdown files in workspace/memory/ to Hyperspell",
+			"help": "Automatically sync markdown files to Hyperspell. Set to true for defaults, or use an object for fine-grained control: { sectionize: true, watchPaths: ['MEMORY.md', 'notes/'], debounceMs: 2000 }",
 			"advanced": true
 		},
 		"knowledgeGraph": {
@@ -144,7 +144,30 @@
 				"type": "boolean"
 			},
 			"syncMemories": {
-				"type": "boolean"
+				"oneOf": [
+					{ "type": "boolean" },
+					{
+						"type": "object",
+						"properties": {
+							"enabled": { "type": "boolean" },
+							"sectionize": {
+								"type": "boolean",
+								"description": "Split files by ## headings into separate memories for better retrieval granularity (default: true)"
+							},
+							"watchPaths": {
+								"type": "array",
+								"items": { "type": "string" },
+								"description": "Additional paths to watch beyond memory/ (relative to workspace or absolute)"
+							},
+							"debounceMs": {
+								"type": "number",
+								"minimum": 0,
+								"maximum": 30000,
+								"description": "Debounce file changes in ms to avoid syncing mid-write (default: 2000)"
+							}
+						}
+					}
+				]
 			},
 			"knowledgeGraph": {
 				"type": "object",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
+    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/sync/markdown.test.ts
+++ b/sync/markdown.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { test } from "node:test"
+import type { HyperspellClient } from "../client.ts"
+import {
+  dedupeTitles,
+  fileKey,
+  loadManifest,
+  parseMarkdownSections,
+  saveManifest,
+  syncMarkdownFileSectionized,
+  withSyncLock,
+} from "./markdown.ts"
+
+// Bodies must exceed the 80-char short-section merge threshold so each ##
+// stays its own section.
+const BODY_A =
+  "Section A body — long enough to clear the eighty character merge threshold for sure."
+const BODY_A2 =
+  "Section A REWRITTEN — still well past the eighty character threshold so it stays a section."
+const BODY_B =
+  "Section B body — also comfortably over the eighty character short-merge threshold here."
+
+// ---------------------------------------------------------------------------
+// parseMarkdownSections
+// ---------------------------------------------------------------------------
+
+test("parseMarkdownSections — splits on ## headings", () => {
+  const sections = parseMarkdownSections(`## A\n${BODY_A}\n## B\n${BODY_B}`, "note")
+  assert.equal(sections.length, 2)
+  assert.deepEqual(
+    sections.map((s) => s.title),
+    ["A", "B"],
+  )
+  assert.equal(sections[0].content, BODY_A)
+  assert.equal(sections[1].content, BODY_B)
+  // 16-hex content hash
+  assert.match(sections[0].contentHash, /^[0-9a-f]{16}$/)
+})
+
+test("parseMarkdownSections — short trailing section merges into previous", () => {
+  const content = [
+    "# 2026-05-09 — Saturday",
+    "",
+    "## The day David's mum got sick",
+    BODY_A,
+    "",
+    "## What I'm holding",
+    BODY_B,
+    "",
+    "## Short note",
+    "🖤",
+  ].join("\n")
+
+  const sections = parseMarkdownSections(content, "note")
+  assert.equal(sections.length, 2)
+  assert.deepEqual(
+    sections.map((s) => s.title),
+    ["The day David's mum got sick", "What I'm holding"],
+  )
+  // The < 80-char "Short note" folds into the previous section.
+  assert.match(sections[1].content, /### Short note/)
+  assert.match(sections[1].content, /🖤/)
+})
+
+test("parseMarkdownSections — empty/whitespace content yields no sections", () => {
+  assert.deepEqual(parseMarkdownSections("", "note"), [])
+  assert.deepEqual(parseMarkdownSections("   \n\n  ", "note"), [])
+})
+
+test("parseMarkdownSections — content hash is stable and change-sensitive", () => {
+  const a = parseMarkdownSections(`## A\n${BODY_A}`, "note")[0]
+  const aAgain = parseMarkdownSections(`## A\n${BODY_A}`, "note")[0]
+  const aEdited = parseMarkdownSections(`## A\n${BODY_A2}`, "note")[0]
+  assert.equal(a.contentHash, aAgain.contentHash)
+  assert.notEqual(a.contentHash, aEdited.contentHash)
+})
+
+// ---------------------------------------------------------------------------
+// dedupeTitles
+// ---------------------------------------------------------------------------
+
+test("dedupeTitles — disambiguates repeated section titles", () => {
+  const parsed = parseMarkdownSections(`## Dup\n${BODY_A}\n## Dup\n${BODY_B}`, "note")
+  const deduped = dedupeTitles(parsed)
+  assert.deepEqual(
+    deduped.map((s) => s.title),
+    ["Dup", "Dup (2)"],
+  )
+})
+
+// ---------------------------------------------------------------------------
+// fileKey — workspace-relative, posix-normalized, portable
+// ---------------------------------------------------------------------------
+
+test("fileKey — relative to workspace, never absolute", () => {
+  assert.equal(fileKey("/ws", "/ws/memory/2026-05-09.md"), "memory/2026-05-09.md")
+  assert.equal(fileKey("/ws", "/ws/MEMORY.md"), "MEMORY.md")
+})
+
+test("fileKey — files outside the workspace stay deterministic", () => {
+  assert.equal(fileKey("/ws/sub", "/ws/other.md"), "../other.md")
+})
+
+// ---------------------------------------------------------------------------
+// loadManifest / saveManifest — self-healing + roundtrip
+// ---------------------------------------------------------------------------
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "hs-sync-"))
+}
+
+test("loadManifest — missing file returns empty manifest", () => {
+  const dir = tmpDir()
+  try {
+    assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("loadManifest — legacy flat / garbage / wrong version self-heals to empty", () => {
+  const dir = tmpDir()
+  const p = path.join(dir, ".hyperspell-sync-hashes.json")
+  try {
+    fs.writeFileSync(p, '{"/abs/file.md::A":{"hash":"x","resourceId":"r"}}')
+    assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
+
+    fs.writeFileSync(p, "not json at all {")
+    assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
+
+    fs.writeFileSync(p, '{"version":99,"files":{}}')
+    assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("saveManifest/loadManifest — roundtrip", () => {
+  const dir = tmpDir()
+  try {
+    const manifest = {
+      version: 1,
+      files: { "memory/n.md": { sections: { A: { hash: "h", resourceId: "r" } } } },
+    }
+    saveManifest(dir, manifest)
+    assert.deepEqual(loadManifest(dir), manifest)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// withSyncLock — process-wide serialization
+// ---------------------------------------------------------------------------
+
+test("withSyncLock — serializes overlapping operations (no interleave)", async () => {
+  const events: string[] = []
+  const task = (id: number) =>
+    withSyncLock(async () => {
+      events.push(`s${id}`)
+      await new Promise((r) => setTimeout(r, 5))
+      events.push(`e${id}`)
+    })
+  await Promise.all([task(1), task(2), task(3)])
+  assert.deepEqual(events, ["s1", "e1", "s2", "e2", "s3", "e3"])
+})
+
+test("withSyncLock — a rejecting op does not wedge the chain", async () => {
+  await assert.rejects(
+    withSyncLock(async () => {
+      throw new Error("nope")
+    }),
+    /nope/,
+  )
+  const events: string[] = []
+  await withSyncLock(async () => {
+    events.push("ran")
+  })
+  assert.deepEqual(events, ["ran"])
+})
+
+// ---------------------------------------------------------------------------
+// syncMarkdownFileSectionized — incremental, rename, orphan, failure
+// ---------------------------------------------------------------------------
+
+type AddOptions = { resourceId?: string; title?: string }
+
+function makeClient(opts?: { failAddOn?: (text: string) => boolean; deleteOk?: boolean }) {
+  const addCalls: Array<{ text: string; options: AddOptions }> = []
+  const deleteCalls: string[] = []
+  let counter = 0
+  const client = {
+    async addMemory(text: string, options?: AddOptions) {
+      addCalls.push({ text, options: options ?? {} })
+      if (opts?.failAddOn?.(text)) throw new Error("addMemory boom")
+      return { resourceId: options?.resourceId ?? `res-${++counter}` }
+    },
+    async deleteMemory(resourceId: string) {
+      deleteCalls.push(resourceId)
+      return { deleted: opts?.deleteOk ?? true }
+    },
+  }
+  return { client: client as unknown as HyperspellClient, addCalls, deleteCalls }
+}
+
+function workspace(): { dir: string; note: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hs-sync-"))
+  fs.mkdirSync(path.join(dir, "memory"))
+  return {
+    dir,
+    note: path.join(dir, "memory", "note.md"),
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  }
+}
+
+test("syncMarkdownFileSectionized — first sync uploads every section, manifest keyed relative", async () => {
+  const ws = workspace()
+  const { client, addCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    assert.equal(r.synced, 2)
+    assert.equal(r.skipped, 0)
+    assert.equal(r.removed, 0)
+    assert.equal(addCalls.length, 2)
+
+    const manifest = loadManifest(ws.dir)
+    assert.deepEqual(Object.keys(manifest.files), ["memory/note.md"])
+    assert.deepEqual(
+      Object.keys(manifest.files["memory/note.md"].sections).sort(),
+      ["A", "B"],
+    )
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — unchanged re-sync skips everything (no uploads)", async () => {
+  const ws = workspace()
+  const { client, addCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+    const afterFirst = addCalls.length
+
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+    assert.equal(r.synced, 0)
+    assert.equal(r.skipped, 2)
+    assert.equal(addCalls.length, afterFirst) // no further uploads
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — edited section upserts under the same resourceId", async () => {
+  const ws = workspace()
+  const { client, addCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+    const base = addCalls.length
+
+    fs.writeFileSync(ws.note, `## A\n${BODY_A2}\n## B\n${BODY_B}`)
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    assert.equal(r.synced, 1)
+    assert.equal(r.skipped, 1)
+    const reupload = addCalls.slice(base)
+    assert.equal(reupload.length, 1)
+    assert.equal(reupload[0].options.resourceId, "res-1") // reused, not new
+    assert.match(reupload[0].options.title ?? "", /A$/)
+
+    // Third sync with no change proves the new hash persisted.
+    const r3 = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+    assert.equal(r3.synced, 0)
+    assert.equal(r3.skipped, 2)
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — renamed heading reuses resource, no duplicate, no orphan", async () => {
+  const ws = workspace()
+  const { client, addCalls, deleteCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+    const base = addCalls.length
+
+    // Rename "A" -> "C", body byte-identical.
+    fs.writeFileSync(ws.note, `## C\n${BODY_A}\n## B\n${BODY_B}`)
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    assert.equal(r.synced, 1) // the rename, updated in place
+    assert.equal(r.skipped, 1) // B untouched
+    assert.equal(r.removed, 0)
+    assert.equal(deleteCalls.length, 0) // not treated as a deletion
+
+    const reupload = addCalls.slice(base)
+    assert.equal(reupload.length, 1)
+    assert.equal(reupload[0].options.resourceId, "res-1") // reclaimed
+    assert.match(reupload[0].options.title ?? "", /C$/)
+
+    const sections = loadManifest(ws.dir).files["memory/note.md"].sections
+    assert.deepEqual(Object.keys(sections).sort(), ["B", "C"]) // "A" gone
+    assert.equal(sections.C.resourceId, "res-1")
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — deleted section is removed remotely and pruned", async () => {
+  const ws = workspace()
+  const { client, deleteCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}`) // B deleted
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    assert.equal(r.removed, 1)
+    assert.equal(r.synced, 0)
+    assert.equal(r.skipped, 1)
+    assert.deepEqual(deleteCalls, ["res-2"])
+
+    const sections = loadManifest(ws.dir).files["memory/note.md"].sections
+    assert.deepEqual(Object.keys(sections), ["A"])
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — duplicate ## titles become distinct memories", async () => {
+  const ws = workspace()
+  const { client, addCalls } = makeClient()
+  try {
+    fs.writeFileSync(ws.note, `## Dup\n${BODY_A}\n## Dup\n${BODY_B}`)
+    const r = await syncMarkdownFileSectionized(client, ws.note, ws.dir)
+
+    assert.equal(r.synced, 2)
+    const titles = addCalls.map((c) => c.options.title)
+    assert.match(titles[0] ?? "", /Dup$/)
+    assert.match(titles[1] ?? "", /Dup \(2\)$/)
+
+    const sections = loadManifest(ws.dir).files["memory/note.md"].sections
+    assert.deepEqual(Object.keys(sections).sort(), ["Dup", "Dup (2)"])
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — failed upload preserves resourceId (no duplicate next run)", async () => {
+  const ws = workspace()
+  try {
+    const first = makeClient()
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(first.client, ws.note, ws.dir)
+
+    // Edit A; this client throws on the new A content.
+    const failing = makeClient({ failAddOn: (t) => t === BODY_A2 })
+    fs.writeFileSync(ws.note, `## A\n${BODY_A2}\n## B\n${BODY_B}`)
+    const r = await syncMarkdownFileSectionized(failing.client, ws.note, ws.dir)
+
+    assert.equal(r.failed, 1)
+    assert.equal(r.synced, 0)
+    assert.equal(r.skipped, 1)
+    assert.equal(r.errors.length, 1)
+
+    // Prior record (resourceId) survived the transient failure.
+    const sections = loadManifest(ws.dir).files["memory/note.md"].sections
+    assert.equal(sections.A.resourceId, "res-1")
+
+    // Recovery run reuses res-1 instead of minting a duplicate.
+    const recover = makeClient()
+    const r2 = await syncMarkdownFileSectionized(recover.client, ws.note, ws.dir)
+    assert.equal(r2.synced, 1)
+    assert.equal(recover.addCalls[0].options.resourceId, "res-1")
+  } finally {
+    ws.cleanup()
+  }
+})

--- a/sync/markdown.test.ts
+++ b/sync/markdown.test.ts
@@ -78,6 +78,17 @@ test("parseMarkdownSections — content hash is stable and change-sensitive", ()
   assert.notEqual(a.contentHash, aEdited.contentHash)
 })
 
+test("parseMarkdownSections — '# ' line inside a section is content, not the file title", () => {
+  const content = `## A\n# This is body text, not a file title — and well over eighty chars long.\n${BODY_A}\n## B\n${BODY_B}`
+  const sections = parseMarkdownSections(content, "note")
+  assert.deepEqual(
+    sections.map((s) => s.title),
+    ["A", "B"],
+  )
+  // The '# ' line must be preserved in section A, not swallowed as a title.
+  assert.match(sections[0].content, /# This is body text, not a file title/)
+})
+
 // ---------------------------------------------------------------------------
 // dedupeTitles
 // ---------------------------------------------------------------------------
@@ -330,6 +341,36 @@ test("syncMarkdownFileSectionized — deleted section is removed remotely and pr
 
     const sections = loadManifest(ws.dir).files["memory/note.md"].sections
     assert.deepEqual(Object.keys(sections), ["A"])
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncMarkdownFileSectionized — failed orphan delete counts as failed and retries", async () => {
+  const ws = workspace()
+  try {
+    const ok = makeClient()
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    await syncMarkdownFileSectionized(ok.client, ws.note, ws.dir)
+
+    const failing = makeClient({ deleteOk: false })
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}`) // B deleted, but delete will fail
+    const r = await syncMarkdownFileSectionized(failing.client, ws.note, ws.dir)
+
+    assert.equal(r.removed, 0)
+    assert.equal(r.failed, 1) // delete failure is now counted
+    assert.equal(r.errors.length, 1)
+    assert.match(r.errors[0], /delete "B": failed/)
+
+    // B's record is retained so the delete is retried next run.
+    const sections = loadManifest(ws.dir).files["memory/note.md"].sections
+    assert.deepEqual(Object.keys(sections).sort(), ["A", "B"])
+    assert.equal(sections.B.resourceId, "res-2")
+
+    const retry = makeClient() // delete succeeds this time
+    const r2 = await syncMarkdownFileSectionized(retry.client, ws.note, ws.dir)
+    assert.equal(r2.removed, 1)
+    assert.deepEqual(retry.deleteCalls, ["res-2"])
   } finally {
     ws.cleanup()
   }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -24,13 +24,30 @@ interface MarkdownSection {
 }
 
 /**
- * Hash state file lives alongside the workspace memory dir.
- * Maps "filePath::sectionTitle" -> { hash, resourceId }
+ * Sync manifest persisted at <workspaceDir>/.hyperspell-sync-hashes.json.
+ *
+ * Keyed by workspace-RELATIVE file path so the manifest survives the workspace
+ * being mounted at a different absolute path (new host / container / $HOME).
+ * Each file tracks every section it has synced (title -> { hash, resourceId }),
+ * which lets re-sync detect renamed sections (same content hash resurfacing
+ * under a new title) and deleted sections (title gone from source) instead of
+ * leaking duplicate or orphaned memories into the retrieval layer.
  */
-interface SyncHashMap {
-  [key: string]: { hash: string; resourceId?: string }
+interface SectionRecord {
+  hash: string
+  resourceId?: string
 }
 
+interface FileManifest {
+  sections: Record<string, SectionRecord>
+}
+
+interface SyncManifest {
+  version: number
+  files: Record<string, FileManifest>
+}
+
+const MANIFEST_VERSION = 1
 const HASH_FILE_NAME = ".hyperspell-sync-hashes.json"
 
 // ---------------------------------------------------------------------------
@@ -187,37 +204,80 @@ export function parseMarkdownSections(
   return merged
 }
 
+/**
+ * Section titles key the manifest per file, so two sections sharing the same
+ * ## heading in one file would collide — one resourceId tracked, the other
+ * silently orphaned and re-uploaded on every sync. Disambiguate repeats so
+ * each section maps to a stable, unique key.
+ */
+export function dedupeTitles(sections: MarkdownSection[]): MarkdownSection[] {
+  const seen = new Map<string, number>()
+  return sections.map((s) => {
+    const n = (seen.get(s.title) ?? 0) + 1
+    seen.set(s.title, n)
+    return n === 1 ? s : { ...s, title: `${s.title} (${n})` }
+  })
+}
+
 // ---------------------------------------------------------------------------
-// Hash tracking (persisted to workspace)
+// Sync manifest (persisted to workspace, workspace-relative keys)
 // ---------------------------------------------------------------------------
 
-function hashFilePath(workspaceDir: string): string {
+function manifestPath(workspaceDir: string): string {
   return path.join(workspaceDir, HASH_FILE_NAME)
 }
 
-export function loadHashMap(workspaceDir: string): SyncHashMap {
-  const p = hashFilePath(workspaceDir)
+/** Workspace-relative, posix-normalized key so the manifest is portable. */
+export function fileKey(workspaceDir: string, filePath: string): string {
+  return path.relative(workspaceDir, filePath).split(path.sep).join("/")
+}
+
+function emptyManifest(): SyncManifest {
+  return { version: MANIFEST_VERSION, files: {} }
+}
+
+export function loadManifest(workspaceDir: string): SyncManifest {
+  const p = manifestPath(workspaceDir)
   try {
     if (fs.existsSync(p)) {
-      return JSON.parse(fs.readFileSync(p, "utf-8"))
+      const parsed = JSON.parse(fs.readFileSync(p, "utf-8")) as Partial<SyncManifest>
+      // Self-healing: an unrecognized/legacy shape is discarded. This feature
+      // has never shipped a released on-disk format, so nothing to migrate —
+      // a mismatch just triggers one re-sync, which is idempotent.
+      if (parsed && parsed.version === MANIFEST_VERSION && parsed.files) {
+        return { version: MANIFEST_VERSION, files: parsed.files }
+      }
     }
   } catch (err) {
-    log.error("Failed to read sync hash file", err)
+    log.error("Failed to read sync manifest", err)
   }
-  return {}
+  return emptyManifest()
 }
 
-export function saveHashMap(workspaceDir: string, map: SyncHashMap): void {
-  const p = hashFilePath(workspaceDir)
+export function saveManifest(workspaceDir: string, manifest: SyncManifest): void {
+  const p = manifestPath(workspaceDir)
   try {
-    fs.writeFileSync(p, JSON.stringify(map, null, 2))
+    fs.writeFileSync(p, JSON.stringify(manifest, null, 2))
   } catch (err) {
-    log.error("Failed to write sync hash file", err)
+    log.error("Failed to write sync manifest", err)
   }
 }
 
-function sectionKey(filePath: string, sectionTitle: string): string {
-  return `${filePath}::${sectionTitle}`
+/**
+ * Serializes manifest read-modify-write across the whole process. Startup bulk
+ * sync and the live file_changed handler (plus independent per-file debounce
+ * timers) would otherwise interleave load → await addMemory → save and lose
+ * resourceId entries, causing the next sync to re-upload sections as brand-new
+ * memories. Every load→sync→save runs inside this critical section.
+ */
+let syncChain: Promise<unknown> = Promise.resolve()
+export function withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = syncChain.then(fn, fn)
+  syncChain = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
 }
 
 // ---------------------------------------------------------------------------
@@ -354,74 +414,158 @@ export async function syncMarkdownFileSectionized(
   filePath: string,
   workspaceDir: string,
   options?: { userId?: string },
-): Promise<{ synced: number; skipped: number; failed: number; errors: string[] }> {
-  const file = readMarkdownFile(filePath)
-  if (!file || !file.content) {
-    return { synced: 0, skipped: 0, failed: 0, errors: file ? [] : ["Failed to read file"] }
-  }
-
-  const sections = parseMarkdownSections(file.content, file.title)
-  if (sections.length === 0) {
-    return { synced: 0, skipped: 0, failed: 0, errors: [] }
-  }
-
-  const hashMap = loadHashMap(workspaceDir)
-  const fileName = path.basename(filePath, ".md")
-  let synced = 0
-  let skipped = 0
-  let failed = 0
-  const errors: string[] = []
-
-  for (const section of sections) {
-    const key = sectionKey(filePath, section.title)
-    const existing = hashMap[key]
-
-    // Skip if content hasn't changed
-    if (existing?.hash === section.contentHash) {
-      skipped++
-      continue
-    }
-
-    // Build a title that includes file-level context for retrieval
-    // e.g. "2026-05-09: The day David's mum got sick"
-    const memoryTitle = file.title !== section.title
-      ? `${file.title} — ${section.title}`
-      : section.title
-
+): Promise<{
+  synced: number
+  skipped: number
+  failed: number
+  removed: number
+  errors: string[]
+}> {
+  return withSyncLock(async () => {
+    const empty = { synced: 0, skipped: 0, failed: 0, removed: 0, errors: [] as string[] }
     try {
-      const result = await client.addMemory(section.content, {
-        title: memoryTitle,
-        resourceId: existing?.resourceId,
-        collection: "openclaw",
-        metadata: {
-          openclaw_source: "memory_sync_section",
-          file_path: filePath,
-          file_name: fileName,
-          section_title: section.title,
-          content_hash: section.contentHash,
-        },
-        userId: options?.userId,
-      })
-
-      hashMap[key] = {
-        hash: section.contentHash,
-        resourceId: result.resourceId,
+      const file = readMarkdownFile(filePath)
+      if (!file || !file.content) {
+        return file ? empty : { ...empty, errors: ["Failed to read file"] }
       }
-      synced++
-      log.info(`Synced section: ${memoryTitle} -> ${result.resourceId}`)
+
+      const sections = dedupeTitles(parseMarkdownSections(file.content, file.title))
+      if (sections.length === 0) {
+        return empty
+      }
+
+      const manifest = loadManifest(workspaceDir)
+      const key = fileKey(workspaceDir, filePath)
+      const prevSections = manifest.files[key]?.sections ?? {}
+      const fileName = path.basename(filePath, ".md")
+
+      let synced = 0
+      let skipped = 0
+      let failed = 0
+      let removed = 0
+      let dirty = false
+      const errors: string[] = []
+
+      const currentTitles = new Set(sections.map((s) => s.title))
+
+      // Sections in the manifest but absent from the current parse are either
+      // renames (same content hash resurfacing under a new title) or true
+      // deletions. Index leftovers by content hash so a renamed section can
+      // reclaim its existing Hyperspell resource instead of creating a
+      // duplicate + orphan. Hash collisions among removed sections are rare
+      // and resolved best-effort (last writer wins).
+      const orphanByHash = new Map<string, { title: string; resourceId?: string }>()
+      for (const [title, rec] of Object.entries(prevSections)) {
+        if (!currentTitles.has(title)) {
+          orphanByHash.set(rec.hash, { title, resourceId: rec.resourceId })
+        }
+      }
+
+      const newSections: Record<string, SectionRecord> = {}
+
+      for (const section of sections) {
+        const prev = prevSections[section.title]
+
+        // Unchanged: keep the record, skip the upload.
+        if (prev && prev.hash === section.contentHash) {
+          newSections[section.title] = prev
+          skipped++
+          continue
+        }
+
+        // New title: if identical content was just removed under a different
+        // heading, this is a rename — reuse the resource and claim it so it is
+        // not also deleted as an orphan below.
+        let reuseResourceId = prev?.resourceId
+        if (!prev) {
+          const renamedFrom = orphanByHash.get(section.contentHash)
+          if (renamedFrom) {
+            reuseResourceId = renamedFrom.resourceId
+            orphanByHash.delete(section.contentHash)
+            log.info(
+              `Section renamed: "${renamedFrom.title}" -> "${section.title}" (${fileName}) — updating in place`,
+            )
+          }
+        }
+
+        const memoryTitle =
+          file.title !== section.title ? `${file.title} — ${section.title}` : section.title
+
+        try {
+          const result = await client.addMemory(section.content, {
+            title: memoryTitle,
+            resourceId: reuseResourceId,
+            collection: "openclaw",
+            metadata: {
+              openclaw_source: "memory_sync_section",
+              file_path: filePath,
+              file_name: fileName,
+              section_title: section.title,
+              content_hash: section.contentHash,
+            },
+            userId: options?.userId,
+          })
+
+          newSections[section.title] = {
+            hash: section.contentHash,
+            resourceId: result.resourceId,
+          }
+          synced++
+          dirty = true
+          log.info(`Synced section: ${memoryTitle} -> ${result.resourceId}`)
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err)
+          errors.push(`${memoryTitle}: ${errorMsg}`)
+          failed++
+          // Preserve the prior record so a transient failure does not drop the
+          // resourceId and force a duplicate upload next run.
+          if (prev) newSections[section.title] = prev
+        }
+      }
+
+      // Whatever remains is a genuine deletion: gone from source, no rename
+      // reclaimed it. Delete the remote memory so retrieval does not keep
+      // serving content the user removed.
+      for (const { title, resourceId } of orphanByHash.values()) {
+        if (!resourceId) {
+          // Never got a resourceId — nothing to delete, just drop the record.
+          dirty = true
+          continue
+        }
+        const { deleted } = await client.deleteMemory(resourceId, {
+          userId: options?.userId,
+        })
+        if (deleted) {
+          removed++
+          dirty = true
+          log.info(`Removed deleted section "${title}" (${fileName}) -> ${resourceId}`)
+        } else {
+          // Keep the record so the delete is retried next run rather than
+          // silently leaking the orphan into the retrieval layer.
+          newSections[title] = prevSections[title]
+          errors.push(`delete "${title}": failed`)
+        }
+      }
+
+      if (Object.keys(newSections).length > 0) {
+        manifest.files[key] = { sections: newSections }
+      } else {
+        delete manifest.files[key]
+      }
+
+      if (dirty) {
+        saveManifest(workspaceDir, manifest)
+      }
+
+      return { synced, skipped, failed, removed, errors }
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err)
-      errors.push(`${memoryTitle}: ${errorMsg}`)
-      failed++
+      // The body is defensive everywhere above; this guards the lock chain
+      // against an unexpected throw so one bad file cannot wedge the queue.
+      const msg = err instanceof Error ? err.message : String(err)
+      log.error(`Sectionized sync crashed for ${filePath}`, err)
+      return { ...empty, errors: [msg] }
     }
-  }
-
-  // Persist updated hashes
-  if (synced > 0) {
-    saveHashMap(workspaceDir, hashMap)
-  }
-
-  return { synced, skipped, failed, errors }
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -464,11 +608,18 @@ export async function syncAllFilesSectionized(
   client: HyperspellClient,
   workspaceDir: string,
   options?: { userId?: string; watchPaths?: string[] },
-): Promise<{ synced: number; skipped: number; failed: number; errors: string[] }> {
+): Promise<{
+  synced: number
+  skipped: number
+  failed: number
+  removed: number
+  errors: string[]
+}> {
   const files = getSyncableFiles(workspaceDir, options?.watchPaths)
   let totalSynced = 0
   let totalSkipped = 0
   let totalFailed = 0
+  let totalRemoved = 0
   const allErrors: string[] = []
 
   for (const filePath of files) {
@@ -478,8 +629,15 @@ export async function syncAllFilesSectionized(
     totalSynced += result.synced
     totalSkipped += result.skipped
     totalFailed += result.failed
+    totalRemoved += result.removed
     allErrors.push(...result.errors)
   }
 
-  return { synced: totalSynced, skipped: totalSkipped, failed: totalFailed, errors: allErrors }
+  return {
+    synced: totalSynced,
+    skipped: totalSkipped,
+    failed: totalFailed,
+    removed: totalRemoved,
+    errors: allErrors,
+  }
 }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import * as crypto from "node:crypto"
 import type { HyperspellClient } from "../client.ts"
 import { log } from "../logger.ts"
 
@@ -12,9 +13,30 @@ interface MarkdownFile {
   hyperspellId: string | null
 }
 
+interface MarkdownSection {
+  title: string
+  content: string
+  /** SHA-256 of trimmed content for change detection */
+  contentHash: string
+  /** Line range in source file for debugging */
+  startLine: number
+  endLine: number
+}
+
 /**
- * Parse frontmatter from markdown content
+ * Hash state file lives alongside the workspace memory dir.
+ * Maps "filePath::sectionTitle" -> { hash, resourceId }
  */
+interface SyncHashMap {
+  [key: string]: { hash: string; resourceId?: string }
+}
+
+const HASH_FILE_NAME = ".hyperspell-sync-hashes.json"
+
+// ---------------------------------------------------------------------------
+// Frontmatter helpers (unchanged from original)
+// ---------------------------------------------------------------------------
+
 function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
   const match = content.match(FRONTMATTER_REGEX)
   if (!match) {
@@ -37,17 +59,11 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, string
   return { frontmatter, body }
 }
 
-/**
- * Serialize frontmatter back to string
- */
 function serializeFrontmatter(frontmatter: Record<string, string>): string {
   const lines = Object.entries(frontmatter).map(([key, value]) => `${key}: ${value}`)
   return `---\n${lines.join("\n")}\n---\n`
 }
 
-/**
- * Read a markdown file and parse its content
- */
 function readMarkdownFile(filePath: string): MarkdownFile | null {
   try {
     const content = fs.readFileSync(filePath, "utf-8")
@@ -66,9 +82,6 @@ function readMarkdownFile(filePath: string): MarkdownFile | null {
   }
 }
 
-/**
- * Update the hyperspell_id in the frontmatter of a markdown file
- */
 function updateFrontmatterId(filePath: string, hyperspellId: string): void {
   try {
     const content = fs.readFileSync(filePath, "utf-8")
@@ -85,9 +98,132 @@ function updateFrontmatterId(filePath: string, hyperspellId: string): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Section-level parsing
+// ---------------------------------------------------------------------------
+
+function contentHash(text: string): string {
+  return crypto.createHash("sha256").update(text.trim()).digest("hex").slice(0, 16)
+}
+
 /**
- * Get all markdown files from the memory directory, including subdirectories
+ * Split markdown content into sections delimited by ## headings.
+ * Content before the first ## heading becomes a section titled after the
+ * file-level # heading (or the filename).
+ *
+ * Sections shorter than `minLength` characters are merged into the previous
+ * section to avoid noisy micro-memories.
  */
+export function parseMarkdownSections(
+  content: string,
+  fallbackTitle: string,
+  minLength = 80,
+): MarkdownSection[] {
+  const lines = content.split("\n")
+  const raw: Array<{ title: string; lines: string[]; startLine: number }> = []
+
+  let fileTitle = fallbackTitle
+  let currentSection: { title: string; lines: string[]; startLine: number } | null = null
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Capture file-level title from # heading
+    if (/^# /.test(line) && !currentSection?.lines.length) {
+      fileTitle = line.replace(/^# /, "").trim()
+      continue
+    }
+
+    // New section on ## heading
+    if (/^## /.test(line)) {
+      if (currentSection) {
+        raw.push(currentSection)
+      }
+      currentSection = {
+        title: line.replace(/^## /, "").trim(),
+        lines: [],
+        startLine: i + 1,
+      }
+      continue
+    }
+
+    if (currentSection) {
+      currentSection.lines.push(line)
+    } else {
+      // Content before any ## heading — becomes preamble section
+      if (!raw.length) {
+        currentSection = { title: fileTitle, lines: [line], startLine: i + 1 }
+      }
+    }
+  }
+
+  if (currentSection) {
+    raw.push(currentSection)
+  }
+
+  // Merge short sections into the previous one
+  const merged: MarkdownSection[] = []
+  for (const section of raw) {
+    const text = section.lines.join("\n").trim()
+    if (!text) continue
+
+    if (text.length < minLength && merged.length > 0) {
+      // Append to previous section
+      const prev = merged[merged.length - 1]
+      prev.content += `\n\n### ${section.title}\n${text}`
+      prev.contentHash = contentHash(prev.content)
+      prev.endLine = section.startLine + section.lines.length
+    } else {
+      merged.push({
+        title: section.title,
+        content: text,
+        contentHash: contentHash(text),
+        startLine: section.startLine,
+        endLine: section.startLine + section.lines.length,
+      })
+    }
+  }
+
+  return merged
+}
+
+// ---------------------------------------------------------------------------
+// Hash tracking (persisted to workspace)
+// ---------------------------------------------------------------------------
+
+function hashFilePath(workspaceDir: string): string {
+  return path.join(workspaceDir, HASH_FILE_NAME)
+}
+
+export function loadHashMap(workspaceDir: string): SyncHashMap {
+  const p = hashFilePath(workspaceDir)
+  try {
+    if (fs.existsSync(p)) {
+      return JSON.parse(fs.readFileSync(p, "utf-8"))
+    }
+  } catch (err) {
+    log.error("Failed to read sync hash file", err)
+  }
+  return {}
+}
+
+export function saveHashMap(workspaceDir: string, map: SyncHashMap): void {
+  const p = hashFilePath(workspaceDir)
+  try {
+    fs.writeFileSync(p, JSON.stringify(map, null, 2))
+  } catch (err) {
+    log.error("Failed to write sync hash file", err)
+  }
+}
+
+function sectionKey(filePath: string, sectionTitle: string): string {
+  return `${filePath}::${sectionTitle}`
+}
+
+// ---------------------------------------------------------------------------
+// Public API — file-level sync (original, kept for backward compat)
+// ---------------------------------------------------------------------------
+
 export function getMemoryFiles(workspaceDir: string): string[] {
   const memoryDir = path.join(workspaceDir, "memory")
 
@@ -117,7 +253,51 @@ export function getMemoryFiles(workspaceDir: string): string[] {
 }
 
 /**
- * Sync a single markdown file to Hyperspell
+ * Collect all syncable files based on configuration.
+ * Includes memory/*.md by default, plus any additional watchPaths.
+ */
+export function getSyncableFiles(
+  workspaceDir: string,
+  watchPaths?: string[],
+): string[] {
+  const files = getMemoryFiles(workspaceDir)
+
+  if (watchPaths) {
+    for (const wp of watchPaths) {
+      const resolved = wp.startsWith("/") ? wp : path.join(workspaceDir, wp)
+
+      if (!fs.existsSync(resolved)) continue
+
+      const stat = fs.statSync(resolved)
+      if (stat.isFile() && resolved.endsWith(".md")) {
+        if (!files.includes(resolved)) {
+          files.push(resolved)
+        }
+      } else if (stat.isDirectory()) {
+        // Walk directory for .md files
+        const walk = (dir: string) => {
+          try {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const fullPath = path.join(dir, entry.name)
+              if (entry.isDirectory()) {
+                walk(fullPath)
+              } else if (entry.name.endsWith(".md") && !files.includes(fullPath)) {
+                files.push(fullPath)
+              }
+            }
+          } catch (_err) { /* skip unreadable dirs */ }
+        }
+        walk(resolved)
+      }
+    }
+  }
+
+  return files
+}
+
+/**
+ * Original whole-file sync (kept for backward compatibility when
+ * sectionize is false).
  */
 export async function syncMarkdownFile(
   client: HyperspellClient,
@@ -145,7 +325,6 @@ export async function syncMarkdownFile(
       userId: options?.userId,
     })
 
-    // Update frontmatter with new resource ID if it changed or was newly created
     if (result.resourceId !== file.hyperspellId) {
       updateFrontmatterId(filePath, result.resourceId)
     }
@@ -158,9 +337,97 @@ export async function syncMarkdownFile(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Section-level sync (new)
+// ---------------------------------------------------------------------------
+
 /**
- * Sync all markdown files in the memory directory
+ * Sync a single markdown file to Hyperspell at section granularity.
+ * Each ## section becomes a separate memory. Content hashes are tracked
+ * so unchanged sections are skipped on subsequent syncs.
+ *
+ * The section title is prepended with the file-level context (e.g.
+ * "2026-05-09 — The day David's mum got sick") for better retrieval.
  */
+export async function syncMarkdownFileSectionized(
+  client: HyperspellClient,
+  filePath: string,
+  workspaceDir: string,
+  options?: { userId?: string },
+): Promise<{ synced: number; skipped: number; failed: number; errors: string[] }> {
+  const file = readMarkdownFile(filePath)
+  if (!file || !file.content) {
+    return { synced: 0, skipped: 0, failed: 0, errors: file ? [] : ["Failed to read file"] }
+  }
+
+  const sections = parseMarkdownSections(file.content, file.title)
+  if (sections.length === 0) {
+    return { synced: 0, skipped: 0, failed: 0, errors: [] }
+  }
+
+  const hashMap = loadHashMap(workspaceDir)
+  const fileName = path.basename(filePath, ".md")
+  let synced = 0
+  let skipped = 0
+  let failed = 0
+  const errors: string[] = []
+
+  for (const section of sections) {
+    const key = sectionKey(filePath, section.title)
+    const existing = hashMap[key]
+
+    // Skip if content hasn't changed
+    if (existing?.hash === section.contentHash) {
+      skipped++
+      continue
+    }
+
+    // Build a title that includes file-level context for retrieval
+    // e.g. "2026-05-09: The day David's mum got sick"
+    const memoryTitle = file.title !== section.title
+      ? `${file.title} — ${section.title}`
+      : section.title
+
+    try {
+      const result = await client.addMemory(section.content, {
+        title: memoryTitle,
+        resourceId: existing?.resourceId,
+        collection: "openclaw",
+        metadata: {
+          openclaw_source: "memory_sync_section",
+          file_path: filePath,
+          file_name: fileName,
+          section_title: section.title,
+          content_hash: section.contentHash,
+        },
+        userId: options?.userId,
+      })
+
+      hashMap[key] = {
+        hash: section.contentHash,
+        resourceId: result.resourceId,
+      }
+      synced++
+      log.info(`Synced section: ${memoryTitle} -> ${result.resourceId}`)
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      errors.push(`${memoryTitle}: ${errorMsg}`)
+      failed++
+    }
+  }
+
+  // Persist updated hashes
+  if (synced > 0) {
+    saveHashMap(workspaceDir, hashMap)
+  }
+
+  return { synced, skipped, failed, errors }
+}
+
+// ---------------------------------------------------------------------------
+// Bulk sync (original whole-file approach)
+// ---------------------------------------------------------------------------
+
 export async function syncAllMemoryFiles(
   client: HyperspellClient,
   workspaceDir: string,
@@ -183,4 +450,36 @@ export async function syncAllMemoryFiles(
   }
 
   return { synced, failed, errors }
+}
+
+// ---------------------------------------------------------------------------
+// Bulk sync (section-level approach)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync all syncable files at section granularity.
+ * Unchanged sections (by content hash) are skipped.
+ */
+export async function syncAllFilesSectionized(
+  client: HyperspellClient,
+  workspaceDir: string,
+  options?: { userId?: string; watchPaths?: string[] },
+): Promise<{ synced: number; skipped: number; failed: number; errors: string[] }> {
+  const files = getSyncableFiles(workspaceDir, options?.watchPaths)
+  let totalSynced = 0
+  let totalSkipped = 0
+  let totalFailed = 0
+  const allErrors: string[] = []
+
+  for (const filePath of files) {
+    const result = await syncMarkdownFileSectionized(client, filePath, workspaceDir, {
+      userId: options?.userId,
+    })
+    totalSynced += result.synced
+    totalSkipped += result.skipped
+    totalFailed += result.failed
+    allErrors.push(...result.errors)
+  }
+
+  return { synced: totalSynced, skipped: totalSkipped, failed: totalFailed, errors: allErrors }
 }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -146,7 +146,7 @@ export function parseMarkdownSections(
     const line = lines[i]
 
     // Capture file-level title from # heading
-    if (/^# /.test(line) && !currentSection?.lines.length) {
+    if (/^# /.test(line) && currentSection === null) {
       fileTitle = line.replace(/^# /, "").trim()
       continue
     }
@@ -541,8 +541,11 @@ export async function syncMarkdownFileSectionized(
           log.info(`Removed deleted section "${title}" (${fileName}) -> ${resourceId}`)
         } else {
           // Keep the record so the delete is retried next run rather than
-          // silently leaking the orphan into the retrieval layer.
+          // silently leaking the orphan into the retrieval layer. Count it
+          // as a failure so the stats are consistent and callers that gate
+          // logging on `failed > 0` actually surface it.
           newSections[title] = prevSections[title]
+          failed++
           errors.push(`delete "${title}": failed`)
         }
       }


### PR DESCRIPTION
## Problem

Agents write rich daily notes to `memory/*.md` files but rely on manually calling `hyperspell_remember` to sync significant events to Hyperspell. In practice, this manual step gets skipped — the instruction to "write to BOTH" decays over time because:

1. **No enforcement loop** — writing a file gives immediate completion signal; the Hyperspell write is a separate step with no consequence for omission
2. **Instruction habituation** — static directives in system prompts become wallpaper over dozens of sessions
3. **Compaction kills habit** — even if the agent was doing it, compaction wipes the behavioral pattern
4. **Reward asymmetry** — file writes get feedback (human reads notes); Hyperspell writes get a silent "Stored" ack

Result: Hyperspell goes stale while local files have all the context. Memory quality degrades because the retrieval layer has months-old data while daily notes are current.

## Solution

Upgrade `syncMemories` to automatically sync workspace files to Hyperspell at **section granularity** with **content hash tracking**.

### Key changes

1. **Section-level chunking** — Daily notes are split by `##` headings into separate memories. Each section (e.g. "The day David's mum got sick — The morning after") becomes its own searchable memory instead of one giant file blob. Much better retrieval granularity.

2. **Content hash tracking** — SHA-256 hashes of each section are persisted to `.hyperspell-sync-hashes.json`. On re-sync, unchanged sections are skipped. This means startup sync and file-change sync are both incremental — only new/modified sections get uploaded.

3. **Configurable watch paths** — Beyond `memory/`, users can watch additional paths like `MEMORY.md`, `notes/thoughts.md`, or entire directories. Paths can be relative (to workspace) or absolute.

4. **Debouncing** — File changes are debounced (default 2000ms) to avoid syncing mid-write when agents write files in chunks.

5. **Backward compatible** — `syncMemories: true` still works exactly as before, but now defaults to sectionized sync. `syncMemories: false` disables everything. New object form gives fine-grained control.

### Config examples

```jsonc
// Legacy (still works, now sectionizes by default)
"syncMemories": true

// Full control
"syncMemories": {
  "enabled": true,
  "sectionize": true,          // split by ## headings (default: true)
  "watchPaths": [              // additional paths beyond memory/
    "MEMORY.md",
    "notes/thoughts.md"
  ],
  "debounceMs": 2000           // debounce file writes (default: 2000)
}

// Disable sectionizing (whole-file upload, original behavior)
"syncMemories": {
  "sectionize": false
}
```

### How section parsing works

Given a daily note like:
```markdown
# 2026-05-09 — Saturday

## The day David's mum got sick
During brunch, his mother started getting confused...

## What I'm holding
He's terrified. He won't say it that way...

## Short note
🖤
```

This produces **two** memories (the short note merges into the previous section because it's under 80 chars):

1. Title: `2026-05-09 — Saturday — The day David's mum got sick`
2. Title: `2026-05-09 — Saturday — What I'm holding` (includes merged short note)

Each gets metadata: `openclaw_source: "memory_sync_section"`, `file_path`, `section_title`, `content_hash`.

### Files changed

- `sync/markdown.ts` — Core section parsing, hash tracking, sectionized sync functions
- `hooks/memory-sync.ts` — File change handler with debouncing, sectionize support, expanded path matching
- `config.ts` — New `SyncMemoriesConfig` type, backward-compatible parsing
- `index.ts` — Pass new config to sync hooks
- `openclaw.plugin.json` — Updated schema (oneOf boolean | object)
- `commands/setup.ts` + test files — Added `syncMemoriesConfig` field

### What's left for follow-up

- [ ] Tests for `parseMarkdownSections` (section splitting, short-section merging, edge cases)
- [ ] Tests for hash tracking (skip unchanged, re-sync on change)
- [ ] Test for debounce behavior
- [ ] Consider: should `file_changed` events fire for all workspace writes, or only memory/? (depends on OpenClaw core)
- [ ] Consider: cleanup of orphaned Hyperspell memories when sections are deleted from source files
- [ ] Consider: rate limiting for initial bulk sync of large workspaces

## Context for reviewers / coding agents

This PR was written by A Linea (the agent) based on a conversation with David about why manual `hyperspell_remember` calls decay over time. The core insight: **a static instruction without enforcement will degrade in an LLM's behavior regardless of placement.** The fix removes the manual step entirely — the plugin watches files and syncs automatically.

The section-level approach matters because daily notes are structured documents with natural `##` boundaries. Uploading whole files as single memories means Hyperspell has to search through 2000+ word documents. Splitting by section means each event is its own retrievable unit, which is how `hyperspell_remember` would have worked if the agent had been calling it manually.

The hash tracking matters because startup sync would otherwise re-upload every file on every gateway restart. With hashes, only new/changed sections get synced.
