### PR TITLE
fix(emotional-state): only count real conversations — gate on trigger + debounce

### DIFF
--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -4,6 +4,7 @@ import {
 	buildEmotionalStateCompactionHandler,
 	buildEmotionalStateFetchHandler,
 	buildEmotionalStateSessionCleanupHandler,
+	buildEmotionalStateStoreHandler,
 	looksLikeRawTranscript,
 } from "./emotional-state.ts";
 
@@ -187,4 +188,69 @@ test("emotional-state fetch — skips injecting a raw-transcript placeholder (pe
 	const second = await handler({}, ctx);
 	assert.equal(second, undefined);
 	assert.equal(client.callCount, 2, "not cached — re-fetched on the next turn");
+});
+
+// ---- store handler: cron-gate + debounce (the cadence fix) ----------------
+
+function makeStoreClient() {
+	const stores: Array<{ transcript: string; opts: { relationshipId?: string } }> = [];
+	const client = {
+		async storeEmotionalState(transcript: string, opts: { relationshipId?: string }) {
+			stores.push({ transcript, opts });
+			return { resourceId: "es-x", status: "pending", summary: "", extractedAt: "", sessionId: null, relationshipId: opts?.relationshipId ?? null };
+		},
+	};
+	return { client, stores };
+}
+
+const richMessages = [
+	{ role: "user", content: "hey, I had a really rough day and wanted to talk it through with you" },
+	{ role: "assistant", content: "I'm here. Tell me what happened — take your time." },
+	{ role: "user", content: "the deploy broke and I felt awful, but you always help me feel better" },
+];
+const storeCfg = (relationshipId: string) =>
+	({ relationshipId }) as unknown as Parameters<typeof buildEmotionalStateStoreHandler>[1];
+
+test("emotional-state store — skips automated triggers (cron/heartbeat/memory don't count)", async () => {
+	for (const trigger of ["cron", "heartbeat", "memory"]) {
+		const { client, stores } = makeStoreClient();
+		const handler = buildEmotionalStateStoreHandler(
+			client as unknown as Parameters<typeof buildEmotionalStateStoreHandler>[0],
+			storeCfg(`rel-${trigger}`),
+		);
+		await handler({ success: true, messages: richMessages }, { trigger });
+		assert.equal(stores.length, 0, `should NOT store for trigger=${trigger}`);
+	}
+});
+
+test("emotional-state store — stores for a real user conversation", async () => {
+	const { client, stores } = makeStoreClient();
+	const handler = buildEmotionalStateStoreHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateStoreHandler>[0],
+		storeCfg("rel-user-store"),
+	);
+	await handler({ success: true, messages: richMessages }, { trigger: "user" });
+	assert.equal(stores.length, 1);
+	assert.equal(stores[0].opts.relationshipId, "rel-user-store");
+});
+
+test("emotional-state store — undefined trigger still stores (don't skip when unknown)", async () => {
+	const { client, stores } = makeStoreClient();
+	const handler = buildEmotionalStateStoreHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateStoreHandler>[0],
+		storeCfg("rel-undef"),
+	);
+	await handler({ success: true, messages: richMessages }, {});
+	assert.equal(stores.length, 1);
+});
+
+test("emotional-state store — debounces repeated stores within the window", async () => {
+	const { client, stores } = makeStoreClient();
+	const handler = buildEmotionalStateStoreHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateStoreHandler>[0],
+		storeCfg("rel-debounce"),
+	);
+	await handler({ success: true, messages: richMessages }, { trigger: "user" });
+	await handler({ success: true, messages: richMessages }, { trigger: "user" });
+	assert.equal(stores.length, 1, "second store within the debounce window is skipped");
 });

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -4,10 +4,30 @@ import { log } from "../logger.ts";
 import { sanitizeTraceText } from "./auto-trace.ts";
 
 type Message = { role?: string; content?: string | unknown };
-type AgentContext = { sessionKey?: string };
+type AgentContext = { sessionKey?: string; trigger?: string };
 
 const MIN_MESSAGES = 3;
 const MIN_CONVERSATION_LENGTH = 100;
+
+/**
+ * Only REAL human conversations should shape her emotional register. Automated
+ * runs — cron check-ins, heartbeats, internal memory passes — are not "how the
+ * relationship feels"; counting them lets a throwaway "how's your afternoon?"
+ * heartbeat overwrite the register from a deep conversation (the whipsaw).
+ * `ctx.trigger` is one of cron|heartbeat|manual|memory|overflow|user; we store
+ * only for user-driven turns (and `overflow`, a continuation of a user run).
+ */
+const NON_CONVERSATIONAL_TRIGGERS = new Set(["cron", "heartbeat", "memory"]);
+
+/**
+ * Debounce window: don't re-extract the register on every turn of an active
+ * conversation (each store is a backend LLM call, and the latest already carries
+ * the full transcript). One snapshot per ~few minutes of real talk is plenty.
+ */
+const STORE_DEBOUNCE_MS = 3 * 60 * 1000;
+
+/** relationshipId → last successful store time (ms). Module-scoped, per process. */
+const lastStoreAt = new Map<string, number>();
 
 /**
  * Sessions where emotional context has already been injected this run.
@@ -169,9 +189,17 @@ export function buildEmotionalStateStoreHandler(
 	client: HyperspellClient,
 	cfg: HyperspellConfig,
 ) {
-	return async (event: Record<string, unknown>) => {
+	return async (event: Record<string, unknown>, ctx?: AgentContext) => {
 		if (event.success === false) {
 			log.debug("emotional-state: skipping — agent ended with error");
+			return;
+		}
+
+		// Only real human conversations count — skip cron/heartbeat/memory runs so
+		// an automated check-in can't overwrite the register from a real talk.
+		const trigger = ctx?.trigger;
+		if (trigger && NON_CONVERSATIONAL_TRIGGERS.has(trigger)) {
+			log.debug(`emotional-state: skipping — non-conversational trigger (${trigger})`);
 			return;
 		}
 
@@ -191,11 +219,22 @@ export function buildEmotionalStateStoreHandler(
 			return;
 		}
 
+		// Debounce: at most one snapshot per STORE_DEBOUNCE_MS of active talk.
+		const relId = cfg.relationshipId ?? "";
+		const since = Date.now() - (lastStoreAt.get(relId) ?? 0);
+		if (since < STORE_DEBOUNCE_MS) {
+			log.debug(
+				`emotional-state: skipping — debounced (${Math.round(since / 1000)}s since last store)`,
+			);
+			return;
+		}
+
 		try {
 			const result = await client.storeEmotionalState(transcript, {
 				relationshipId: cfg.relationshipId,
 				metadata: { source: "openclaw_agent_end" },
 			});
+			lastStoreAt.set(relId, Date.now());
 			log.info(`emotional-state: stored ${result.resourceId}`);
 		} catch (err) {
 			// Fire-and-forget — never let this break the session


### PR DESCRIPTION
## What
Stops Alinea's emotional register (Tin Man) from **whipsawing**: it was stored on every turn *and* every session, so an automated cron/heartbeat check-in could overwrite the warm register from a real, deep conversation with "transactional."

## Fix (store handler, `agent_end`)
- **Cron-gate:** skip non-conversational triggers — `ctx.trigger ∈ {cron, heartbeat, memory}`. Only user-driven turns shape the register. `overflow`/`manual`/unknown still count (don't drop real talk we can't classify).
- **Debounce:** at most one snapshot per ~3 min of active conversation (each store is a backend LLM extraction; the latest already carries the full transcript).

## Why now
With the backend collapse fixed (hyperspell#1947), the extraction is finally accurate — so the remaining issue was *which* conversations get snapshotted and *how often*. Confirmed in her logs that recent stores were cron heartbeats clobbering real talks.

## Tests
Skips cron/heartbeat/memory; stores for user + unknown trigger; debounces a second store within the window. tsc + build clean; **155 pass**.

## Follow-up
Inject the **last ~3 moods** at session start so she sees the *arc* of how she's been, not a single snapshot (the moods are stored as vault resources in the `_emotional_state` collection; needs either a small backend `limit` param on GET or a plugin-side collection list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)