### PR TITLE
fix(startup-orientation): skip trace listMemories when auto-trace is off (~12s/turn)

### DIFF
--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -56,7 +56,9 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 	return {
 		apiKey: "k",
 		autoContext: false,
-		autoTrace: { enabled: false, extract: ["procedure"] },
+		// Recent-interactions are agent_end traces, fetched only when auto-trace
+		// is on — so the recent-path tests below run with it enabled.
+		autoTrace: { enabled: true, extract: ["procedure"] },
 		hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
 		emotionalContext: false,
 		startupOrientation: {
@@ -232,6 +234,21 @@ test("startup-orientation — list call passes source:trace and userId", async (
 		undefined,
 		"single-user mode passes undefined",
 	);
+});
+
+test("startup-orientation — auto-trace OFF skips the trace listMemories (perf), still runs loops", async () => {
+	// agent_end traces exist only when auto-trace is on. With it off, the trace
+	// list is guaranteed-empty AND expensive (~12s + failures observed live), so
+	// it must be skipped entirely — but the unfinished-loops search still runs.
+	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, highlights: [] }] });
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg({ autoTrace: { enabled: false, extract: ["procedure"] } }),
+	);
+	await handler({}, { sessionKey: "s-no-autotrace" });
+
+	assert.equal(client.listCalls.length, 0, "trace listMemories must NOT be called when auto-trace is off");
+	assert.equal(client.searchCalls.length, 1, "loops search still runs");
 });
 
 test("startup-orientation — compaction clears cache, next turn re-fetches", async () => {

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -179,8 +179,19 @@ export function buildStartupOrientationHandler(
 
 		const cutoff = isoDaysAgo(so.recentDays);
 
+		// Recent-interactions are `agent_end` traces, which exist ONLY when
+		// auto-trace is enabled. When it's off there are none to fetch, and the
+		// trace-source `listMemories` is not merely empty but EXPENSIVE — observed
+		// taking ~12s and failing on every turn (it blocks before_agent_start, so
+		// it directly slows the agent's reply). Skip it entirely in that case and
+		// keep just the unfinished-loops search (a normal query that works
+		// regardless). Mirrors the warning logged at startup.
+		const wantRecent = cfg.autoTrace.enabled;
+
 		const [recentSettled, loopsSettled] = await Promise.allSettled([
-			fetchRecentTraces(client, cutoff, so.recentLimit, userId),
+			wantRecent
+				? fetchRecentTraces(client, cutoff, so.recentLimit, userId)
+				: Promise.resolve([] as SearchResult[]),
 			client.search(so.loopsQuery, {
 				limit: so.loopsLimit,
 				userId,


### PR DESCRIPTION
## What
Gates `fetchRecentTraces` (the recent-interactions block) on `autoTrace.enabled`.

## Why — found while investigating "turns feel slow" on a live agent
The recent-interactions block lists `agent_end` traces via `listMemories({ source: "trace" })`. Those exist **only** when auto-trace is enabled — the hook already warns at startup that recent-interactions will be empty when it's off. But it ran the list **every turn anyway**, and on an auto-trace-off agent that call was observed **taking ~12s and failing** on each turn. Since `before_agent_start` blocks the reply, this directly slowed every turn.

Live evidence:
```
11:08:46  [memories.list] request
11:08:59  startup-orientation: recent listMemories failed   ← ~12s later
11:08:59  startup-orientation: injecting recent=0 loops=8
```

## Fix
When `autoTrace` is off, skip the trace list entirely (guaranteed-empty) and keep just the unfinished-loops search (a normal query that works regardless).

## Tests
Recent-path tests now run with auto-trace on (where traces exist); added a gate test asserting the trace list is **not** called when auto-trace is off while loops still runs. `tsc` + build clean; **148 pass**.

## Note
Separately, the per-session caches don't persist (the host re-inits the plugin per turn), so even cheap hooks re-run each turn — a deeper, pre-existing item not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)