### PR TITLE
fix(recall): apply agent_end exclude unconditionally now that backend #1921 is live

### DIFF
--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -6,7 +6,7 @@ import {
   resolveUser,
   type ResolvedUser,
 } from "../lib/sender.ts"
-import { excludeFilterFor, mergeWithExclude } from "../lib/filters.ts"
+import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "../lib/filters.ts"
 import { classifySearchError, logSearchError } from "../lib/search-error.ts"
 import { resolveCurrentSessionId } from "../lib/session.ts"
 import { log } from "../logger.ts"
@@ -127,7 +127,7 @@ export function buildAutoContextHandler(
       const results = dropCurrentSession(
         await client.search(prompt, {
           limit: cfg.maxResults,
-          filter: excludeFilterFor(cfg),
+          filter: EXCLUDE_SESSION_END_FILTER,
         }),
         currentSessionId,
       )
@@ -185,7 +185,7 @@ async function multiUserSearch(
     ? client.search(prompt, {
         limit: cfg.maxResults,
         userId: resolved!.userId,
-        filter: excludeFilterFor(cfg),
+        filter: EXCLUDE_SESSION_END_FILTER,
       })
     : null
 
@@ -198,7 +198,7 @@ async function multiUserSearch(
       ? client.search(prompt, {
           limit: sharedLimit,
           userId: multiUser.sharedUserId,
-          filter: mergeWithExclude(scopeFilter, cfg),
+          filter: mergeWithExclude(scopeFilter),
         })
       : null
 

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -1,45 +1,24 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import {
-  EXCLUDE_SESSION_END_FILTER,
-  excludeFilterFor,
-  mergeWithExclude,
-} from "./filters.ts"
+import { EXCLUDE_SESSION_END_FILTER, mergeWithExclude } from "./filters.ts"
 
-const ON = { autoTrace: { enabled: true } }
-const OFF = { autoTrace: { enabled: false } }
-
-test("EXCLUDE_SESSION_END_FILTER — plain $ne agent_end (the only shape the backend honors)", () => {
-  // sendTrace tags traces as metadata.openclaw_source = "agent_end". A $exists/$or
-  // "tolerant" form was tried to also admit untagged hot-buffer rows, but the live
-  // backend returns 0 rows for $or/$exists (see docs/filter-dialect-test.mjs), so
-  // we keep the plain $ne and rely on excludeFilterFor's gate to keep hot rows.
+test("EXCLUDE_SESSION_END_FILTER — plain $ne agent_end (backend #1921 honors absent-field semantics)", () => {
+  // sendTrace tags traces as metadata.openclaw_source = "agent_end". With #1921
+  // deployed, $ne follows MongoDB semantics and KEEPS rows whose openclaw_source
+  // is absent (untagged hot rows) while dropping only agent_end — verified live.
   assert.deepEqual(EXCLUDE_SESSION_END_FILTER, {
     openclaw_source: { $ne: "agent_end" },
   })
 })
 
-test("excludeFilterFor — applies the exclude only when auto-trace is on (Option 4)", () => {
-  // agent_end rows are written ONLY by the auto-trace hook; with it disabled there
-  // are none to hide, so we skip the filter entirely. That's also the ONLY way to
-  // keep untagged hot-buffer rows visible — no filter and no write-tag can.
-  assert.deepEqual(excludeFilterFor(ON), EXCLUDE_SESSION_END_FILTER)
-  assert.equal(excludeFilterFor(OFF), undefined)
+test("mergeWithExclude — no base returns the exclude filter alone (applied unconditionally)", () => {
+  assert.deepEqual(mergeWithExclude(), EXCLUDE_SESSION_END_FILTER)
+  assert.deepEqual(mergeWithExclude(undefined), EXCLUDE_SESSION_END_FILTER)
 })
 
-test("mergeWithExclude — auto-trace ON, no base returns the exclude filter alone", () => {
-  assert.deepEqual(mergeWithExclude(undefined, ON), EXCLUDE_SESSION_END_FILTER)
-})
-
-test("mergeWithExclude — auto-trace ON, base is AND-combined with the exclude", () => {
+test("mergeWithExclude — base is AND-combined with the exclude", () => {
   const base = { openclaw_scope: { $in: ["family"] } }
-  assert.deepEqual(mergeWithExclude(base, ON), {
+  assert.deepEqual(mergeWithExclude(base), {
     $and: [base, EXCLUDE_SESSION_END_FILTER],
   })
-})
-
-test("mergeWithExclude — auto-trace OFF passes the base through untouched", () => {
-  const base = { openclaw_scope: { $in: ["family"] } }
-  assert.deepEqual(mergeWithExclude(base, OFF), base)
-  assert.equal(mergeWithExclude(undefined, OFF), undefined)
 })

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -7,64 +7,40 @@
  * convention `buildScopeFilter` uses (`openclaw_scope`, `openclaw_user`).
  */
 
-/** Minimal slice of config the exclude logic needs (avoids a config-module cycle). */
-type ExcludeCfg = { autoTrace: { enabled: boolean } }
-
 /**
  * Memories produced by the auto-trace session-end hook are tagged in metadata
  * as `openclaw_source: "agent_end"` (see `sendTrace` in client.ts). Those should
  * NOT surface via generic retrieval — replaying whole sanitized transcripts back
- * into context creates a self-amplifying pollution loop. Exclude them here.
+ * into context creates a self-amplifying pollution loop. Exclude them here,
+ * UNCONDITIONALLY.
  *
- * THE #40 TENSION: hot-buffer rows written via `POST /messages` carry NO
- * `openclaw_source`, and the backend evaluates absent-field metadata predicates
- * in SQL three-valued logic — `metadata->>'openclaw_source'` is NULL for a
- * missing key, and `NULL != 'agent_end'` is NULL (not TRUE) — so this filter
- * also drops every untagged hot-buffer row. We could not work around that at the
- * filter layer: `docs/filter-dialect-test.mjs` against the live backend showed
- * that NO `openclaw_source` predicate returns untagged rows ($exists/$or/$nin/
- * $not all fail), AND that `POST /messages` silently ignores a `metadata` field,
- * so the rows can't be positively tagged either. See `excludeFilterFor` for the
- * fix we ship (gate on auto-trace), and issue #40 for the backend follow-up
- * (make `/messages` accept metadata, or make the filter NULL-tolerant).
+ * History (issue #40): before the backend honored MongoDB absent-field
+ * semantics, `metadata->>'openclaw_source'` was SQL NULL for a missing key and
+ * `NULL != 'agent_end'` evaluated to NULL (not TRUE), so this `$ne` filter also
+ * silently dropped every untagged hot-buffer row. Plugin 0.15.0 worked around
+ * that by gating the filter on `autoTrace.enabled` (Option 4) — which left a
+ * known hole: auto-trace-ON installs still dropped untagged hot rows.
  *
- * NOTE: an earlier version checked the top-level `source` field for
- * "openclaw_agent_end" — wrong on BOTH counts (the tag lives in metadata under
- * `openclaw_source`, value `"agent_end"`), so it silently matched nothing.
+ * Backend Hyperspell #1921 fixed this: `$ne` now follows MongoDB semantics and
+ * KEEPS rows whose `openclaw_source` is absent (verified live — untagged hot
+ * rows survive `{$ne:"agent_end"}` while `agent_end` rows are dropped). So the
+ * gate is unnecessary and removed: the filter applies unconditionally again,
+ * which also fixes the auto-trace-ON case. Hot-buffer rows are additionally
+ * tagged `openclaw_source: "hot_buffer"` (≠ `"agent_end"`), so they survive on
+ * either path.
  */
 export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
   openclaw_source: { $ne: "agent_end" },
 }
 
 /**
- * The exclude clause to apply for a given config — or `undefined` to skip
- * filtering entirely (issue #40, Option 4 — the only viable plugin-side fix).
- * `openclaw_source: "agent_end"` rows are written ONLY by the auto-trace hook;
- * when auto-trace is disabled there are none to hide, so we skip the filter
- * entirely — which is also the ONLY way to keep untagged hot-buffer rows
- * visible, since (per the dialect test) no filter and no write-tag can do it.
- *
- * LIMITATION: when auto-trace IS enabled, this still applies `$ne agent_end`,
- * which drops untagged hot-buffer rows along with the traces. There is no
- * plugin-side fix for that combination today; it needs the backend change
- * tracked in #40. (The common single-feature install has auto-trace off.)
- */
-export function excludeFilterFor(
-  cfg: ExcludeCfg,
-): Record<string, unknown> | undefined {
-  return cfg.autoTrace.enabled ? EXCLUDE_SESSION_END_FILTER : undefined
-}
-
-/**
  * Combine a caller-supplied filter with the session-end exclude via `$and`.
- * Returns `undefined` when neither a base filter nor an exclude applies.
+ * The exclude is applied unconditionally (see above); pass a base filter to
+ * intersect it (e.g. a scope clause), or omit it for the exclude alone.
  */
 export function mergeWithExclude(
-  base: Record<string, unknown> | undefined,
-  cfg: ExcludeCfg,
-): Record<string, unknown> | undefined {
-  const exclude = excludeFilterFor(cfg)
-  if (!exclude) return base
-  if (!base) return exclude
-  return { $and: [base, exclude] }
+  base?: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!base) return EXCLUDE_SESSION_END_FILTER
+  return { $and: [base, EXCLUDE_SESSION_END_FILTER] }
 }

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -75,7 +75,7 @@ export function createSearchToolFactory(
 
       // Keep session-end trace memories out of agent-facing search, matching
       // the auto-context hook so both retrieval paths filter identically.
-      filter = mergeWithExclude(filter, cfg)
+      filter = mergeWithExclude(filter)
 
       log.debug(
         `search tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"} userId=${userId} scope=${params.scope ?? "any"}`,


### PR DESCRIPTION
## What
Removes the `autoTrace.enabled` gate on the `{$ne:"agent_end"}` exclude filter — the dropped half of #43, now unblocked by backend **Hyperspell #1921** being deployed.

## Why
Plugin 0.15.0 gated the exclude on auto-trace (#40, Option 4) because the old backend's SQL three-valued logic made `NULL != 'agent_end'` evaluate to NULL — so the filter also dropped every **untagged hot-buffer row**. The gate avoided that for the common (auto-trace-off) install but left a hole: **auto-trace-ON installs still dropped untagged hot rows**.

#1921 fixes the backend to follow MongoDB absent-field semantics. **Verified live** (throwaway-user canary against prod):

```
{$ne agent_end}:  untagged U → KEPT,  agent_end A → DROPPED
```

So the gate is unnecessary and removed.

## Changes
- `EXCLUDE_SESSION_END_FILTER` applied **unconditionally** again.
- `mergeWithExclude(base)` → single-arg (drops the `cfg` thread, pre-0.15.0 shape).
- `excludeFilterFor()` removed; `search.ts` / `auto-context.ts` reference the filter directly.
- Also fixes the **auto-trace-ON** case. Hot rows are additionally tagged `openclaw_source: "hot_buffer"` (≠ `"agent_end"`), so they survive on either path.

## Tests
`filters.test.ts` updated to the unconditional API. `tsc --noEmit` + build clean; **145 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)