### PR TITLE
feat(recall): fix #40 exclude filter + make cross-session recall discoverable

### DIFF
--- a/docs/filter-dialect-test.mjs
+++ b/docs/filter-dialect-test.mjs
@@ -1,0 +1,122 @@
+// Full characterization of the Hyperspell backend filter dialect for issue #40.
+//
+// We need an exclude filter that DROPS agent_end rows but KEEPS untagged
+// hot-buffer rows. The obvious MongoDB-style answers ($exists:false, $or) were
+// falsified by --filter-probe (returned 0 docs). This maps what the dialect
+// ACTUALLY supports, against controlled canaries, so we ship a proven filter.
+//
+// Canaries (all share a unique term so one query returns them together):
+//   U  — UNTAGGED, written via POST /messages  (the real hot-buffer row)
+//   A  — tagged openclaw_source="agent_end" via memories.add (the row to EXCLUDE)
+//   H  — tagged openclaw_source="hot_buffer"  via memories.add (Option 2 sim)
+//   Um — UNTAGGED-but-with-metadata via POST /messages (tests whether /messages
+//        even accepts metadata — i.e. whether Option 2 is possible for hot rows)
+//
+// Goal filter: returns U=yes, A=no, status 200. Everything is deleted at the end.
+//
+// Run:  node docs/filter-dialect-test.mjs
+
+import Hyperspell from "hyperspell"
+import fs from "node:fs"
+
+const cfg = JSON.parse(fs.readFileSync(process.env.HOME + "/.openclaw/openclaw.json", "utf8"))
+  .plugins.entries["openclaw-hyperspell"].config
+const apiKey = cfg.apiKey
+const userId = cfg.userId
+const client = new Hyperspell({ apiKey, userID: userId })
+const ro = userId ? { headers: { "X-As-User": userId } } : undefined
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+if (!userId) { console.error("no userId; aborting"); process.exit(1) }
+
+const run = Date.now().toString(36)
+const SHARED = `dialecttest-${run}` // common term in every canary
+const tok = { U: `tokU-${run}`, A: `tokA-${run}`, H: `tokH-${run}`, Um: `tokUm-${run}` }
+const Uid = `fdt-U-${run}`
+const Umid = `fdt-Um-${run}`
+
+async function postMessage(resourceId, token, extra) {
+  const msg = { resource_id: resourceId, message_id: `m-${token}`, content: `${SHARED} ${token}. Safe to delete.`, ...extra }
+  const res = await fetch("https://api.hyperspell.com/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}`, "X-As-User": userId },
+    body: JSON.stringify({ source: "vault", messages: [msg] }),
+  })
+  return { status: res.status, body: res.ok ? "" : await res.text() }
+}
+
+console.log("=== filter dialect test (issue #40) ===  run", run)
+
+// --- write canaries ---
+const created = [] // {label, resource_id, via}
+const rU = await postMessage(Uid, tok.U)
+console.log(`U  (/messages untagged)        -> ${rU.status}`)
+if (rU.status < 300) created.push({ label: "U", resource_id: Uid, via: "messages" })
+
+const rUm = await postMessage(Umid, tok.Um, { metadata: { openclaw_source: "hot_buffer" } })
+console.log(`Um (/messages + metadata)      -> ${rUm.status} ${rUm.body ? "("+rUm.body.slice(0,60)+")" : ""}`)
+if (rUm.status < 300) created.push({ label: "Um", resource_id: Umid, via: "messages" })
+
+let A, H
+try {
+  A = await client.memories.add({ text: `${SHARED} ${tok.A}. Safe to delete.`, title: `FDT A ${run}`, collection: "openclaw", metadata: { openclaw_source: "agent_end" } }, ro)
+  console.log(`A  (memories.add agent_end)    -> ${A.resource_id}`)
+  created.push({ label: "A", resource_id: A.resource_id, via: "memories" })
+} catch (e) { console.log("A add failed:", e?.status, e?.message) }
+try {
+  H = await client.memories.add({ text: `${SHARED} ${tok.H}. Safe to delete.`, title: `FDT H ${run}`, collection: "openclaw", metadata: { openclaw_source: "hot_buffer" } }, ro)
+  console.log(`H  (memories.add hot_buffer)   -> ${H.resource_id}`)
+  created.push({ label: "H", resource_id: H.resource_id, via: "memories" })
+} catch (e) { console.log("H add failed:", e?.status, e?.message) }
+
+console.log("\nindexing… (4s)")
+await sleep(4000)
+
+// --- probe helper: which canaries come back under a given filter ---
+async function probe(filter) {
+  const opts = { max_results: 25, ...(filter ? { filter } : {}) }
+  try {
+    const r = await client.memories.search({ query: SHARED, options: opts }, ro)
+    const hay = r.documents.map((d) => `${d.resource_id} ${d.title ?? ""} ${(d.highlights ?? []).map((h) => h.text).join(" ")}`).join(" || ")
+    const has = (t, id) => hay.includes(t) || hay.includes(id)
+    return { status: 200, n: r.documents.length, U: has(tok.U, Uid), Um: has(tok.Um, Umid), A: has(tok.A, A?.resource_id ?? "A?"), H: has(tok.H, H?.resource_id ?? "H?") }
+  } catch (e) { return { status: e?.status ?? "ERR", err: e?.message } }
+}
+
+const FILTERS = [
+  ["no filter (baseline)", undefined],
+  ["$ne agent_end", { openclaw_source: { $ne: "agent_end" } }],
+  ["$exists:false", { openclaw_source: { $exists: false } }],
+  ["$or[$exists:false,$ne]", { $or: [{ openclaw_source: { $exists: false } }, { openclaw_source: { $ne: "agent_end" } }] }],
+  ["$or[null,$ne]", { $or: [{ openclaw_source: null }, { openclaw_source: { $ne: "agent_end" } }] }],
+  ["openclaw_source:null", { openclaw_source: null }],
+  ["$nin[agent_end]", { openclaw_source: { $nin: ["agent_end"] } }],
+  ["$not{$eq}", { openclaw_source: { $not: { $eq: "agent_end" } } }],
+  ["$ne null", { openclaw_source: { $ne: null } }],
+  ["$eq hot_buffer", { openclaw_source: { $eq: "hot_buffer" } }],
+  ["$in[hot_buffer]", { openclaw_source: { $in: ["hot_buffer"] } }],
+  ["$and[$ne]", { $and: [{ openclaw_source: { $ne: "agent_end" } }] }],
+]
+
+console.log("\n=== truth table (want: U=Y, A=N, status 200) ===")
+console.log("filter".padEnd(26), "stat", " U ", "Um ", " A ", " H ", " n")
+for (const [label, f] of FILTERS) {
+  const r = await probe(f)
+  if (r.status !== 200) { console.log(label.padEnd(26), String(r.status).padEnd(4), " — err:", r.err); continue }
+  const y = (b) => (b ? " Y " : " . ")
+  console.log(label.padEnd(26), "200 ", y(r.U), y(r.Um), y(r.A), y(r.H), String(r.n).padStart(2))
+}
+
+// --- cleanup everything ---
+console.log("\n=== cleanup ===")
+for (const c of created) {
+  try { await client.memories.delete(c.resource_id, { source: "vault" }, ro); console.log("deleted", c.label, c.resource_id) }
+  catch (e) {
+    // fall back to search-by-token delete (works where direct delete 404s pre-consolidation)
+    try {
+      const r = await client.memories.search({ query: tok[c.label], options: { max_results: 5 } }, ro)
+      for (const d of r.documents) { try { await client.memories.delete(d.resource_id, { source: d.source ?? "vault" }, ro) } catch {} }
+      console.log("deleted(via search)", c.label)
+    } catch { console.log("COULD NOT DELETE", c.label, c.resource_id, "— token", tok[c.label]) }
+  }
+}
+console.log("\nKey: U=untagged hot row (KEEP), A=agent_end (DROP), Um=/messages+metadata (does tagging stick?), H=tagged hot_buffer (Option 2)")

--- a/docs/hotbuffer-verify.mjs
+++ b/docs/hotbuffer-verify.mjs
@@ -1,0 +1,276 @@
+// Verify the hot-buffer read path is fixed (hyperspell PR #1899).
+//
+// Bug it confirms gone: /memories/query returned HTTP 500 on ANY query that
+// matched a realtime hot-buffer row, while the row was still "hot" (before the
+// ~60s server-side consolidation into a vault Resource). Root cause was
+// HybridSearch asserting Chunk.id is not None; MessageRetriever built hot chunks
+// with id=None.
+//
+// What this does: writes one labeled canary straight to the hot buffer (exactly
+// what the agent_end hook does), then searches for it repeatedly across the
+// pre-consolidation window, logging the STATUS of every call. Best-effort
+// deletes the canary at the end so it doesn't linger in the vault.
+//
+//   PASS  = zero 500s across the whole window AND the canary surfaces early
+//           (t+0 / t+1.5s — i.e. genuinely served from the hot buffer).
+//   FAIL  = any 500 (fix not live / not deployed to this row's path), or the
+//           canary never surfaces.
+//
+// Usage:
+//   node docs/hotbuffer-verify.mjs                 # run the verification (self-cleans)
+//   node docs/hotbuffer-verify.mjs --cleanup       # delete leftover canaries from THIS script
+//   node docs/hotbuffer-verify.mjs --cleanup TOKEN # delete any vault resource matching TOKEN
+//                                                   #   (use the nonce/secret word from a Test-2
+//                                                   #    blind-sister probe, e.g. lighthouse-velvet)
+//   add --dry-run to --cleanup to list matches without deleting.
+
+import Hyperspell from "hyperspell"
+import fs from "node:fs"
+
+const cfg = JSON.parse(fs.readFileSync(process.env.HOME + "/.openclaw/openclaw.json", "utf8"))
+  .plugins.entries["openclaw-hyperspell"].config
+const apiKey = cfg.apiKey
+const userId = cfg.userId // "alinea" in her live config; X-As-User is required for /messages
+const client = new Hyperspell({ apiKey, userID: userId })
+const ro = userId ? { headers: { "X-As-User": userId } } : undefined
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+if (!userId) {
+  console.error("No userId in config — POST /messages requires X-As-User. Aborting.")
+  process.exit(1)
+}
+
+// Markers this script stamps on its own canaries, used by default --cleanup.
+const CANARY_ID_PREFIX = "hbverify-session-"
+const CANARY_MARK = "Hot-buffer verification canary"
+
+const args = process.argv.slice(2)
+const doCleanup = args.includes("--cleanup")
+const doFilterProbe = args.includes("--filter-probe")
+const dryRun = args.includes("--dry-run")
+const tokenArg = args.find((a) => !a.startsWith("--"))
+
+// Write a labeled hot-buffer canary; returns { resourceId, secret, nonce }.
+async function writeCanary(tag) {
+  const n = `${tag}-` + Date.now().toString(36)
+  const secret = `lighthouse-${n}`
+  const resourceId = `${CANARY_ID_PREFIX}${n}`
+  const res = await fetch("https://api.hyperspell.com/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+      "X-As-User": userId,
+    },
+    body: JSON.stringify({
+      source: "vault",
+      messages: [
+        {
+          resource_id: resourceId,
+          message_id: `a-${n}`,
+          content: `${CANARY_MARK} ${n}. Secret word: ${secret}. Safe to delete.`,
+        },
+      ],
+    }),
+  })
+  if (!res.ok) throw new Error(`write failed ${res.status}: ${await res.text()}`)
+  return { resourceId, secret, nonce: n }
+}
+
+async function searchHit(secret, resourceId, filter) {
+  const opts = { max_results: 5, ...(filter ? { filter } : {}) }
+  const r = await client.memories.search({ query: secret, options: opts }, ro)
+  return {
+    docs: r.documents.length,
+    hit: r.documents.some((d) => d.resource_id === resourceId),
+  }
+}
+
+/**
+ * Empirically validate issue #40 + the proposed fixes against the LIVE backend
+ * dialect (read-only besides one self-deleted canary). Proves whether the
+ * untagged hot row is dropped by the current filter and whether the $exists /
+ * $or fixes actually re-admit it — BEFORE anyone ships a filter that could fail
+ * the same silent way.
+ */
+async function filterProbe() {
+  console.log("=== filter dialect probe (issue #40) ===")
+  const { resourceId, secret, nonce } = await writeCanary("hbfilter")
+  console.log(`wrote canary ${resourceId} (nonce ${nonce})`)
+  await sleep(2500) // let it index
+
+  const cases = [
+    ["no filter (baseline)", undefined, "TRUE"],
+    ["current  { $ne: agent_end }", { openclaw_source: { $ne: "agent_end" } }, "FALSE (repro #40)"],
+    ["Option1a { $exists: false }", { openclaw_source: { $exists: false } }, "TRUE"],
+    [
+      "Option1  { $or: [$exists:false, $ne] }",
+      { $or: [{ openclaw_source: { $exists: false } }, { openclaw_source: { $ne: "agent_end" } }] },
+      "TRUE",
+    ],
+  ]
+  for (const [label, filter, expect] of cases) {
+    try {
+      const { docs, hit } = await searchHit(secret, resourceId, filter)
+      console.log(`  ${label.padEnd(40)} | 200 | docs=${docs} | hit=${hit}  (expect ${expect})`)
+    } catch (e) {
+      const status = e?.status ?? ""
+      console.log(`  ${label.padEnd(40)} | ${status} ERROR ${e?.message ?? e}  (expect ${expect})`)
+      if (label.includes("$exists")) {
+        console.log("    ^ $exists not supported by this dialect — prefer Option 4 (gate on autoTrace) / Option 2 (tag writes).")
+      }
+    }
+  }
+
+  try {
+    await client.memories.delete(resourceId, { source: "vault" }, ro)
+    console.log(`cleanup: deleted ${resourceId}`)
+  } catch (e) {
+    console.log(`cleanup: could not delete ${resourceId}; run --cleanup ${nonce}`)
+  }
+  console.log(
+    "\nVerdict: Option 1 is viable iff the $exists / $or rows came back 200 + hit=TRUE.",
+  )
+}
+
+function resourceText(d) {
+  const title = d.title ?? ""
+  const hl = (d.highlights ?? []).map((h) => h?.text ?? "").join(" ")
+  return { title, hl, id: String(d.resource_id ?? "") }
+}
+
+/**
+ * Conservative cleanup: only deletes a resource when `token` (or this script's
+ * own canary signature) actually appears in its id/title/highlight text — never
+ * on a bare relevance hit. Lists everything; --dry-run skips the delete.
+ */
+async function cleanup(token) {
+  const queries = token ? [token] : [CANARY_MARK, "hbverify", "Safe to delete"]
+  const matches = new Map() // resourceId -> { source, title }
+  console.log(`=== cleanup ${dryRun ? "(dry-run) " : ""}===`)
+  console.log(token ? `token: ${JSON.stringify(token)}` : "target: this script's own canaries")
+
+  for (const q of queries) {
+    let docs = []
+    try {
+      const r = await client.memories.search({ query: q, options: { max_results: 25 } }, ro)
+      docs = r.documents ?? []
+    } catch (e) {
+      console.log(`  search ${JSON.stringify(q)} ERROR ${e?.status ?? ""} ${e?.message ?? e}`)
+      continue
+    }
+    for (const d of docs) {
+      const { title, hl, id } = resourceText(d)
+      const hay = `${id}\n${title}\n${hl}`
+      const isMatch = token
+        ? hay.includes(token)
+        : id.startsWith(CANARY_ID_PREFIX) || hay.includes(CANARY_MARK) || hay.includes("hbverify-")
+      if (isMatch && id) matches.set(id, { source: d.source ?? "vault", title })
+    }
+  }
+
+  if (matches.size === 0) {
+    console.log("  no matching resources found — nothing to delete.")
+    return 0
+  }
+
+  let deleted = 0
+  for (const [rid, info] of matches) {
+    const label = `${rid}  [${info.source}]  ${JSON.stringify(info.title || "")}`
+    if (dryRun) {
+      console.log(`  would delete: ${label}`)
+      continue
+    }
+    try {
+      await client.memories.delete(rid, { source: info.source }, ro)
+      deleted++
+      console.log(`  deleted: ${label}`)
+    } catch (e) {
+      console.log(`  FAILED to delete ${rid}: ${e?.status ?? ""} ${e?.message ?? e}`)
+    }
+  }
+  console.log(`\n${dryRun ? `${matches.size} match(es) — none deleted (dry-run).` : `deleted ${deleted}/${matches.size}.`}`)
+  return matches.size
+}
+
+if (doCleanup) {
+  await cleanup(tokenArg)
+  process.exit(0)
+}
+
+if (doFilterProbe) {
+  await filterProbe()
+  process.exit(0)
+}
+
+// ---- verification run ----
+const nonce = "hbverify-" + Date.now().toString(36)
+const secret = `lighthouse-${nonce}`
+const resourceId = `${CANARY_ID_PREFIX}${nonce}`
+const messageId = `a-${nonce}`
+const content = `${CANARY_MARK} ${nonce}. Secret word: ${secret}. Safe to delete.`
+
+console.log("=== hot-buffer verify ===")
+console.log("userId:", userId, "| nonce:", nonce)
+
+// 1) Write the canary directly to the hot buffer (mirrors the agent_end hook).
+const wr = await fetch("https://api.hyperspell.com/messages", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    "X-As-User": userId,
+  },
+  body: JSON.stringify({
+    source: "vault",
+    messages: [{ resource_id: resourceId, message_id: messageId, content }],
+  }),
+})
+console.log(`write POST /messages -> ${wr.status}${wr.ok ? "" : "  " + (await wr.text())}`)
+if (!wr.ok) {
+  console.error("FAIL: could not write canary to hot buffer.")
+  process.exit(1)
+}
+
+// 2) Search across the pre-consolidation window. Log STATUS of every call.
+//    A 500 anywhere = the read-path bug is still live for this path.
+let any500 = false
+let firstHitMs = null
+const t0 = Date.now()
+const schedule = [0, 1500, 3000, 6000, 12000, 25000, 45000, 70000]
+let prev = 0
+for (const at of schedule) {
+  if (at > prev) await sleep(at - prev)
+  prev = at
+  const elapsed = Date.now() - t0
+  try {
+    const r = await client.memories.search({ query: secret, options: { max_results: 5 } }, ro)
+    const hit = r.documents.some(
+      (d) => d.resource_id === resourceId || (d.title ?? "").includes(nonce),
+    )
+    if (hit && firstHitMs === null) firstHitMs = elapsed
+    console.log(`  t+${elapsed}ms  OK    docs=${r.documents.length}  hit=${hit}`)
+  } catch (e) {
+    const status = e?.status ?? ""
+    if (String(status).startsWith("5")) any500 = true
+    console.log(`  t+${elapsed}ms  FAIL ${status}  ${e?.message ?? e}`)
+  }
+}
+
+// 3) Best-effort cleanup so the canary doesn't pollute the vault / dreams.
+try {
+  await client.memories.delete(resourceId, { source: "vault" }, ro)
+  console.log(`cleanup: deleted ${resourceId}`)
+} catch (e) {
+  console.log(`cleanup: could not delete ${resourceId} (${e?.status ?? ""} ${e?.message ?? e})`)
+  console.log(`         run:  node docs/hotbuffer-verify.mjs --cleanup ${nonce}`)
+}
+
+// 4) Verdict.
+const pass = !any500 && firstHitMs !== null && firstHitMs <= 6000
+console.log("\n=== verdict ===")
+console.log(`  no 500s:          ${!any500 ? "yes" : "NO  <-- read-path bug still live"}`)
+console.log(`  surfaced:         ${firstHitMs !== null ? `yes, first at t+${firstHitMs}ms` : "NO  <-- never found"}`)
+console.log(`  surfaced in-window(<=6s): ${firstHitMs !== null && firstHitMs <= 6000 ? "yes" : "no"}`)
+console.log(pass ? "\nPASS — hot-buffer instant recall works end-to-end." : "\nFAIL — see above.")
+process.exit(pass ? 0 : 1)

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -6,7 +6,7 @@ import {
   resolveUser,
   type ResolvedUser,
 } from "../lib/sender.ts"
-import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "../lib/filters.ts"
+import { excludeFilterFor, mergeWithExclude } from "../lib/filters.ts"
 import { log } from "../logger.ts"
 
 function formatRelativeTime(isoTimestamp: string): string {
@@ -63,9 +63,9 @@ function formatHighlightBullets(
 }
 
 const INTRO =
-  "The following is context from the user's connected sources. Reference it only when relevant to the conversation."
+  "The following is surfaced from the user's memory and connected sources, including past conversations. Reference it as recalled context, only when relevant to the conversation."
 const DISCLAIMER =
-  "Use this context naturally when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
+  "Draw on it when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
 
 function wrapSingle(body: string): string {
   return `<hyperspell-context>\n${INTRO}\n\n${body}\n\n${DISCLAIMER}\n</hyperspell-context>`
@@ -94,7 +94,7 @@ export function buildAutoContextHandler(
     try {
       const results = await client.search(prompt, {
         limit: cfg.maxResults,
-        filter: EXCLUDE_SESSION_END_FILTER,
+        filter: excludeFilterFor(cfg),
       })
       const formatted = formatHighlightBullets(
         results,
@@ -145,7 +145,7 @@ async function multiUserSearch(
     ? client.search(prompt, {
         limit: cfg.maxResults,
         userId: resolved!.userId,
-        filter: EXCLUDE_SESSION_END_FILTER,
+        filter: excludeFilterFor(cfg),
       })
     : null
 
@@ -158,7 +158,7 @@ async function multiUserSearch(
       ? client.search(prompt, {
           limit: sharedLimit,
           userId: multiUser.sharedUserId,
-          filter: mergeWithExclude(scopeFilter),
+          filter: mergeWithExclude(scopeFilter, cfg),
         })
       : null
 

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -9,23 +9,20 @@ import {
 const ON = { autoTrace: { enabled: true } }
 const OFF = { autoTrace: { enabled: false } }
 
-test("EXCLUDE_SESSION_END_FILTER — hides agent_end traces but tolerates untagged rows (issue #40)", () => {
-  // sendTrace tags traces as metadata.openclaw_source = "agent_end". The filter
-  // must exclude those, while still admitting rows with NO openclaw_source
-  // (e.g. hot-buffer /messages rows) — which a bare { $ne } would silently drop
-  // under the backend's SQL NULL semantics.
+test("EXCLUDE_SESSION_END_FILTER — plain $ne agent_end (the only shape the backend honors)", () => {
+  // sendTrace tags traces as metadata.openclaw_source = "agent_end". A $exists/$or
+  // "tolerant" form was tried to also admit untagged hot-buffer rows, but the live
+  // backend returns 0 rows for $or/$exists (see docs/filter-dialect-test.mjs), so
+  // we keep the plain $ne and rely on excludeFilterFor's gate to keep hot rows.
   assert.deepEqual(EXCLUDE_SESSION_END_FILTER, {
-    $or: [
-      { openclaw_source: { $exists: false } },
-      { openclaw_source: { $ne: "agent_end" } },
-    ],
+    openclaw_source: { $ne: "agent_end" },
   })
 })
 
 test("excludeFilterFor — applies the exclude only when auto-trace is on (Option 4)", () => {
-  // agent_end rows are written ONLY by the auto-trace hook; with it disabled
-  // there are none to hide, so we skip the filter entirely — which also keeps
-  // untagged hot-buffer rows visible regardless of backend $exists support.
+  // agent_end rows are written ONLY by the auto-trace hook; with it disabled there
+  // are none to hide, so we skip the filter entirely. That's also the ONLY way to
+  // keep untagged hot-buffer rows visible — no filter and no write-tag can.
   assert.deepEqual(excludeFilterFor(ON), EXCLUDE_SESSION_END_FILTER)
   assert.equal(excludeFilterFor(OFF), undefined)
 })

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -1,23 +1,48 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "./filters.ts"
+import {
+  EXCLUDE_SESSION_END_FILTER,
+  excludeFilterFor,
+  mergeWithExclude,
+} from "./filters.ts"
 
-test("EXCLUDE_SESSION_END_FILTER — matches the real trace tag (metadata key + value)", () => {
-  // sendTrace tags traces as metadata.openclaw_source = "agent_end"; the filter
-  // must target that bare key/value, not top-level `source`/`openclaw_agent_end`.
+const ON = { autoTrace: { enabled: true } }
+const OFF = { autoTrace: { enabled: false } }
+
+test("EXCLUDE_SESSION_END_FILTER — hides agent_end traces but tolerates untagged rows (issue #40)", () => {
+  // sendTrace tags traces as metadata.openclaw_source = "agent_end". The filter
+  // must exclude those, while still admitting rows with NO openclaw_source
+  // (e.g. hot-buffer /messages rows) — which a bare { $ne } would silently drop
+  // under the backend's SQL NULL semantics.
   assert.deepEqual(EXCLUDE_SESSION_END_FILTER, {
-    openclaw_source: { $ne: "agent_end" },
+    $or: [
+      { openclaw_source: { $exists: false } },
+      { openclaw_source: { $ne: "agent_end" } },
+    ],
   })
 })
 
-test("mergeWithExclude — no base returns the exclude filter alone", () => {
-  assert.deepEqual(mergeWithExclude(), EXCLUDE_SESSION_END_FILTER)
-  assert.deepEqual(mergeWithExclude(undefined), EXCLUDE_SESSION_END_FILTER)
+test("excludeFilterFor — applies the exclude only when auto-trace is on (Option 4)", () => {
+  // agent_end rows are written ONLY by the auto-trace hook; with it disabled
+  // there are none to hide, so we skip the filter entirely — which also keeps
+  // untagged hot-buffer rows visible regardless of backend $exists support.
+  assert.deepEqual(excludeFilterFor(ON), EXCLUDE_SESSION_END_FILTER)
+  assert.equal(excludeFilterFor(OFF), undefined)
 })
 
-test("mergeWithExclude — base is AND-combined with the exclude", () => {
+test("mergeWithExclude — auto-trace ON, no base returns the exclude filter alone", () => {
+  assert.deepEqual(mergeWithExclude(undefined, ON), EXCLUDE_SESSION_END_FILTER)
+})
+
+test("mergeWithExclude — auto-trace ON, base is AND-combined with the exclude", () => {
   const base = { openclaw_scope: { $in: ["family"] } }
-  assert.deepEqual(mergeWithExclude(base), {
+  assert.deepEqual(mergeWithExclude(base, ON), {
     $and: [base, EXCLUDE_SESSION_END_FILTER],
   })
+})
+
+test("mergeWithExclude — auto-trace OFF passes the base through untouched", () => {
+  const base = { openclaw_scope: { $in: ["family"] } }
+  assert.deepEqual(mergeWithExclude(base, OFF), base)
+  assert.equal(mergeWithExclude(undefined, OFF), undefined)
 })

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -7,27 +7,60 @@
  * convention `buildScopeFilter` uses (`openclaw_scope`, `openclaw_user`).
  */
 
+/** Minimal slice of config the exclude logic needs (avoids a config-module cycle). */
+type ExcludeCfg = { autoTrace: { enabled: boolean } }
+
 /**
- * Memories produced by session-end hooks (auto-trace, emotional-state) are
- * tagged in metadata as `openclaw_source: "agent_end"` (see `sendTrace` in
- * client.ts). Those should NOT surface via generic retrieval: the
- * emotional-state hook injects them through its own dedicated path, and
- * replaying whole sanitized transcripts back into context creates a
- * self-amplifying pollution loop. Exclude them at the search filter.
+ * Memories produced by the auto-trace session-end hook are tagged in metadata
+ * as `openclaw_source: "agent_end"` (see `sendTrace` in client.ts). Those should
+ * NOT surface via generic retrieval — replaying whole sanitized transcripts back
+ * into context creates a self-amplifying pollution loop. Exclude them here.
  *
- * NOTE: an earlier version of this filter checked the top-level `source` field
- * for the value `"openclaw_agent_end"` — wrong on BOTH counts (the tag lives in
- * metadata under `openclaw_source`, and its value is `"agent_end"`), so it
- * silently matched nothing and excluded no traces.
+ * TOLERANT FORM (issue #40): hot-buffer rows written via `POST /messages` carry
+ * NO `openclaw_source`. A bare `{ openclaw_source: { $ne: "agent_end" } }`
+ * silently drops them: the backend evaluates the JSONB predicate in SQL
+ * three-valued logic — `metadata->>'openclaw_source'` is NULL for an absent key,
+ * and `NULL != 'agent_end'` is NULL (not TRUE), so the row fails to match and is
+ * excluded. This is the OPPOSITE of MongoDB `$ne` (which matches missing fields)
+ * — do not "correct" it back. `$or`-ing an explicit `$exists: false` branch
+ * re-admits untagged rows while still hiding the real `agent_end` traces.
+ *
+ * NOTE: an earlier version checked the top-level `source` field for
+ * "openclaw_agent_end" — wrong on BOTH counts (the tag lives in metadata under
+ * `openclaw_source`, value `"agent_end"`), so it silently matched nothing.
  */
 export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
-  openclaw_source: { $ne: "agent_end" },
+  $or: [
+    { openclaw_source: { $exists: false } },
+    { openclaw_source: { $ne: "agent_end" } },
+  ],
 }
 
-/** Combine a caller-supplied filter with the session-end exclude via `$and`. */
+/**
+ * The exclude clause to apply for a given config — or `undefined` to skip
+ * filtering entirely (issue #40, Option 4). `openclaw_source: "agent_end"` rows
+ * are written ONLY by the auto-trace hook; when auto-trace is disabled no such
+ * rows exist, so the exclude is pure cost — and skipping it keeps untagged
+ * hot-buffer rows visible without depending on the backend's `$exists`/null
+ * handling at all. Auto-trace-on installs still get the tolerant clause above
+ * (validate `$exists` support via `hotbuffer-verify.mjs --filter-probe`).
+ */
+export function excludeFilterFor(
+  cfg: ExcludeCfg,
+): Record<string, unknown> | undefined {
+  return cfg.autoTrace.enabled ? EXCLUDE_SESSION_END_FILTER : undefined
+}
+
+/**
+ * Combine a caller-supplied filter with the session-end exclude via `$and`.
+ * Returns `undefined` when neither a base filter nor an exclude applies.
+ */
 export function mergeWithExclude(
-  base?: Record<string, unknown>,
-): Record<string, unknown> {
-  if (!base) return EXCLUDE_SESSION_END_FILTER
-  return { $and: [base, EXCLUDE_SESSION_END_FILTER] }
+  base: Record<string, unknown> | undefined,
+  cfg: ExcludeCfg,
+): Record<string, unknown> | undefined {
+  const exclude = excludeFilterFor(cfg)
+  if (!exclude) return base
+  if (!base) return exclude
+  return { $and: [base, exclude] }
 }

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -16,34 +16,38 @@ type ExcludeCfg = { autoTrace: { enabled: boolean } }
  * NOT surface via generic retrieval — replaying whole sanitized transcripts back
  * into context creates a self-amplifying pollution loop. Exclude them here.
  *
- * TOLERANT FORM (issue #40): hot-buffer rows written via `POST /messages` carry
- * NO `openclaw_source`. A bare `{ openclaw_source: { $ne: "agent_end" } }`
- * silently drops them: the backend evaluates the JSONB predicate in SQL
- * three-valued logic — `metadata->>'openclaw_source'` is NULL for an absent key,
- * and `NULL != 'agent_end'` is NULL (not TRUE), so the row fails to match and is
- * excluded. This is the OPPOSITE of MongoDB `$ne` (which matches missing fields)
- * — do not "correct" it back. `$or`-ing an explicit `$exists: false` branch
- * re-admits untagged rows while still hiding the real `agent_end` traces.
+ * THE #40 TENSION: hot-buffer rows written via `POST /messages` carry NO
+ * `openclaw_source`, and the backend evaluates absent-field metadata predicates
+ * in SQL three-valued logic — `metadata->>'openclaw_source'` is NULL for a
+ * missing key, and `NULL != 'agent_end'` is NULL (not TRUE) — so this filter
+ * also drops every untagged hot-buffer row. We could not work around that at the
+ * filter layer: `docs/filter-dialect-test.mjs` against the live backend showed
+ * that NO `openclaw_source` predicate returns untagged rows ($exists/$or/$nin/
+ * $not all fail), AND that `POST /messages` silently ignores a `metadata` field,
+ * so the rows can't be positively tagged either. See `excludeFilterFor` for the
+ * fix we ship (gate on auto-trace), and issue #40 for the backend follow-up
+ * (make `/messages` accept metadata, or make the filter NULL-tolerant).
  *
  * NOTE: an earlier version checked the top-level `source` field for
  * "openclaw_agent_end" — wrong on BOTH counts (the tag lives in metadata under
  * `openclaw_source`, value `"agent_end"`), so it silently matched nothing.
  */
 export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
-  $or: [
-    { openclaw_source: { $exists: false } },
-    { openclaw_source: { $ne: "agent_end" } },
-  ],
+  openclaw_source: { $ne: "agent_end" },
 }
 
 /**
  * The exclude clause to apply for a given config — or `undefined` to skip
- * filtering entirely (issue #40, Option 4). `openclaw_source: "agent_end"` rows
- * are written ONLY by the auto-trace hook; when auto-trace is disabled no such
- * rows exist, so the exclude is pure cost — and skipping it keeps untagged
- * hot-buffer rows visible without depending on the backend's `$exists`/null
- * handling at all. Auto-trace-on installs still get the tolerant clause above
- * (validate `$exists` support via `hotbuffer-verify.mjs --filter-probe`).
+ * filtering entirely (issue #40, Option 4 — the only viable plugin-side fix).
+ * `openclaw_source: "agent_end"` rows are written ONLY by the auto-trace hook;
+ * when auto-trace is disabled there are none to hide, so we skip the filter
+ * entirely — which is also the ONLY way to keep untagged hot-buffer rows
+ * visible, since (per the dialect test) no filter and no write-tag can do it.
+ *
+ * LIMITATION: when auto-trace IS enabled, this still applies `$ne agent_end`,
+ * which drops untagged hot-buffer rows along with the traces. There is no
+ * plugin-side fix for that combination today; it needs the backend change
+ * tracked in #40. (The common single-feature install has auto-trace off.)
  */
 export function excludeFilterFor(
   cfg: ExcludeCfg,

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -19,7 +19,7 @@ export function createSearchToolFactory(
     name: "hyperspell_search",
     label: "Memory Search",
     description:
-      "Search through the user's connected sources (Notion, Slack, Gmail, Google Drive, etc.) for relevant information.",
+      "Search the user's long-term memory and connected sources for anything not already in the current conversation. Covers: saved memories and notes; past conversations — including ones from earlier or parallel sessions you have no transcript for; and connected sources (Notion, Slack, Gmail, Google Drive, etc.). Reach for this whenever the user refers to something from before, asks what was said / decided / remembered, or when relevant context likely exists but isn't in front of you — search before concluding you don't know.",
     parameters: Type.Object({
       query: Type.String({ description: "Search query" }),
       limit: Type.Optional(
@@ -70,7 +70,7 @@ export function createSearchToolFactory(
 
       // Keep session-end trace memories out of agent-facing search, matching
       // the auto-context hook so both retrieval paths filter identically.
-      filter = mergeWithExclude(filter)
+      filter = mergeWithExclude(filter, cfg)
 
       log.debug(
         `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId} scope=${params.scope ?? "any"}`,


### PR DESCRIPTION
## What & why
After the backend 500 (Hyperspell PR #1899) was fixed, two issues surfaced underneath. This makes hot-buffer cross-session recall **work** and **get used**.

### 1. Fix #40 — exclude filter hid untagged hot-buffer rows (Option 4)
`{ openclaw_source: { $ne: "agent_end" } }` also dropped rows where `openclaw_source` is **absent** — every hot-buffer `/messages` row — because the backend evaluates absent-field metadata predicates as NULL (SQL three-valued logic), so `NULL != 'agent_end'` is not TRUE.

**Empirically characterized the dialect** (`docs/filter-dialect-test.mjs`, run against prod) — this killed the two "obvious" fixes:
- **No `openclaw_source` filter returns untagged rows.** `$ne`, `$exists:false`, `$nin`, `$or`, `$not` all drop them. The `$or/$exists` "tolerant" filter returned **0 rows** — it would have *broken* search for auto-trace-on installs.
- **`POST /messages` silently ignores `metadata`**, so hot rows can't be positively tagged either (Option 2 not possible via the current API).

**Shipped fix — Option 4 (the only viable plugin-side option):** `excludeFilterFor(cfg)` applies the exclude **only when `autoTrace.enabled`**. `agent_end` rows are written *only* by the auto-trace hook (`sendTrace`); with it off there are none to hide, and skipping the filter is also the only way to keep untagged hot rows. **Fully fixes the common single-feature install (auto-trace off, e.g. the live `alinea` config) — verified `hit=true`.**

> **Known limitation (needs backend change → issue #40 follow-up):** auto-trace-**on** installs keep the `agent_end` exclusion but still drop untagged hot rows. No plugin-side fix exists; requires `/messages` to accept metadata, or NULL-tolerant filtering.

### 2. Discoverability
- `hyperspell_search` description now names **cross-session past-conversation recall** + "search before concluding you don't know."
- auto-context banner reframed as **testimony, not seamless remembering**: arrival verb passive ("surfaced from"), use verb "recalled context"; dropped "naturally."

## Testing
- `docs/filter-dialect-test.mjs` — full filter-dialect truth table vs the live backend.
- `docs/hotbuffer-verify.mjs` — verify (`t+0..t+86s`), `--cleanup [token]`, `--filter-probe`.
- `lib/filters.test.ts` updated; **107 pass, tsc clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
