### PR TITLE
feat(startup-orientation): source recent-interactions from the hot buffer

### DIFF
--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import type { HyperspellClient, SearchResult } from "../client.ts";
-import type { HyperspellConfig } from "../config.ts";
+import type { HyperspellConfig, HyperspellSource } from "../config.ts";
 import {
 	buildStartupOrientationCompactionHandler,
 	buildStartupOrientationHandler,
@@ -15,7 +15,7 @@ type SearchCall = {
 type ListCall = { options?: Parameters<HyperspellClient["listMemories"]>[0] };
 type ListedMemory = {
 	resourceId: string;
-	source: "trace";
+	source: HyperspellSource;
 	title: string | null;
 	metadata: Record<string, unknown>;
 };
@@ -236,19 +236,52 @@ test("startup-orientation — list call passes source:trace and userId", async (
 	);
 });
 
-test("startup-orientation — auto-trace OFF skips the trace listMemories (perf), still runs loops", async () => {
-	// agent_end traces exist only when auto-trace is on. With it off, the trace
-	// list is guaranteed-empty AND expensive (~12s + failures observed live), so
-	// it must be skipped entirely — but the unfinished-loops search still runs.
+test("startup-orientation — neither hot-buffer nor auto-trace: skips recent fetch (perf), still runs loops", async () => {
+	// No session record source available → nothing to fetch, and the trace-source
+	// list is expensive (~12s + failures observed live), so skip it entirely.
 	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, highlights: [] }] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
-		makeCfg({ autoTrace: { enabled: false, extract: ["procedure"] } }),
+		makeCfg({
+			hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
+			autoTrace: { enabled: false, extract: ["procedure"] },
+		}),
 	);
-	await handler({}, { sessionKey: "s-no-autotrace" });
+	await handler({}, { sessionKey: "s-neither" });
 
-	assert.equal(client.listCalls.length, 0, "trace listMemories must NOT be called when auto-trace is off");
+	assert.equal(client.listCalls.length, 0, "no listMemories when there's no recent source");
 	assert.equal(client.searchCalls.length, 1, "loops search still runs");
+});
+
+test("startup-orientation — hot-buffer source: recent comes from vault session resources (UUID+untagged), cron/tagged excluded", async () => {
+	// The modern path (e.g. auto-trace OFF + hot buffer ON, like a real agent):
+	// recent-interactions is sourced from the hot buffer's session-grouped vault
+	// resources, not agent_end traces.
+	const conv = (id: string, title: string): ListedMemory => ({ resourceId: id, source: "vault", title, metadata: {} });
+	const client = makeClient({
+		traces: [
+			conv("0471aa5b-2c34-43d0-a810-3bd846076e43", "Talked about dinner"),
+			{ resourceId: "note-readme.md", source: "vault", title: "synced doc", metadata: { openclaw_source: "memory_sync_section" } },
+			conv("11111111-2222-3333-4444-555555555555", "[cron:abc] heartbeat run"),
+			conv("22222222-2222-3333-4444-555555555555", "Morning check-in"),
+		],
+		loops: [],
+	});
+	const handler = buildStartupOrientationHandler(
+		client as unknown as HyperspellClient,
+		makeCfg({
+			hotBuffer: { enabled: true, source: "vault", writeUser: true, writeAssistant: true },
+			autoTrace: { enabled: false, extract: ["procedure"] },
+		}),
+	);
+	const out = await handler({}, { sessionKey: "s-hotbuf" });
+
+	assert.equal(client.listCalls[0]?.options?.source, "vault", "lists vault, not trace");
+	const ctx = (out as { prependContext?: string })?.prependContext ?? "";
+	assert.match(ctx, /Talked about dinner/);
+	assert.match(ctx, /Morning check-in/);
+	assert.doesNotMatch(ctx, /cron/, "automated cron sessions excluded");
+	assert.doesNotMatch(ctx, /synced doc/, "tagged sync rows excluded");
 });
 
 test("startup-orientation — compaction clears cache, next turn re-fetches", async () => {

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -8,6 +8,10 @@ type AgentContext = Record<string, unknown> & { sessionKey?: string };
 const MAX_ATTEMPTS = 2;
 const RECENT_BUFFER_LIMIT = 100;
 
+/** Hot-buffer conversation resources are keyed by the session id (a UUID). */
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Sessions where the orientation block was already injected (or where we
  * deliberately decided not to inject — unknown sender, exhausted retries).
@@ -147,6 +151,58 @@ async function fetchRecentTraces(
 	return buffer.slice(0, limit);
 }
 
+/**
+ * Pull recent conversation sessions from the hot buffer's vault resources — the
+ * modern source of "recent interactions" (the agent_end-trace path only works
+ * when auto-trace is on, which it usually isn't). The hot buffer writes one
+ * session-grouped Resource per conversation: `resource_id` = the session id (a
+ * UUID), untagged (no `openclaw_source`), with a generated title. We rely on
+ * `listMemories` returning resources newest-first (verified live) and take the
+ * newest `limit` conversation resources — their metadata carries no date to
+ * filter on, so order is our recency signal.
+ *
+ * Excludes: tagged rows (memory_sync_section / command / agent_end), non-UUID
+ * resources (synced docs), automated cron sessions, and untitled rows.
+ */
+async function fetchRecentConversations(
+	client: HyperspellClient,
+	limit: number,
+	userId: string | undefined,
+): Promise<SearchResult[]> {
+	const out: SearchResult[] = [];
+	const seenTitles = new Set<string>();
+	let scanned = 0;
+	for await (const memory of client.listMemories({
+		source: "vault",
+		userId,
+		pageSize: 50,
+	})) {
+		scanned++;
+		if (scanned > RECENT_BUFFER_LIMIT) break;
+		if (!UUID_RE.test(memory.resourceId)) continue;
+		if (memory.metadata?.openclaw_source) continue;
+		const title = memory.title ?? "";
+		if (title.length === 0 || /^\[cron:/i.test(title)) continue;
+		// The backend sometimes generates the same title for distinct sessions
+		// (e.g. repeated daily-summary chats); collapse those so the block isn't
+		// padded with duplicates.
+		const titleKey = title.trim().toLowerCase();
+		if (seenTitles.has(titleKey)) continue;
+		seenTitles.add(titleKey);
+		out.push({
+			resourceId: memory.resourceId,
+			title: memory.title,
+			source: memory.source,
+			score: null,
+			url: null,
+			createdAt: null,
+			highlights: [],
+		});
+		if (out.length >= limit) break; // newest-first → first N are most recent
+	}
+	return out;
+}
+
 export function buildStartupOrientationHandler(
 	client: HyperspellClient,
 	cfg: HyperspellConfig,
@@ -177,21 +233,26 @@ export function buildStartupOrientationHandler(
 			return;
 		}
 
-		const cutoff = isoDaysAgo(so.recentDays);
-
-		// Recent-interactions are `agent_end` traces, which exist ONLY when
-		// auto-trace is enabled. When it's off there are none to fetch, and the
-		// trace-source `listMemories` is not merely empty but EXPENSIVE — observed
-		// taking ~12s and failing on every turn (it blocks before_agent_start, so
-		// it directly slows the agent's reply). Skip it entirely in that case and
-		// keep just the unfinished-loops search (a normal query that works
-		// regardless). Mirrors the warning logged at startup.
-		const wantRecent = cfg.autoTrace.enabled;
+		// Source recent-interactions from wherever the session record actually
+		// lives. Prefer the hot buffer (modern path: clean session-grouped vault
+		// resources, present whenever the hot buffer is on — including auto-trace-
+		// off agents). Fall back to agent_end traces only when there's no hot
+		// buffer but auto-trace is on. Otherwise skip: there's nothing to fetch,
+		// and the trace-source list is expensive (observed ~12s + failing/turn),
+		// blocking before_agent_start and slowing the reply.
+		const recentFetch = cfg.hotBuffer.enabled
+			? fetchRecentConversations(client, so.recentLimit, userId)
+			: cfg.autoTrace.enabled
+				? fetchRecentTraces(
+						client,
+						isoDaysAgo(so.recentDays),
+						so.recentLimit,
+						userId,
+					)
+				: Promise.resolve([] as SearchResult[]);
 
 		const [recentSettled, loopsSettled] = await Promise.allSettled([
-			wantRecent
-				? fetchRecentTraces(client, cutoff, so.recentLimit, userId)
-				: Promise.resolve([] as SearchResult[]),
+			recentFetch,
 			client.search(so.loopsQuery, {
 				limit: so.loopsLimit,
 				userId,


### PR DESCRIPTION
## What
Re-points the session-start "recent interactions" block at the **hot buffer** instead of `agent_end` traces.

## Why
Recent-interactions read traces, which only exist when **auto-trace is on**. On the common **hot-buffer-on / auto-trace-off** setup (e.g. a live agent that deliberately avoids trace pollution), it found **nothing every turn** — the feature was effectively dead — and #50 had to stop it wasting ~12s/turn failing to read that empty source.

The conversations *do* exist: the hot buffer writes one session-grouped vault resource per conversation (`resource_id` = session UUID, untagged, titled — clean now thanks to the #42 session-keying fix). So we read from there.

## Behavior
- `hotBuffer.enabled` → list vault, keep UUID-keyed untagged resources, exclude cron/automated + untitled rows, dedup repeated titles, take newest N (list is newest-first).
- else `autoTrace.enabled` → legacy `agent_end` trace path.
- else → skip (nothing to read).

## Verified live
`recent` went from **0 (always, all day)** → **5 real recent conversations** on the deployed agent.

## Tests
Existing recent-path tests keep the trace path (auto-trace on); added a hot-buffer-source test (lists vault; cron/tagged excluded) and a no-source skip test. `tsc` + build clean; **149 pass**.

## Known follow-up (bigger-picture)
Some titles are low-quality ("Conversation info (untrusted metadata)", "Unnamed Conversation") — a "what counts as a real conversation" filtering question, deferred to the traces-vs-hot-buffer roles discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)