### PR TITLE
fix(emotional-state): don't inject the raw-transcript placeholder during extraction

### DIFF
--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -4,6 +4,7 @@ import {
 	buildEmotionalStateCompactionHandler,
 	buildEmotionalStateFetchHandler,
 	buildEmotionalStateSessionCleanupHandler,
+	looksLikeRawTranscript,
 } from "./emotional-state.ts";
 
 type FakeClient = {
@@ -157,4 +158,33 @@ test("emotional-state fetch — missing sessionKey still fetches (fallback)", as
 		2,
 		"without sessionKey we can't cache — fetch each call",
 	);
+});
+
+test("looksLikeRawTranscript — detects the pending raw-transcript placeholder, not real summaries", () => {
+	assert.equal(looksLikeRawTranscript("user: hi\nassistant: hey there"), true);
+	assert.equal(looksLikeRawTranscript("assistant: I think we left things tender"), true);
+	assert.equal(
+		looksLikeRawTranscript(
+			"Your relationship with this user currently feels warm and steady; they leaned on you and felt met.",
+		),
+		false,
+	);
+});
+
+test("emotional-state fetch — skips injecting a raw-transcript placeholder (pending), does NOT cache (retries next turn)", async () => {
+	// During the ~10s extraction window the GET returns the raw transcript. We
+	// must not inject it; and we must not cache, so a later turn re-fetches once
+	// extraction completes.
+	const { client } = makeClient("user: rough day\nassistant: I'm here");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		cfg,
+	);
+	const ctx = { sessionKey: "session-pending" };
+
+	const first = await handler({}, ctx);
+	assert.equal(first, undefined, "no injection while still extracting");
+	const second = await handler({}, ctx);
+	assert.equal(second, undefined);
+	assert.equal(client.callCount, 2, "not cached — re-fetched on the next turn");
 });

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -65,6 +65,17 @@ function messagesToTranscript(messages: unknown[]): string {
 }
 
 /**
+ * True if a fetched emotional-state `summary` is actually the raw transcript
+ * placeholder returned during the async extraction window (status=pending),
+ * rather than a distilled emotional register. Real summaries are second-person
+ * prose ("Your relationship with this user…"); the placeholder echoes the input
+ * conversation, which has role-prefixed lines.
+ */
+export function looksLikeRawTranscript(summary: string): boolean {
+	return /(^|\n)\s*(user|assistant)\s*:/i.test(summary);
+}
+
+/**
  * Fetch emotional state on the first agent turn of a session and inject into
  * context. On later turns of the same session, return undefined — the
  * injection from the first turn is already in the conversation history.
@@ -87,6 +98,21 @@ export function buildEmotionalStateFetchHandler(
 			if (!state) {
 				log.debug("emotional-context: no prior emotional state found");
 				if (sessionKey) injectedSessions.add(sessionKey);
+				return;
+			}
+
+			// Extraction is async: for ~10s after a store, GET /emotional-state
+			// returns status=pending with `summary` set to the RAW transcript (the
+			// input), not the distilled register — and the response carries no
+			// status field to check. Detect that placeholder structurally (a real
+			// summary is second-person prose; a raw transcript has role-prefixed
+			// lines) and DON'T inject it: handing back the raw transcript as
+			// "feeling" is useless and pollutes tone. Don't cache, so a later turn
+			// re-fetches once extraction has completed.
+			if (looksLikeRawTranscript(state.summary)) {
+				log.debug(
+					"emotional-context: state still extracting (raw-transcript placeholder) — skipping injection this turn",
+				);
 				return;
 			}
 


### PR DESCRIPTION
## What
Guards Tin Man (`emotionalContext`) against injecting the raw-transcript placeholder that `GET /emotional-state` returns during the ~10s async extraction window.

## Why
After a `POST /emotional-state` store, extraction is async. For ~10s the GET returns `status=pending` with `summary` = the **raw input transcript**, not the distilled register — and the GET response has **no status field** to check. If a session starts inside that window, Tin Man would inject the raw transcript as "emotional context" — useless, and the exact transcript-pollution we avoid everywhere else.

## How
`looksLikeRawTranscript(summary)` detects the placeholder structurally — a real summary is second-person prose (*"Your relationship with this user…"*); the raw placeholder has role-prefixed `user:`/`assistant:` lines. On a match: skip injection and **don't cache**, so a later turn re-fetches once extraction completes.

## Verified
Live round-trip: store → ~10s → real second-person summary; this guards only the placeholder window. `tsc` + build clean; **151 pass** (added a unit test for the detector + a handler test for skip-without-caching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)