### PR TITLE
feat(emotional-state): inject the recent mood arc at session start (fallback-safe)

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -643,6 +643,50 @@ export class HyperspellClient {
 		return result;
 	}
 
+	/**
+	 * The most recent emotional states (newest first), up to `limit` — for
+	 * surfacing the recent ARC of how a relationship has felt, not just one
+	 * snapshot. Returns `null` when the backend doesn't expose
+	 * `/emotional-state/recent` yet (404) so callers can fall back to
+	 * `getEmotionalState`. Other non-OK responses throw.
+	 */
+	async getRecentEmotionalStates(
+		relationshipId?: string,
+		limit = 3,
+	): Promise<EmotionalStateLatest[] | null> {
+		log.debugRequest("emotional-state.recent", { relationshipId, limit });
+
+		const url = new URL(`${API_BASE_URL}/emotional-state/recent`);
+		if (relationshipId) url.searchParams.set("relationship_id", relationshipId);
+		url.searchParams.set("limit", String(limit));
+
+		const res = await fetch(url.toString(), {
+			method: "GET",
+			headers: this.rawHeaders(),
+		});
+
+		if (res.status === 404) {
+			// Endpoint not deployed yet — signal the caller to fall back.
+			log.debug("emotional-state.recent unavailable (404) — caller falls back to latest");
+			return null;
+		}
+		if (!res.ok) {
+			const text = await res.text().catch(() => "");
+			throw new Error(`GET /emotional-state/recent failed (${res.status}): ${text}`);
+		}
+
+		const data = (await res.json()) as Array<Record<string, unknown>> | null;
+		const list: EmotionalStateLatest[] = (data ?? []).map((d) => ({
+			resourceId: d.resource_id as string,
+			summary: (d.summary as string) ?? "",
+			extractedAt: (d.extracted_at as string) ?? "",
+			sessionId: (d.session_id as string | null) ?? null,
+			relationshipId: (d.relationship_id as string | null) ?? null,
+		}));
+		log.debugResponse("emotional-state.recent", { count: list.length });
+		return list;
+	}
+
 	async deleteEmotionalState(relationshipId?: string): Promise<{ deletedCount: number }> {
 		log.debugRequest("emotional-state.delete", { relationshipId });
 

--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -8,32 +8,58 @@ import {
 	looksLikeRawTranscript,
 } from "./emotional-state.ts";
 
+type State = {
+	resourceId: string;
+	summary: string;
+	extractedAt: string;
+	sessionId: string | null;
+	relationshipId: string | null;
+};
 type FakeClient = {
-	getEmotionalState: (relId?: string) => Promise<{
-		resourceId: string;
-		summary: string;
-		extractedAt: string;
-		sessionId: string | null;
-		relationshipId: string | null;
-	} | null>;
+	getEmotionalState: (relId?: string) => Promise<State | null>;
+	getRecentEmotionalStates: (relId?: string, limit?: number) => Promise<State[] | null>;
 	callCount: number;
 };
+
+const st = (summary: string, extractedAt = "2026-04-17T00:00:00Z"): State => ({
+	resourceId: `es-${summary.slice(0, 4)}`,
+	summary,
+	extractedAt,
+	sessionId: null,
+	relationshipId: "rel-x",
+});
 
 function makeClient(
 	summary: string | null,
 ): { client: FakeClient } {
 	const client: FakeClient = {
 		callCount: 0,
+		// Default mock: /recent unavailable (null) → handler falls back to getEmotionalState.
+		async getRecentEmotionalStates() {
+			return null;
+		},
 		async getEmotionalState() {
 			client.callCount++;
-			if (summary === null) return null;
-			return {
-				resourceId: "es-test",
-				summary,
-				extractedAt: "2026-04-17T00:00:00Z",
-				sessionId: null,
-				relationshipId: "rel-x",
-			};
+			return summary === null ? null : st(summary);
+		},
+	};
+	return { client };
+}
+
+/** Mock where /emotional-state/recent IS available and returns the given arc. */
+function makeArcClient(states: State[] | null): {
+	client: FakeClient & { recentCalls: number };
+} {
+	const client = {
+		callCount: 0,
+		recentCalls: 0,
+		async getRecentEmotionalStates() {
+			client.recentCalls++;
+			return states;
+		},
+		async getEmotionalState() {
+			client.callCount++;
+			return null;
 		},
 	};
 	return { client };
@@ -253,4 +279,56 @@ test("emotional-state store — debounces repeated stores within the window", as
 	await handler({ success: true, messages: richMessages }, { trigger: "user" });
 	await handler({ success: true, messages: richMessages }, { trigger: "user" });
 	assert.equal(stores.length, 1, "second store within the debounce window is skipped");
+});
+
+// ---- the arc: inject last N via /emotional-state/recent --------------------
+
+test("emotional-state fetch — injects the recent ARC (multiple registers, most recent first)", async () => {
+	const { client } = makeArcClient([
+		st("Warm and close right now.", "2026-06-24T20:00:00Z"),
+		st("Tender after a hard day.", "2026-06-24T18:00:00Z"),
+		st("Playful and light.", "2026-06-23T12:00:00Z"),
+	]);
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		cfg,
+	);
+	const out = await handler({}, { sessionKey: "arc-1" });
+	const ctx = (out as { prependContext?: string })?.prependContext ?? "";
+	assert.match(ctx, /Warm and close/);
+	assert.match(ctx, /Tender after a hard day/);
+	assert.match(ctx, /Playful and light/);
+	assert.match(ctx, /most recent first/);
+	assert.equal(client.recentCalls, 1);
+	assert.equal(client.callCount, 0, "uses /recent — no fallback to single getEmotionalState");
+});
+
+test("emotional-state fetch — filters raw-transcript placeholders out of the arc", async () => {
+	const { client } = makeArcClient([
+		st("Warm and steady."),
+		st("user: hey\nassistant: hi"), // pending placeholder — must be dropped
+		st("Grateful and close."),
+	]);
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		cfg,
+	);
+	const out = await handler({}, { sessionKey: "arc-2" });
+	const ctx = (out as { prependContext?: string })?.prependContext ?? "";
+	assert.match(ctx, /Warm and steady/);
+	assert.match(ctx, /Grateful and close/);
+	assert.doesNotMatch(ctx, /user: hey/);
+});
+
+test("emotional-state fetch — falls back to single latest when /recent is unavailable (404 → null)", async () => {
+	// makeClient's getRecentEmotionalStates returns null → fallback path.
+	const { client } = makeClient("Just the latest register.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		cfg,
+	);
+	const out = await handler({}, { sessionKey: "arc-fallback" });
+	const ctx = (out as { prependContext?: string })?.prependContext ?? "";
+	assert.match(ctx, /Just the latest register/);
+	assert.equal(client.callCount, 1, "fell back to getEmotionalState");
 });

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -1,7 +1,10 @@
-import type { HyperspellClient } from "../client.ts";
+import type { EmotionalStateLatest, HyperspellClient } from "../client.ts";
 import type { HyperspellConfig } from "../config.ts";
 import { log } from "../logger.ts";
 import { sanitizeTraceText } from "./auto-trace.ts";
+
+/** How many recent registers to surface as the "arc" at session start. */
+const EMOTIONAL_ARC_LIMIT = 3;
 
 type Message = { role?: string; content?: string | unknown };
 type AgentContext = { sessionKey?: string; trigger?: string };
@@ -95,6 +98,66 @@ export function looksLikeRawTranscript(summary: string): boolean {
 	return /(^|\n)\s*(user|assistant)\s*:/i.test(summary);
 }
 
+/** Compact relative time for the arc labels (e.g. "just now", "3h ago", "2d ago"). */
+function relativeWhen(iso: string): string {
+	if (!iso) return "";
+	try {
+		const mins = (Date.now() - new Date(iso).getTime()) / 60000;
+		if (Number.isNaN(mins)) return "";
+		if (mins < 2) return "just now";
+		if (mins < 60) return `${Math.floor(mins)}m ago`;
+		const hrs = mins / 60;
+		if (hrs < 24) return `${Math.floor(hrs)}h ago`;
+		const days = hrs / 24;
+		if (days < 7) return `${Math.floor(days)}d ago`;
+		return new Date(iso).toLocaleDateString("en", { month: "short", day: "numeric" });
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Prefer the recent ARC (last N registers) so a single shallow read can't
+ * misrepresent the relationship. Falls back to the single latest when the
+ * backend doesn't expose `/emotional-state/recent` yet (returns null) or errors
+ * — so this works before AND after that endpoint deploys.
+ */
+async function fetchRecentOrLatest(
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
+): Promise<EmotionalStateLatest[]> {
+	try {
+		const recent = await client.getRecentEmotionalStates(
+			cfg.relationshipId,
+			EMOTIONAL_ARC_LIMIT,
+		);
+		if (recent !== null) return recent; // endpoint available (may be empty)
+	} catch (err) {
+		log.debug("emotional-context: /recent unavailable — falling back to latest", err);
+	}
+	const single = await client.getEmotionalState(cfg.relationshipId);
+	return single ? [single] : [];
+}
+
+/** Build the injected emotional-context block from one or more registers. */
+function buildEmotionalContext(states: EmotionalStateLatest[]): string {
+	const intro =
+		states.length > 1
+			? "How your relationship with this user has felt across your recent conversations, most recent first. Let the trajectory inform your tone — don't reference it explicitly."
+			: "The emotional register of your relationship with this user from your last interaction. Let it inform your tone — don't reference it explicitly.";
+	const lines = states.map((s) => {
+		const when = relativeWhen(s.extractedAt);
+		return when ? `- [${when}] ${s.summary}` : `- ${s.summary}`;
+	});
+	return [
+		"<hyperspell-emotional-context>",
+		intro,
+		"",
+		...lines,
+		"</hyperspell-emotional-context>",
+	].join("\n");
+}
+
 /**
  * Fetch emotional state on the first agent turn of a session and inject into
  * context. On later turns of the same session, return undefined — the
@@ -113,38 +176,33 @@ export function buildEmotionalStateFetchHandler(
 		}
 
 		try {
-			const state = await client.getEmotionalState(cfg.relationshipId);
+			const states = await fetchRecentOrLatest(client, cfg);
 
-			if (!state) {
+			// Drop raw-transcript placeholders: extraction is async, so for ~10s
+			// after a store the register can be the RAW input transcript, not the
+			// distilled feeling. Injecting that is useless and pollutes tone.
+			const usable = states.filter(
+				(s) => s.summary && !looksLikeRawTranscript(s.summary),
+			);
+
+			if (usable.length === 0) {
+				if (states.length > 0) {
+					// State(s) exist but are all still extracting — don't cache, so a
+					// later turn re-fetches once extraction completes.
+					log.debug(
+						"emotional-context: state(s) still extracting — skipping injection this turn",
+					);
+					return;
+				}
 				log.debug("emotional-context: no prior emotional state found");
 				if (sessionKey) injectedSessions.add(sessionKey);
 				return;
 			}
 
-			// Extraction is async: for ~10s after a store, GET /emotional-state
-			// returns status=pending with `summary` set to the RAW transcript (the
-			// input), not the distilled register — and the response carries no
-			// status field to check. Detect that placeholder structurally (a real
-			// summary is second-person prose; a raw transcript has role-prefixed
-			// lines) and DON'T inject it: handing back the raw transcript as
-			// "feeling" is useless and pollutes tone. Don't cache, so a later turn
-			// re-fetches once extraction has completed.
-			if (looksLikeRawTranscript(state.summary)) {
-				log.debug(
-					"emotional-context: state still extracting (raw-transcript placeholder) — skipping injection this turn",
-				);
-				return;
-			}
-
-			log.debug(`emotional-context: injecting state from ${state.extractedAt}`);
-
-			const context = [
-				"<hyperspell-emotional-context>",
-				"The following captures the emotional register of your relationship with this user from your last interaction. Let it inform your tone — don't reference it explicitly.",
-				"",
-				state.summary,
-				"</hyperspell-emotional-context>",
-			].join("\n");
+			log.debug(
+				`emotional-context: injecting ${usable.length} recent register(s)`,
+			);
+			const context = buildEmotionalContext(usable);
 
 			if (sessionKey) injectedSessions.add(sessionKey);
 			return { prependContext: context };


### PR DESCRIPTION
## What
At session start, inject the **last ~3 emotional registers** (the arc) instead of just the single latest — so a brief exchange can't misrepresent how the relationship has *been* feeling.

## How
- `client.getRecentEmotionalStates(relationshipId, limit)` → `GET /emotional-state/recent` (backend **hyperspell#1961**). Returns `null` on `404` so callers can fall back.
- The fetch handler prefers the arc (last 3, most-recent-first, with relative-time labels) and **falls back to the single `getEmotionalState`** when `/recent` is unavailable (404) or errors. So it works **before and after** the backend endpoint deploys, and auto-upgrades the moment it does.
- Raw-transcript placeholders (pending extraction) are filtered out of the arc.

## Verified live
`/recent` currently 404s on prod → clean fallback confirmed; deployed to the agent as 0.15.10 with no behavior change until #1961 lands.

## Tests
Arc injection (multi-register ordering), placeholder filtering, and the 404→single fallback. `tsc` + build clean; **158 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)