### PR TITLE
fix: non-blocking startup sync + bounded memory re-ingestion (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ When `syncMemories: true`, the plugin syncs markdown files from your agent's wor
 - The returned `resource_id` is stored in the file's YAML frontmatter as `hyperspell_id`
 - On subsequent syncs, files with an existing `hyperspell_id` are updated rather than duplicated
 - Files are synced automatically on startup and when they change
+- Startup sync runs in the **background** — the agent boots immediately and sync proceeds without blocking it
+- A per-section content hash is tracked in `<workspace>/.hyperspell-sync-hashes.json`, so unchanged sections are skipped on subsequent syncs (no re-ingestion)
+
+**Tuning sync (object form):**
+
+```jsonc
+"syncMemories": {
+  "enabled": true,
+  "sectionize": true,     // split files on ## headings into separate memories
+  "watchPaths": [],        // extra files/dirs to sync beyond memory/
+  "debounceMs": 2000,      // wait for writes to settle before syncing
+  "maxAgeDays": 30          // startup skips already-synced files older than this
+}
+```
+
+`maxAgeDays` bounds steady-state load: on startup, files whose mtime is older than the cutoff **and** already recorded in the sync manifest are skipped without re-reading. Files not yet in the manifest are always synced once regardless of age, and editing an old file bumps its mtime back into the window. Set to `0` to disable the cutoff.
 
 **Example frontmatter after sync:**
 

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -344,6 +344,7 @@ async function runSetup(): Promise<void> {
           sectionize: true,
           watchPaths: [],
           debounceMs: 2000,
+          maxAgeDays: 30,
         },
         sources: [],
         maxResults: 10,

--- a/config.test.ts
+++ b/config.test.ts
@@ -235,6 +235,7 @@ test("parseConfig — syncMemories boolean true keeps legacy behavior, sectioniz
   assert.equal(cfg.syncMemoriesConfig.sectionize, true)
   assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, [])
   assert.equal(cfg.syncMemoriesConfig.debounceMs, 2000)
+  assert.equal(cfg.syncMemoriesConfig.maxAgeDays, 30)
 })
 
 test("parseConfig — syncMemories false disables sync", () => {
@@ -250,12 +251,14 @@ test("parseConfig — syncMemories object form parses and enables by default", (
       sectionize: false,
       watchPaths: ["MEMORY.md", "notes/"],
       debounceMs: 500,
+      maxAgeDays: 7,
     },
   })
   assert.equal(cfg.syncMemories, true) // object without explicit enabled => on
   assert.equal(cfg.syncMemoriesConfig.sectionize, false)
   assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, ["MEMORY.md", "notes/"])
   assert.equal(cfg.syncMemoriesConfig.debounceMs, 500)
+  assert.equal(cfg.syncMemoriesConfig.maxAgeDays, 7)
 })
 
 test("parseConfig — syncMemories object with a typo'd key throws", () => {

--- a/config.ts
+++ b/config.ts
@@ -94,6 +94,13 @@ export type SyncMemoriesConfig = {
 	watchPaths: string[];
 	/** Debounce file changes in ms to avoid syncing mid-write (default: 2000) */
 	debounceMs: number;
+	/**
+	 * Startup bulk sync skips files whose mtime is older than this many days
+	 * AND that are already recorded in the sync manifest (i.e. ingested at
+	 * least once). Bounds steady-state re-ingest load on large/old corpora.
+	 * 0 disables the cutoff (always consider every file). Default: 30.
+	 */
+	maxAgeDays: number;
 };
 
 export type HyperspellConfig = {
@@ -416,7 +423,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 	if (typeof smRaw === "object" && smRaw !== null && !Array.isArray(smRaw)) {
 		assertAllowedKeys(
 			smObj,
-			["enabled", "sectionize", "watchPaths", "debounceMs"],
+			["enabled", "sectionize", "watchPaths", "debounceMs", "maxAgeDays"],
 			"hyperspell.syncMemories",
 		);
 	}
@@ -453,6 +460,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 				? (smObj.watchPaths as string[])
 				: [],
 			debounceMs: (smObj.debounceMs as number) ?? 2000,
+			maxAgeDays: (smObj.maxAgeDays as number) ?? 30,
 		},
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -130,6 +130,7 @@ export async function syncMemoriesOnStartup(
     userId?: string
     sectionize?: boolean
     watchPaths?: string[]
+    maxAgeDays?: number
   },
 ): Promise<void> {
   log.info("Syncing existing memory files...")
@@ -138,10 +139,11 @@ export async function syncMemoriesOnStartup(
     const result = await syncAllFilesSectionized(client, workspaceDir, {
       userId: options.userId,
       watchPaths: options.watchPaths,
+      maxAgeDays: options.maxAgeDays,
     })
 
     log.info(
-      `Section sync complete: ${result.synced} synced, ${result.skipped} unchanged, ${result.removed} removed, ${result.failed} failed`,
+      `Section sync complete: ${result.synced} synced, ${result.skipped} unchanged, ${result.agedOut} aged-out, ${result.removed} removed, ${result.failed} failed`,
     )
     if (result.failed > 0) {
       for (const error of result.errors) {

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -71,6 +71,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 			sectionize: true,
 			watchPaths: [],
 			debounceMs: 2000,
+			maxAgeDays: 30,
 		},
 		sources: [],
 		maxResults: 10,

--- a/index.ts
+++ b/index.ts
@@ -152,13 +152,22 @@ export default {
 			start: async () => {
 				api.logger.info("hyperspell: connected");
 
-				// Sync memories on startup if enabled
+				// Sync memories on startup if enabled.
+				//
+				// Deliberately NOT awaited: the bulk sync is sequential and
+				// network-bound (one request per changed section), so awaiting
+				// it here stalls the agent's startup until the entire corpus
+				// has been processed. Run it in the background and let the
+				// agent come up immediately; failures are logged, not fatal.
 				if (cfg.syncMemories) {
 					const workspaceDir = getWorkspaceDir();
-					await syncMemoriesOnStartup(client, workspaceDir, {
+					void syncMemoriesOnStartup(client, workspaceDir, {
 						userId: cfg.multiUser?.sharedUserId,
 						sectionize: cfg.syncMemoriesConfig.sectionize,
 						watchPaths: cfg.syncMemoriesConfig.watchPaths,
+						maxAgeDays: cfg.syncMemoriesConfig.maxAgeDays,
+					}).catch((err) => {
+						api.logger.error("hyperspell: background memory sync failed", err);
 					});
 				}
 			},

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -21,6 +21,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
       sectionize: true,
       watchPaths: [],
       debounceMs: 2000,
+      maxAgeDays: 30,
     },
     sources: [],
     maxResults: 5,

--- a/sync/markdown.test.ts
+++ b/sync/markdown.test.ts
@@ -10,6 +10,7 @@ import {
   loadManifest,
   parseMarkdownSections,
   saveManifest,
+  syncAllFilesSectionized,
   syncMarkdownFileSectionized,
   withSyncLock,
 } from "./markdown.ts"
@@ -132,18 +133,36 @@ test("loadManifest — missing file returns empty manifest", () => {
   }
 })
 
-test("loadManifest — legacy flat / garbage / wrong version self-heals to empty", () => {
+test("loadManifest — unusable shapes self-heal to empty", () => {
   const dir = tmpDir()
   const p = path.join(dir, ".hyperspell-sync-hashes.json")
   try {
+    // Legacy flat shape: no `files` key -> unusable -> empty.
     fs.writeFileSync(p, '{"/abs/file.md::A":{"hash":"x","resourceId":"r"}}')
     assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
 
+    // Corrupt JSON -> empty.
     fs.writeFileSync(p, "not json at all {")
     assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
 
-    fs.writeFileSync(p, '{"version":99,"files":{}}')
+    // `files` present but null -> unusable -> empty.
+    fs.writeFileSync(p, '{"version":1,"files":null}')
     assert.deepEqual(loadManifest(dir), { version: 1, files: {} })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("loadManifest — version mismatch with valid files is forward-migrated, not discarded", () => {
+  const dir = tmpDir()
+  const p = path.join(dir, ".hyperspell-sync-hashes.json")
+  try {
+    // A future/older version but a structurally valid files map must be
+    // preserved — discarding it would force a full re-ingest, the exact
+    // load this guard exists to prevent.
+    const files = { "memory/n.md": { sections: { A: { hash: "h", resourceId: "r" } } } }
+    fs.writeFileSync(p, JSON.stringify({ version: 99, files }))
+    assert.deepEqual(loadManifest(dir), { version: 1, files })
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -421,6 +440,55 @@ test("syncMarkdownFileSectionized — failed upload preserves resourceId (no dup
     const r2 = await syncMarkdownFileSectionized(recover.client, ws.note, ws.dir)
     assert.equal(r2.synced, 1)
     assert.equal(recover.addCalls[0].options.resourceId, "res-1")
+  } finally {
+    ws.cleanup()
+  }
+})
+
+// ---------------------------------------------------------------------------
+// syncAllFilesSectionized — age pre-filter
+// ---------------------------------------------------------------------------
+
+test("syncAllFilesSectionized — old + already-manifested file is skipped (aged out)", async () => {
+  const ws = workspace()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+
+    // First pass with no cutoff: ingests and records in the manifest.
+    const first = makeClient()
+    const r1 = await syncAllFilesSectionized(first.client, ws.dir, { maxAgeDays: 0 })
+    assert.equal(r1.synced, 2)
+    assert.equal(r1.agedOut, 0)
+
+    // Backdate the file well past the cutoff.
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(ws.note, old, old)
+
+    // Second pass with a 30d cutoff: file is known + stale -> not even read.
+    const second = makeClient()
+    const r2 = await syncAllFilesSectionized(second.client, ws.dir, { maxAgeDays: 30 })
+    assert.equal(r2.agedOut, 1)
+    assert.equal(r2.synced, 0)
+    assert.equal(r2.skipped, 0)
+    assert.equal(second.addCalls.length, 0)
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("syncAllFilesSectionized — old but NOT-yet-manifested file still syncs once", async () => {
+  const ws = workspace()
+  try {
+    fs.writeFileSync(ws.note, `## A\n${BODY_A}\n## B\n${BODY_B}`)
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+    fs.utimesSync(ws.note, old, old)
+
+    // Cold manifest: age cutoff must not strand never-ingested content.
+    const { client, addCalls } = makeClient()
+    const r = await syncAllFilesSectionized(client, ws.dir, { maxAgeDays: 30 })
+    assert.equal(r.agedOut, 0)
+    assert.equal(r.synced, 2)
+    assert.equal(addCalls.length, 2)
   } finally {
     ws.cleanup()
   }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -241,10 +241,14 @@ export function loadManifest(workspaceDir: string): SyncManifest {
   try {
     if (fs.existsSync(p)) {
       const parsed = JSON.parse(fs.readFileSync(p, "utf-8")) as Partial<SyncManifest>
-      // Self-healing: an unrecognized/legacy shape is discarded. This feature
-      // has never shipped a released on-disk format, so nothing to migrate —
-      // a mismatch just triggers one re-sync, which is idempotent.
-      if (parsed && parsed.version === MANIFEST_VERSION && parsed.files) {
+      // Forward-migrate rather than discard. Throwing the manifest away on a
+      // version bump means every section re-uploads on the next run — the
+      // exact full-re-ingest load this guard exists to prevent. As long as the
+      // `files` map is structurally a record we keep it: the per-section hash
+      // check still gates every upload, so a stale-but-readable manifest is
+      // strictly better than an empty one. Only a missing/corrupt `files`
+      // (truly unusable) falls back to empty.
+      if (parsed && typeof parsed.files === "object" && parsed.files !== null) {
         return { version: MANIFEST_VERSION, files: parsed.files }
       }
     }
@@ -256,10 +260,21 @@ export function loadManifest(workspaceDir: string): SyncManifest {
 
 export function saveManifest(workspaceDir: string, manifest: SyncManifest): void {
   const p = manifestPath(workspaceDir)
+  // Atomic write: a process killed mid-write (deploy/restart) would otherwise
+  // leave a truncated JSON file, which loadManifest can only treat as corrupt
+  // -> empty -> full re-ingest. Write to a temp sibling, then rename (atomic
+  // on the same filesystem) so readers only ever see a complete manifest.
+  const tmp = `${p}.${process.pid}.tmp`
   try {
-    fs.writeFileSync(p, JSON.stringify(manifest, null, 2))
+    fs.writeFileSync(tmp, JSON.stringify(manifest, null, 2))
+    fs.renameSync(tmp, p)
   } catch (err) {
     log.error("Failed to write sync manifest", err)
+    try {
+      if (fs.existsSync(tmp)) fs.unlinkSync(tmp)
+    } catch {
+      /* best-effort cleanup */
+    }
   }
 }
 
@@ -610,22 +625,56 @@ export async function syncAllMemoryFiles(
 export async function syncAllFilesSectionized(
   client: HyperspellClient,
   workspaceDir: string,
-  options?: { userId?: string; watchPaths?: string[] },
+  options?: { userId?: string; watchPaths?: string[]; maxAgeDays?: number },
 ): Promise<{
   synced: number
   skipped: number
   failed: number
   removed: number
+  agedOut: number
   errors: string[]
 }> {
   const files = getSyncableFiles(workspaceDir, options?.watchPaths)
+
+  // Age pre-filter: a file untouched for longer than maxAgeDays that is
+  // already recorded in the manifest has been ingested at least once and is
+  // not changing — re-parsing/hashing/diffing it every startup is pure churn.
+  // Files NOT yet in the manifest are always processed regardless of age, so
+  // a genuinely cold start (or a never-synced old file) still ingests once.
+  // The live file_changed handler is unaffected: an edit bumps mtime, so
+  // edited-but-old files re-enter the window naturally.
+  const maxAgeDays = options?.maxAgeDays ?? 0
+  let candidates = files
+  let agedOut = 0
+  if (maxAgeDays > 0) {
+    const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000
+    const manifest = loadManifest(workspaceDir)
+    candidates = files.filter((filePath) => {
+      const key = fileKey(workspaceDir, filePath)
+      const known = manifest.files[key] !== undefined
+      if (!known) return true
+      try {
+        if (fs.statSync(filePath).mtimeMs >= cutoff) return true
+      } catch {
+        return true // stat failed — be safe, process it
+      }
+      agedOut++
+      return false
+    })
+    if (agedOut > 0) {
+      log.info(
+        `Skipping ${agedOut} unchanged file(s) older than ${maxAgeDays}d (already synced)`,
+      )
+    }
+  }
+
   let totalSynced = 0
   let totalSkipped = 0
   let totalFailed = 0
   let totalRemoved = 0
   const allErrors: string[] = []
 
-  for (const filePath of files) {
+  for (const filePath of candidates) {
     const result = await syncMarkdownFileSectionized(client, filePath, workspaceDir, {
       userId: options?.userId,
     })
@@ -641,6 +690,7 @@ export async function syncAllFilesSectionized(
     skipped: totalSkipped,
     failed: totalFailed,
     removed: totalRemoved,
+    agedOut,
     errors: allErrors,
   }
 }


### PR DESCRIPTION
Closes #33.

## Problem
Two reports (alinea): the plugin re-ingests all memory/history on every startup regardless of age (sustained Hyperspell load), and the bulk sync blocks agent startup until it finishes.

## Root cause — validated, not hypothesized
The section-level change detection introduced in #27 is **correct**. Verified on unmodified v0.14.0 against a copy of a real 98-file / 353-section corpus:

| run | result |
|---|---|
| 1 (cold, no manifest) | 352 uploads, manifest written (98 files / 352 sections, valid) |
| 2 (warm, manifest present) | **0 uploads**, 352 skipped |

So the re-ingestion is **not** a dedup logic bug. The actual mechanism:

1. The startup bulk sync is `await`-ed inside the plugin service `start()` (`index.ts`) and is sequential + network-bound — one `addMemory` per changed section. On a few-hundred-section corpus that is ~60s+ of **blocked agent startup**.
2. The agent appears hung and gets killed/restarted before the sync finishes and before the manifest is durably written.
3. `saveManifest` was a non-atomic `writeFileSync`, and `loadManifest` discarded the whole manifest on any parse/shape issue — so an interrupted write left no usable manifest.
4. Next boot starts cold → re-ingests everything → blocks again → killed again → **perpetual full re-ingestion.**

Blocking startup is the engine of the re-ingestion. The two reported symptoms are one bug.

## Changes
- **`index.ts`** — startup sync runs in the background (`void … .catch(log)`); the agent boots immediately.
- **`sync/markdown.ts`**
  - `saveManifest` writes atomically (temp + `renameSync`) so an interrupted/killed boot can't truncate the manifest into corrupt → empty → full re-ingest.
  - `loadManifest` forward-migrates a structurally valid `files` map across version mismatch instead of discarding it.
  - `syncAllFilesSectionized` skips files older than `maxAgeDays` that are already in the manifest (never-synced files always ingest once; live `file_changed` path unaffected — an edit bumps mtime back into the window).
- **`config.ts`** — new `syncMemories.maxAgeDays` (default `30`, `0` disables), strict-key validated.
- **README** — background sync + object-form tuning incl. `maxAgeDays`.

## Live validation — real plugin, real corpus, real Hyperspell
Built fix installed into a real OpenClaw runtime, `syncMemories` enabled, real 98-file / 353-section corpus, real Hyperspell API:

| Boot | `connected` → `[gateway] ready` | Background sync | Result |
|---|---|---|---|
| Cold | 6 ms | 66 s (async; agent serving throughout) | 212 synced, 24 aged-out, 0 failed |
| Warm (after restart) | 13 ms | 326 ms | **0 synced**, 136 unchanged, 40 aged-out, 0 failed |

- **Non-blocking:** gateway `ready` ~10 ms after sync kickoff on both boots; webchat was served during the entire 66 s cold sync. Stock v0.14.0's `await` would have held the gateway down for that full 66 s — exactly the reported "prevents startup until everything is sync'd".
- **Convergence:** the warm boot did **zero** re-ingestion. Manifest persists (98 files / 353 sections, valid JSON).
- **Age filter is effective on real mtimes:** it skipped 24 then 40 already-synced old files from being re-read/hashed. (An earlier isolated harness under-counted this because `cp` reset file mtimes; the real-workspace test corrects that — the filter earns its place.)

## Tests
`tsc --noEmit` + build clean. Suite 87/87, including new age-filter and manifest-resilience cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
