### PR TITLE
ci: tag-triggered publish instead of publish-on-main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,23 @@
 name: Publish Package
 
+# Releases are cut by pushing a version tag (e.g. v0.14.0), NOT by merging
+# to main. This makes every published version a deliberate, traceable act
+# and stops merges from triggering failed/duplicate publishes.
+#
+# To release:
+#   1. Land your changes on main (via PR as usual).
+#   2. Bump the version:  npm version <patch|minor|major>
+#      (this commits the bump and creates the matching vX.Y.Z tag locally)
+#   3. Push commit + tag:  git push origin main --follow-tags
+#   The tag push triggers this workflow.
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 permissions:
-  id-token: write
-  contents: read
+  id-token: write # npm provenance / trusted publisher (OIDC)
+  contents: write # create the GitHub Release
 
 jobs:
   publish:
@@ -18,4 +29,27 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+
+      # Fail loudly if the tag and package.json disagree, so a mistagged
+      # release never publishes the wrong version.
+      - name: Verify tag matches package.json version
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          TAG="${GITHUB_REF_NAME#v}"
+          if [ "$PKG" != "$TAG" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=${TAG}) != package.json version ${PKG}. Bump package.json or fix the tag."
+            exit 1
+          fi
+          echo "Releasing ${GITHUB_REF_NAME} (package.json ${PKG})"
+
+      # Release gates — this repo has no PR CI, so this is the one place
+      # broken code is caught before it ships.
+      - run: npm run check-types
+      - run: npm test
+
       - run: npm publish --access public
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes


### PR DESCRIPTION
Closes #29.

## What

Switches `publish.yml` from **publish-on-push-to-main** to **publish-on-version-tag**.

## Why

Today every merge to `main` triggers `npm publish`, which **fails** (npm rejects republishing the already-live version) — so every merge leaves a red `Publish Package` run, and `npm latest` silently lags `main` until a human remembers to bump + push. We just hit this with #27 (failed run on `2acc9fd`; npm stuck at 0.13.1 until a manual bump).

## Behavior after this

- Merging to main: **no publish** (trigger is `tags: ['v*']` only).
- Releasing:
  1. land changes on main via PR
  2. `npm version <patch|minor|major>`
  3. `git push origin main --follow-tags`
  4. tag push → workflow: tag↔`package.json` guard → `check-types` → `test` → `npm publish --access public` → GitHub Release with auto-generated notes.

Adds a version-match guard (mistag can't ship the wrong version) and `check-types`+`test` as release gates (repo has no PR CI; the tag publish is the last line of defense).

## Transition note

Once merged, the new workflow is what runs on the merge push — and since it triggers on tags only, **merging this PR does not trigger a publish** (clean cutover, no final failed run). First real use is the next `vX.Y.Z` tag.

Provenance/OIDC (`id-token: write`) preserved; `contents: write` added only for `gh release create`.