### PR TITLE
fix(hot-buffer): stop tagging rows — /messages metadata makes them non-retrievable

### DIFF
--- a/hooks/hot-buffer.test.ts
+++ b/hooks/hot-buffer.test.ts
@@ -55,21 +55,25 @@ test("hot-buffer — writes user and assistant turns with stable ids", async () 
 	assert.notEqual(calls[0][0].messageId, calls[0][1].messageId);
 });
 
-test("hot-buffer — tags writes with openclaw_source=hot_buffer (Hyperspell #1921)", async () => {
+test("hot-buffer — does NOT send metadata (a /messages write with metadata is not retrievable post-#1921)", async () => {
+	// Regression guard: tagging hot rows via POST /messages metadata is accepted
+	// (200) but makes the row non-retrievable (verified live). Untagged rows are
+	// searchable and survive the unconditional {$ne:"agent_end"} exclude, so we
+	// must write content only — no metadata.
 	const { client, calls, optionsList } = makeClient();
 	const handler = buildHotBufferHandler(client, cfg);
 	await handler(
 		{
 			success: true,
 			sessionId: "s-tag",
-			messages: [{ role: "user", content: "tag me please" }],
+			messages: [{ role: "user", content: "do not tag me" }],
 		},
 		{},
 	);
 	assert.equal(calls.length, 1);
-	assert.deepEqual(
+	assert.equal(
 		(optionsList[0] as { metadata?: unknown }).metadata,
-		{ openclaw_source: "hot_buffer" },
+		undefined,
 	);
 });
 

--- a/hooks/hot-buffer.ts
+++ b/hooks/hot-buffer.ts
@@ -161,13 +161,17 @@ export function buildHotBufferHandler(
 		try {
 			let total = 0;
 			for (const b of batches) {
+				// Do NOT tag hot rows with metadata: a POST /messages write that
+				// carries `metadata` is accepted (200) but the row never becomes
+				// retrievable (verified live, post-Hyperspell #1921) — tagging
+				// silently breaks hot-buffer recall. The tag isn't needed anyway:
+				// untagged rows survive the unconditional {$ne:"agent_end"} exclude
+				// (absent-field semantics, #1921) AND are full-text searchable. So
+				// we write content only. (Backend follow-up: make /messages metadata
+				// not suppress indexing, then this can be reinstated.)
 				const result = await client.sendMessages(b, {
 					userId,
 					source: cfg.hotBuffer.source,
-					// Tag hot rows so retrieval can distinguish them (Hyperspell #1921).
-					// Value differs from "agent_end", so they survive the session-end
-					// exclude filter while staying positively identifiable.
-					metadata: { openclaw_source: "hot_buffer" },
 				});
 				total += result.count;
 			}


### PR DESCRIPTION
## What
Removes the `openclaw_source: "hot_buffer"` metadata tag from hot-buffer writes (added in #43).

## Why — found while deploying to a live agent
A `POST /messages` write that carries `metadata` is **accepted (HTTP 200) but the row never becomes retrievable**. Verified live against prod (post-Hyperspell #1921), throwaway user:

```
@~3s   untagged: FOUND    tagged: missing
@~8s   untagged: FOUND    tagged: missing
@~15s  untagged: FOUND    tagged: missing   (tagged row also 404s on get)
```

#43 added the tag assuming #1921 would persist `/messages` metadata **and** keep the row searchable. The first holds; the second does not — so tagging **silently broke hot-buffer recall** (every hot row written → not retrievable).

The tag isn't needed regardless: with #1921's absent-field semantics, untagged hot rows already **survive the unconditional `{$ne:"agent_end"}` exclude** (#46) **and** are full-text searchable. So we write content only.

## Changes
- `hooks/hot-buffer.ts`: drop the `metadata: { openclaw_source: "hot_buffer" }` arg.
- `hooks/hot-buffer.test.ts`: inverted — asserts **no** metadata is sent (regression guard).
- Client retains the `metadata` param (unused here) for when the backend is fixed.

## Backend follow-up
`/messages` should not suppress indexing when `metadata` is present; once fixed, the tag can be reinstated.

## Tests
`tsc --noEmit` + build clean; **145 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)