### PR TITLE
fix: stop dream/scaffolding pollution + repair trace-exclude filter

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -345,6 +345,7 @@ async function runSetup(): Promise<void> {
           watchPaths: [],
           debounceMs: 2000,
           maxAgeDays: 30,
+          ignorePaths: ["dreaming"],
         },
         sources: [],
         maxResults: 10,

--- a/config.test.ts
+++ b/config.test.ts
@@ -236,6 +236,7 @@ test("parseConfig — syncMemories boolean true keeps legacy behavior, sectioniz
   assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, [])
   assert.equal(cfg.syncMemoriesConfig.debounceMs, 2000)
   assert.equal(cfg.syncMemoriesConfig.maxAgeDays, 30)
+  assert.deepEqual(cfg.syncMemoriesConfig.ignorePaths, ["dreaming"])
 })
 
 test("parseConfig — syncMemories false disables sync", () => {
@@ -252,6 +253,7 @@ test("parseConfig — syncMemories object form parses and enables by default", (
       watchPaths: ["MEMORY.md", "notes/"],
       debounceMs: 500,
       maxAgeDays: 7,
+      ignorePaths: ["dreaming", "scratch"],
     },
   })
   assert.equal(cfg.syncMemories, true) // object without explicit enabled => on
@@ -259,6 +261,7 @@ test("parseConfig — syncMemories object form parses and enables by default", (
   assert.deepEqual(cfg.syncMemoriesConfig.watchPaths, ["MEMORY.md", "notes/"])
   assert.equal(cfg.syncMemoriesConfig.debounceMs, 500)
   assert.equal(cfg.syncMemoriesConfig.maxAgeDays, 7)
+  assert.deepEqual(cfg.syncMemoriesConfig.ignorePaths, ["dreaming", "scratch"])
 })
 
 test("parseConfig — syncMemories object with a typo'd key throws", () => {

--- a/config.ts
+++ b/config.ts
@@ -101,6 +101,15 @@ export type SyncMemoriesConfig = {
 	 * 0 disables the cutoff (always consider every file). Default: 30.
 	 */
 	maxAgeDays: number;
+	/**
+	 * Directory names (not paths) skipped when walking memory/ for syncable
+	 * files. Dot-directories (e.g. `.dreams`) are ALWAYS skipped regardless of
+	 * this list. Default: `["dreaming"]` — the dreaming engine writes
+	 * first-person dream journals under memory/dreaming/ that would otherwise
+	 * be ingested as user memories and pollute retrieval. Set `[]` to sync
+	 * everything except dot-directories.
+	 */
+	ignorePaths: string[];
 };
 
 export type HyperspellConfig = {
@@ -423,7 +432,14 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 	if (typeof smRaw === "object" && smRaw !== null && !Array.isArray(smRaw)) {
 		assertAllowedKeys(
 			smObj,
-			["enabled", "sectionize", "watchPaths", "debounceMs", "maxAgeDays"],
+			[
+				"enabled",
+				"sectionize",
+				"watchPaths",
+				"debounceMs",
+				"maxAgeDays",
+				"ignorePaths",
+			],
 			"hyperspell.syncMemories",
 		);
 	}
@@ -461,6 +477,9 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 				: [],
 			debounceMs: (smObj.debounceMs as number) ?? 2000,
 			maxAgeDays: (smObj.maxAgeDays as number) ?? 30,
+			ignorePaths: Array.isArray(smObj.ignorePaths)
+				? (smObj.ignorePaths as string[])
+				: ["dreaming"],
 		},
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -6,26 +6,8 @@ import {
   resolveUser,
   type ResolvedUser,
 } from "../lib/sender.ts"
+import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "../lib/filters.ts"
 import { log } from "../logger.ts"
-
-/**
- * Memories produced by session-end hooks (auto-trace, emotional-state) are
- * tagged `source: "openclaw_agent_end"`. The emotional-state hook already has
- * a dedicated fetch path (`getEmotionalState` + `<hyperspell-emotional-context>`
- * injection), so those memories should NOT also surface via generic retrieval —
- * double-injection dilutes results and replays the conversation verbatim.
- * Exclude them here at the search filter.
- */
-const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
-  source: { $ne: "openclaw_agent_end" },
-}
-
-function mergeWithExclude(
-  base?: Record<string, unknown>,
-): Record<string, unknown> {
-  if (!base) return EXCLUDE_SESSION_END_FILTER
-  return { $and: [base, EXCLUDE_SESSION_END_FILTER] }
-}
 
 function formatRelativeTime(isoTimestamp: string): string {
   try {

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -27,11 +27,25 @@ export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellCo
   const sectionize = cfg.syncMemoriesConfig.sectionize
   const watchPaths = cfg.syncMemoriesConfig.watchPaths
   const debounceMs = cfg.syncMemoriesConfig.debounceMs
+  const ignoreDirs = new Set(cfg.syncMemoriesConfig.ignorePaths)
 
   // Resolve additional watch paths to absolute paths for matching
   const resolvedWatchPaths = (watchPaths ?? []).map((wp) =>
     wp.startsWith("/") ? wp : path.join(workspaceDir, wp),
   )
+
+  /**
+   * Mirror the bulk walk's exclusions on the live path: a file under a
+   * dot-directory (e.g. .dreams) or an ignored directory (e.g. dreaming) must
+   * not live-sync either, or an edit would re-ingest exactly what the walk
+   * skips.
+   */
+  function isIgnoredPath(filePath: string): boolean {
+    const rel = path.relative(memoryDir, filePath)
+    if (rel.startsWith("..") || path.isAbsolute(rel)) return false
+    const segments = rel.split(path.sep).slice(0, -1) // directory segments only
+    return segments.some((seg) => seg.startsWith(".") || ignoreDirs.has(seg))
+  }
 
   // Debounce map: filePath -> timeout handle
   const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -41,6 +55,7 @@ export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellCo
    */
   function isSyncable(filePath: string): boolean {
     if (!filePath.endsWith(".md")) return false
+    if (isIgnoredPath(filePath)) return false
 
     // Always sync memory/ files
     if (filePath.startsWith(memoryDir + path.sep)) return true
@@ -131,6 +146,7 @@ export async function syncMemoriesOnStartup(
     sectionize?: boolean
     watchPaths?: string[]
     maxAgeDays?: number
+    ignorePaths?: string[]
   },
 ): Promise<void> {
   log.info("Syncing existing memory files...")
@@ -140,6 +156,7 @@ export async function syncMemoriesOnStartup(
       userId: options.userId,
       watchPaths: options.watchPaths,
       maxAgeDays: options.maxAgeDays,
+      ignorePaths: options.ignorePaths,
     })
 
     log.info(

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -72,6 +72,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 			watchPaths: [],
 			debounceMs: 2000,
 			maxAgeDays: 30,
+			ignorePaths: ["dreaming"],
 		},
 		sources: [],
 		maxResults: 10,

--- a/index.ts
+++ b/index.ts
@@ -166,6 +166,7 @@ export default {
 						sectionize: cfg.syncMemoriesConfig.sectionize,
 						watchPaths: cfg.syncMemoriesConfig.watchPaths,
 						maxAgeDays: cfg.syncMemoriesConfig.maxAgeDays,
+						ignorePaths: cfg.syncMemoriesConfig.ignorePaths,
 					}).catch((err) => {
 						api.logger.error("hyperspell: background memory sync failed", err);
 					});

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "./filters.ts"
+
+test("EXCLUDE_SESSION_END_FILTER — matches the real trace tag (metadata key + value)", () => {
+  // sendTrace tags traces as metadata.openclaw_source = "agent_end"; the filter
+  // must target that bare key/value, not top-level `source`/`openclaw_agent_end`.
+  assert.deepEqual(EXCLUDE_SESSION_END_FILTER, {
+    openclaw_source: { $ne: "agent_end" },
+  })
+})
+
+test("mergeWithExclude — no base returns the exclude filter alone", () => {
+  assert.deepEqual(mergeWithExclude(), EXCLUDE_SESSION_END_FILTER)
+  assert.deepEqual(mergeWithExclude(undefined), EXCLUDE_SESSION_END_FILTER)
+})
+
+test("mergeWithExclude — base is AND-combined with the exclude", () => {
+  const base = { openclaw_scope: { $in: ["family"] } }
+  assert.deepEqual(mergeWithExclude(base), {
+    $and: [base, EXCLUDE_SESSION_END_FILTER],
+  })
+})

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Hyperspell `options.filter` clauses, used by every retrieval path
+ * (auto-context hook + the hyperspell_search tool) so filtering stays
+ * consistent across them.
+ *
+ * Filters match against memory METADATA keys by their bare name — the same
+ * convention `buildScopeFilter` uses (`openclaw_scope`, `openclaw_user`).
+ */
+
+/**
+ * Memories produced by session-end hooks (auto-trace, emotional-state) are
+ * tagged in metadata as `openclaw_source: "agent_end"` (see `sendTrace` in
+ * client.ts). Those should NOT surface via generic retrieval: the
+ * emotional-state hook injects them through its own dedicated path, and
+ * replaying whole sanitized transcripts back into context creates a
+ * self-amplifying pollution loop. Exclude them at the search filter.
+ *
+ * NOTE: an earlier version of this filter checked the top-level `source` field
+ * for the value `"openclaw_agent_end"` — wrong on BOTH counts (the tag lives in
+ * metadata under `openclaw_source`, and its value is `"agent_end"`), so it
+ * silently matched nothing and excluded no traces.
+ */
+export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
+  openclaw_source: { $ne: "agent_end" },
+}
+
+/** Combine a caller-supplied filter with the session-end exclude via `$and`. */
+export function mergeWithExclude(
+  base?: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!base) return EXCLUDE_SESSION_END_FILTER
+  return { $and: [base, EXCLUDE_SESSION_END_FILTER] }
+}

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -22,6 +22,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
       watchPaths: [],
       debounceMs: 2000,
       maxAgeDays: 30,
+      ignorePaths: ["dreaming"],
     },
     sources: [],
     maxResults: 5,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types lib/sender.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
+    "test": "node --test --experimental-strip-types lib/sender.test.ts lib/filters.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/sync/markdown.test.ts
+++ b/sync/markdown.test.ts
@@ -7,6 +7,8 @@ import type { HyperspellClient } from "../client.ts"
 import {
   dedupeTitles,
   fileKey,
+  getMemoryFiles,
+  getSyncableFiles,
   loadManifest,
   parseMarkdownSections,
   saveManifest,
@@ -123,6 +125,57 @@ test("fileKey — files outside the workspace stay deterministic", () => {
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "hs-sync-"))
 }
+
+// ---------------------------------------------------------------------------
+// getMemoryFiles / getSyncableFiles — ignore dot-dirs + configured paths
+// ---------------------------------------------------------------------------
+
+function seedMemoryTree(ws: string): void {
+  const mem = path.join(ws, "memory")
+  fs.mkdirSync(path.join(mem, ".dreams"), { recursive: true })
+  fs.mkdirSync(path.join(mem, "dreaming", "rem"), { recursive: true })
+  fs.mkdirSync(path.join(mem, "topics"), { recursive: true })
+  fs.writeFileSync(path.join(mem, "2026-06-19.md"), "# Real memory\n")
+  fs.writeFileSync(path.join(mem, "topics", "work.md"), "# Nested real memory\n")
+  fs.writeFileSync(path.join(mem, ".dreams", "2026-06-14.md"), "# Dream\n")
+  fs.writeFileSync(path.join(mem, "dreaming", "rem", "2026-06-14.md"), "# REM\n")
+}
+
+test("getMemoryFiles — skips .dreams (dot-dir) and dreaming/ by default", () => {
+  const ws = tmpDir()
+  seedMemoryTree(ws)
+  const got = getMemoryFiles(ws).map((f) => fileKey(ws, f)).sort()
+  assert.deepEqual(got, ["memory/2026-06-19.md", "memory/topics/work.md"])
+})
+
+test("getMemoryFiles — dot-dirs stay excluded even when ignorePaths is emptied", () => {
+  const ws = tmpDir()
+  seedMemoryTree(ws)
+  // Empty list re-enables dreaming/, but dot-directories are ALWAYS skipped.
+  const got = getMemoryFiles(ws, []).map((f) => fileKey(ws, f)).sort()
+  assert.deepEqual(got, [
+    "memory/2026-06-19.md",
+    "memory/dreaming/rem/2026-06-14.md",
+    "memory/topics/work.md",
+  ])
+})
+
+test("getSyncableFiles — applies the same ignore to walked watchPaths", () => {
+  const ws = tmpDir()
+  seedMemoryTree(ws)
+  const extra = path.join(ws, "extra")
+  fs.mkdirSync(path.join(extra, "dreaming"), { recursive: true })
+  fs.mkdirSync(path.join(extra, ".hidden"), { recursive: true })
+  fs.writeFileSync(path.join(extra, "keep.md"), "# Keep\n")
+  fs.writeFileSync(path.join(extra, "dreaming", "drop.md"), "# Drop\n")
+  fs.writeFileSync(path.join(extra, ".hidden", "drop.md"), "# Drop\n")
+  const got = getSyncableFiles(ws, [extra]).map((f) => fileKey(ws, f)).sort()
+  assert.deepEqual(got, [
+    "extra/keep.md",
+    "memory/2026-06-19.md",
+    "memory/topics/work.md",
+  ])
+})
 
 test("loadManifest — missing file returns empty manifest", () => {
   const dir = tmpDir()

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -299,18 +299,43 @@ export function withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
 // Public API — file-level sync (original, kept for backward compat)
 // ---------------------------------------------------------------------------
 
-export function getMemoryFiles(workspaceDir: string): string[] {
+/**
+ * Directory names skipped by default when walking memory/. The dreaming engine
+ * writes first-person dream journals under memory/dreaming/ that are not user
+ * memories; ingesting them pollutes retrieval (they score highly on emotional/
+ * associative queries and crowd out real memories). Configurable via
+ * `syncMemories.ignorePaths`.
+ */
+export const DEFAULT_IGNORE_DIRS = ["dreaming"]
+
+/**
+ * Skip a directory entry during the walk when it is a dot-directory/file
+ * (e.g. `.dreams`, engine scaffolding) or a directory named in `ignore`.
+ * Dot-entries are always skipped regardless of the configured list.
+ */
+function isIgnoredEntry(entry: fs.Dirent, ignore: Set<string>): boolean {
+  if (entry.name.startsWith(".")) return true
+  if (entry.isDirectory() && ignore.has(entry.name)) return true
+  return false
+}
+
+export function getMemoryFiles(
+  workspaceDir: string,
+  ignorePaths?: string[],
+): string[] {
   const memoryDir = path.join(workspaceDir, "memory")
 
   if (!fs.existsSync(memoryDir)) {
     return []
   }
 
+  const ignore = new Set(ignorePaths ?? DEFAULT_IGNORE_DIRS)
   const results: string[] = []
 
   function walk(dir: string): void {
     try {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (isIgnoredEntry(entry, ignore)) continue
         const fullPath = path.join(dir, entry.name)
         if (entry.isDirectory()) {
           walk(fullPath)
@@ -334,8 +359,10 @@ export function getMemoryFiles(workspaceDir: string): string[] {
 export function getSyncableFiles(
   workspaceDir: string,
   watchPaths?: string[],
+  ignorePaths?: string[],
 ): string[] {
-  const files = getMemoryFiles(workspaceDir)
+  const ignore = new Set(ignorePaths ?? DEFAULT_IGNORE_DIRS)
+  const files = getMemoryFiles(workspaceDir, ignorePaths)
 
   if (watchPaths) {
     for (const wp of watchPaths) {
@@ -353,6 +380,7 @@ export function getSyncableFiles(
         const walk = (dir: string) => {
           try {
             for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              if (isIgnoredEntry(entry, ignore)) continue
               const fullPath = path.join(dir, entry.name)
               if (entry.isDirectory()) {
                 walk(fullPath)
@@ -625,7 +653,12 @@ export async function syncAllMemoryFiles(
 export async function syncAllFilesSectionized(
   client: HyperspellClient,
   workspaceDir: string,
-  options?: { userId?: string; watchPaths?: string[]; maxAgeDays?: number },
+  options?: {
+    userId?: string
+    watchPaths?: string[]
+    maxAgeDays?: number
+    ignorePaths?: string[]
+  },
 ): Promise<{
   synced: number
   skipped: number
@@ -634,7 +667,11 @@ export async function syncAllFilesSectionized(
   agedOut: number
   errors: string[]
 }> {
-  const files = getSyncableFiles(workspaceDir, options?.watchPaths)
+  const files = getSyncableFiles(
+    workspaceDir,
+    options?.watchPaths,
+    options?.ignorePaths,
+  )
 
   // Age pre-filter: a file untouched for longer than maxAgeDays that is
   // already recorded in the manifest has been ingested at least once and is

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox"
 import type { HyperspellClient } from "../client.ts"
 import type { CanReadScope, HyperspellConfig } from "../config.ts"
+import { mergeWithExclude } from "../lib/filters.ts"
 import { buildScopeFilter, getCanReadScopes, resolveUser } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 
@@ -66,6 +67,10 @@ export function createSearchToolFactory(
           : canRead
         filter = buildScopeFilter(allowed, resolved?.userId ?? "")
       }
+
+      // Keep session-end trace memories out of agent-facing search, matching
+      // the auto-context hook so both retrieval paths filter identically.
+      filter = mergeWithExclude(filter)
 
       log.debug(
         `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId} scope=${params.scope ?? "any"}`,


### PR DESCRIPTION
Closes the active half of #35. Diagnosed against the live workspace + vault, with read-only probes before any change.

## What was wrong

Recurring "I store a memory, it never comes back in search." Live probing found the symptom is **retrieval pollution + indexing latency**, not a broken write path:

- **129 dream memories** (`memory/dreaming/{rem,light,deep}/` + `memory/.dreams/` + an archived diary) had been section-synced into the vault and were crowding out real memories — a dream ranked **#1 (score 0.80)** for *"what should I work on tonight"*.
- The write→read "failure" reproduced as **~26s server-side indexing latency** (canary invisible at 16s, found at 25.8s), same user on write and read — not a `userId`/`X-As-User` mismatch.

(Live vault cleanup — purging the 129 + correcting a stale "write→read broken" memory — was done out-of-band; this PR is the code so it can't recur.)

## Fixes

**F1 — sync no longer ingests non-memory scaffolding.** `getMemoryFiles`/`getSyncableFiles` walked `memory/` with no exclusions. Now: dot-directories (`.dreams`) are **always** skipped, plus a configurable `syncMemories.ignorePaths` (default `["dreaming"]`). Applied in the bulk walk, the watchPath walk, **and** the live file-change handler, so an edit can't re-ingest what the walk skips. The issue's original "skip dot-dirs" idea would have caught only 10 of the 129 — `memory/dreaming/` is not hidden.

**F5 — the trace-exclude filter matched nothing.** It checked top-level `source` for `"openclaw_agent_end"`, but traces are tagged `metadata.openclaw_source: "agent_end"` (wrong key **and** value), so session-end transcripts were never excluded from recall. Corrected to `{ openclaw_source: { $ne: "agent_end" } }` (verified against the working `buildScopeFilter` bare-key convention) and centralized in `lib/filters.ts`.

**F6 — the `hyperspell_search` tool applied no exclude filter at all.** It now shares the centralized filter, so the auto-context hook and the search tool behave identically.

**F4 (relevance floor / recency tiebreak) — intentionally deferred.** It's a behavior change to the live agent, and probing showed it would not fix the write→read symptom (a hard floor hides a fresh low-score write *more*). Tracked as follow-up in #35.

## Tests

- `sync/markdown.test.ts` — dot-dir + `dreaming/` exclusion in both walks, and that dot-dirs stay excluded even when `ignorePaths` is emptied.
- `lib/filters.test.ts` — the corrected filter key/value and `$and` merge.
- `config.test.ts` — `ignorePaths` default + override parsing.

`npm run build`, `npm run check-types`, and all **93** tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)