### PR TITLE
fix: warn when startup-orientation is enabled but autoTrace is off

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ import {
 	buildStartupOrientationHandler,
 	buildStartupOrientationSessionCleanupHandler,
 } from "./hooks/startup-orientation.ts"
-import { initLogger } from "./logger.ts"
+import { initLogger, log } from "./logger.ts"
 import { createRememberToolFactory } from "./tools/remember.ts"
 import { createSearchToolFactory } from "./tools/search.ts"
 import { registerNetworkTools } from "./graph/index.ts"
@@ -119,6 +119,16 @@ export default {
 		// Register startup-orientation hooks: recent-interactions + unfinished-loops
 		// injected once per session on first turn. Lifecycle mirrors emotional-context.
 		if (cfg.startupOrientation.enabled) {
+			// The recent-interactions half reads source:"trace" / openclaw_source:"agent_end"
+			// memories, which are ONLY written by the auto-trace hook. With auto-trace off,
+			// that half silently injects nothing forever (recent=0). Warn so the operator
+			// knows the configured feature is half-inert rather than wondering why their
+			// agent has no recent continuity.
+			if (!cfg.autoTrace.enabled) {
+				log.warn(
+					"startup-orientation is enabled but autoTrace is disabled; recent-interactions injection will be empty (no traces are written). Enable autoTrace to restore recent-conversation continuity.",
+				);
+			}
 			api.on("before_agent_start", buildStartupOrientationHandler(client, cfg));
 			api.on("after_compaction", buildStartupOrientationCompactionHandler());
 			api.on("session_end", buildStartupOrientationSessionCleanupHandler());


### PR DESCRIPTION
## Summary

`startupOrientation`'s **recent-interactions** injection silently produces nothing whenever `autoTrace` is disabled, even though the feature is enabled. The result is `recent=0` on every session, with only a `debug` log — so an operator who turned on startup-orientation for conversational continuity gets none, and has no signal as to why.

### Root cause (the writer/reader coupling)

- `fetchRecentTraces` (`hooks/startup-orientation.ts`) reads memories filtered to `listMemories({ source: "trace" })` + `metadata.openclaw_source === "agent_end"`.
- Those memories are written **only** by the auto-trace hook (`client.sendTrace` → `sessions.add`, stamping `openclaw_source: "agent_end"` in `client.ts`).
- That hook is registered **only** when `cfg.autoTrace.enabled` (`index.ts`):
  ```ts
  if (cfg.autoTrace.enabled) {
      api.on("agent_end", buildAutoTraceHandler(client, cfg));
  }
  ```
- `autoTrace.enabled` **defaults to `false`** (`config.ts`), while `startupOrientation` is independently opt-in. So `startupOrientation: { enabled: true }` **without** `autoTrace: { enabled: true }` is a natural, valid-looking config that silently disables half the feature forever.

The unfinished-loops half (semantic `client.search`) still works, which makes the failure harder to spot: the feature looks alive and partly functional.

### Fix

Emit a `log.warn` at registration time (the logger is already initialized at that point) when `startupOrientation.enabled && !autoTrace.enabled`, naming the empty feature and the remedy. No behavior change for valid loops-only setups; no throw (that would wrongly break intentional loops-only configs). This mirrors the plugin's existing "don't silently give users behavior they didn't ask for" stance (the `syncMemories` strict-keys note in `config.ts`).

## Verification

Run in a fresh clone of `main` with this change:

- `npm run check-types` — clean
- `npm test` — 93/93 pass
- `git diff --check` — no whitespace issues; added lines use tabs and match surrounding style

Lint note: `npm run lint` invokes `bunx @biomejs/biome ci .`, which needs `bun` (not present in my environment). Running latest Biome via `npx` reports 2 errors on `index.ts` — but the **unmodified** `main` file reports the identical 2 (format + `organizeImports`), so they're pre-existing under latest Biome (no Biome version is pinned in `devDependencies`), not introduced here. The single import line I touched (`{ initLogger, log }`) is alphabetically ordered.

## How this was found

Debugging a live deployment with `startupOrientation.enabled: true` and `autoTrace.enabled: false`: logs showed `startup-orientation: injecting recent=0 loops=10` on every session and the agent had lost recent-conversation continuity. Static identity/bootstrap context loaded fine; only the recent-interactions memory path was dead, traced to the coupling above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
