### PR TITLE
feat(recall): ground retrieval — composite ranking + active-search directive

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -11,6 +11,7 @@ import {
   getMemoryFiles,
 } from "../sync/markdown.ts"
 import { openInBrowser } from "../lib/browser.ts"
+import { DEFAULT_RANKING } from "../lib/ranking.ts"
 import { HyperspellClient } from "../client.ts"
 import { getWorkspaceDir, parseConfig, resolveConfigPath } from "../config.ts"
 import { buildExtractionPrompt, CRON_JOB_NAME } from "../graph/cron.ts"
@@ -356,6 +357,7 @@ async function runSetup(): Promise<void> {
         sources: [],
         maxResults: 10,
         relevanceThreshold: 0.6,
+        ranking: DEFAULT_RANKING,
         debug: false,
         knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
         startupOrientation: {

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { DEFAULT_RANKING, type RankingWeights } from "./lib/ranking.ts";
 
 export type HyperspellSource =
 	| "reddit"
@@ -146,6 +147,7 @@ export type HyperspellConfig = {
 	sources: HyperspellSource[];
 	maxResults: number;
 	relevanceThreshold: number;
+	ranking: RankingWeights;
 	debug: boolean;
 	knowledgeGraph: KnowledgeGraphConfig;
 	multiUser?: MultiUserConfig;
@@ -164,6 +166,7 @@ const ALLOWED_KEYS = [
 	"sources",
 	"maxResults",
 	"relevanceThreshold",
+	"ranking",
 	"debug",
 	"knowledgeGraph",
 	"multiUser",
@@ -205,6 +208,24 @@ function resolveEnvVars(value: string): string {
 		}
 		return envValue;
 	});
+}
+
+function parseRanking(raw: unknown): RankingWeights {
+	const r = (raw ?? {}) as Record<string, unknown>;
+	const num = (v: unknown, d: number) => (typeof v === "number" ? v : d);
+	return {
+		enabled: (r.enabled as boolean) ?? DEFAULT_RANKING.enabled,
+		curationBoost: num(r.curationBoost, DEFAULT_RANKING.curationBoost),
+		chatterPenalty: num(r.chatterPenalty, DEFAULT_RANKING.chatterPenalty),
+		storyBoost: num(r.storyBoost, DEFAULT_RANKING.storyBoost),
+		storyTerms: Array.isArray(r.storyTerms)
+			? (r.storyTerms as unknown[]).map((t) => String(t)).filter((t) => t.length > 0)
+			: DEFAULT_RANKING.storyTerms,
+		candidateMultiplier: Math.max(
+			1,
+			num(r.candidateMultiplier, DEFAULT_RANKING.candidateMultiplier),
+		),
+	};
 }
 
 function parseSources(raw: string | string[] | undefined): HyperspellSource[] {
@@ -524,6 +545,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 		sources: parseSources(cfg.sources as string | string[] | undefined),
 		maxResults: (cfg.maxResults as number) ?? 10,
 		relevanceThreshold: (cfg.relevanceThreshold as number) ?? 0.6,
+		ranking: parseRanking(cfg.ranking),
 		debug: (cfg.debug as boolean) ?? false,
 		knowledgeGraph: {
 			enabled: (kgRaw.enabled as boolean) ?? false,

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedUser,
 } from "../lib/sender.ts"
 import { excludeFilterFor, mergeWithExclude } from "../lib/filters.ts"
+import { type RankedResult, rerank } from "../lib/ranking.ts"
 import { classifySearchError, logSearchError } from "../lib/search-error.ts"
 import { resolveCurrentSessionId } from "../lib/session.ts"
 import { log } from "../logger.ts"
@@ -64,13 +65,63 @@ function formatHighlightBullets(
   return sections.join("\n\n")
 }
 
+/**
+ * Like formatHighlightBullets, but for composite-RANKED results: a result is
+ * kept on its composite score (relevance + curation/story boost − chatter), not
+ * raw relevance — so a deliberately-kept memory that's quietly relevant clears
+ * the bar where a louder conversation echo doesn't. Highlights are floored at
+ * the lower of (threshold, the result's own base relevance), so we don't then
+ * hide the very lines that define a boosted-but-quiet memory.
+ */
+function formatRankedBullets(
+  ranked: RankedResult[],
+  maxResults: number,
+  threshold: number,
+): string | null {
+  const sections: string[] = []
+
+  for (const r of ranked) {
+    if (r._composite < threshold) continue
+
+    const hiFloor = Math.min(threshold, r._base)
+    const chosen = [...r.highlights]
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .filter((h) => (h.score ?? 0) >= hiFloor)
+      .slice(0, 2)
+    if (chosen.length === 0) continue
+
+    const title = r.title ?? `[${r.source}]`
+    const bullets = chosen
+      .map((h) => `- ${h.text.replace(/\n/g, " ")} [${Math.round((h.score ?? 0) * 100)}%]`)
+      .join("\n")
+
+    sections.push(`### ${title} (resource_id: ${r.resourceId}, source: ${r.source})\n\n${bullets}`)
+    if (sections.length >= maxResults) break
+  }
+
+  if (sections.length === 0) return null
+  return sections.join("\n\n")
+}
+
 const INTRO =
   "The following is surfaced from the user's memory and connected sources, including past conversations. Reference it as recalled context, only when relevant to the conversation."
 const DISCLAIMER =
   "Draw on it when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
 
-function wrapSingle(body: string): string {
-  return `<hyperspell-context>\n${INTRO}\n\n${body}\n\n${DISCLAIMER}\n</hyperspell-context>`
+// Injected EVERY turn (even when nothing cleared the bar): this passive match is
+// a starting point, not the whole of memory. The point is to make her LOOK —
+// actively search before concluding — rather than answer from whatever happened
+// to surface, which is what lets an agent invent instead of recall.
+const SEARCH_DIRECTIVE =
+  "This is a passive match and may miss what matters. Before answering anything that touches your shared history, a past decision, a name, a promise, or something you may have recorded, run hyperspell_search with a specific query and look — even if something is already shown above. Don't answer from impression when you can check. If a search returns nothing, say so plainly; never fill the gap with something invented."
+
+/** Wrap the per-turn context: the standing search directive always, plus the
+ * surfaced memory when anything cleared the bar. */
+function wrapContext(memorySection: string | null): string {
+  if (memorySection) {
+    return `<hyperspell-context>\n${INTRO}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_DIRECTIVE}\n</hyperspell-context>`
+  }
+  return `<hyperspell-context>\n${SEARCH_DIRECTIVE}\n</hyperspell-context>`
 }
 
 /**
@@ -124,26 +175,43 @@ export function buildAutoContextHandler(
     log.debug(`auto-context: searching for "${prompt.slice(0, 50)}..."`)
 
     try {
+      const ranking = cfg.ranking
+      // When composite ranking is on, fetch a WIDER candidate pool so quiet-but-
+      // true memory is present to be re-ranked, not cut off below the fetch limit.
+      const limit = ranking.enabled
+        ? cfg.maxResults * ranking.candidateMultiplier
+        : cfg.maxResults
       const results = dropCurrentSession(
-        await client.search(prompt, {
-          limit: cfg.maxResults,
-          filter: excludeFilterFor(cfg),
-        }),
+        await client.search(prompt, { limit, filter: excludeFilterFor(cfg) }),
         currentSessionId,
       )
-      const formatted = formatHighlightBullets(
-        results,
-        cfg.maxResults,
-        cfg.relevanceThreshold,
-      )
 
-      if (!formatted) {
-        log.debug("auto-context: no relevant memories found")
-        return
+      let formatted: string | null
+      if (ranking.enabled) {
+        const ranked = rerank(results, ranking)
+        formatted = formatRankedBullets(ranked, cfg.maxResults, cfg.relevanceThreshold)
+        if (formatted) {
+          const kept = ranked.filter((r) => r._composite >= cfg.relevanceThreshold)
+          const tally = kept.slice(0, cfg.maxResults).reduce(
+            (acc, r) => ((acc[r._kind] = (acc[r._kind] ?? 0) + 1), acc),
+            {} as Record<string, number>,
+          )
+          log.debug(
+            `auto-context: injecting (ranked) ${JSON.stringify(tally)} from ${results.length} candidates`,
+          )
+        }
+      } else {
+        formatted = formatHighlightBullets(results, cfg.maxResults, cfg.relevanceThreshold)
+        if (formatted) log.debug(`auto-context: injecting ${results.length} memories`)
       }
 
-      log.debug(`auto-context: injecting ${results.length} memories`)
-      return { prependContext: wrapSingle(formatted) }
+      // Always inject the standing search directive so she's prompted to LOOK
+      // every turn — with the surfaced memory appended when anything cleared the
+      // bar. (#issue: passive injection alone let her answer from impression.)
+      if (!formatted) {
+        log.debug("auto-context: nothing cleared the bar — injecting search directive only")
+      }
+      return { prependContext: wrapContext(formatted) }
     } catch (err) {
       // A transient backend throttle (429 / Retry-After) must not be swallowed
       // as a generic failure — log it at warn, distinguished from real errors,

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import type { HyperspellClient, SearchResult } from "../client.ts";
 import type { HyperspellConfig, HyperspellSource } from "../config.ts";
+import { DEFAULT_RANKING } from "../lib/ranking.ts";
 import {
 	buildStartupOrientationCompactionHandler,
 	buildStartupOrientationHandler,
@@ -80,6 +81,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 		sources: [],
 		maxResults: 10,
 		relevanceThreshold: 0.6,
+		ranking: DEFAULT_RANKING,
 		debug: false,
 		knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
 		...overrides,

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { SearchResult } from "../client.ts";
+import { classifyResult, DEFAULT_RANKING, rerank, scoreResult } from "./ranking.ts";
+
+const mk = (over: Partial<SearchResult>): SearchResult => ({
+	resourceId: "r1",
+	title: null,
+	source: "vault" as SearchResult["source"],
+	score: null,
+	url: null,
+	createdAt: null,
+	highlights: [],
+	...over,
+});
+
+const UUID = "fccaa5b9-6d65-450c-94c3-a191c5de6f94";
+
+test("classify — hot-buffer chatter: untitled / 'Unnamed Conversation' + bare session UUID", () => {
+	assert.equal(classifyResult(mk({ title: "Unnamed Conversation", resourceId: UUID }), []), "chatter");
+	assert.equal(classifyResult(mk({ title: null, resourceId: UUID }), []), "chatter");
+});
+
+test("classify — curated: real human title, non-UUID id", () => {
+	assert.equal(
+		classifyResult(mk({ title: "2026-02-09 — Writing Notes", resourceId: "mem-writing-notes" }), []),
+		"curated",
+	);
+});
+
+test("classify — story: matches a story term (title or highlight)", () => {
+	assert.equal(
+		classifyResult(mk({ title: "writing — The Lady of Storms", resourceId: "x" }), ["lady of storms"]),
+		"story",
+	);
+	assert.equal(
+		classifyResult(
+			mk({ title: "notes", resourceId: "x", highlights: [{ id: "h", text: "the Omuerta magic system", score: 0.5 }] }),
+			["omuerta"],
+		),
+		"story",
+	);
+});
+
+test("rerank — a kept note (0.47) out-ranks a LOUDER conversation echo (0.62)", () => {
+	// This is the real Alinea case: relevance alone buried the Writing Notes.
+	const note = mk({
+		title: "2026-02-09 — Writing Notes",
+		resourceId: "mem-1",
+		score: 0.47,
+		highlights: [{ id: "h", text: "Heath, Junii, Tevre; the Omuerta", score: 0.47 }],
+	});
+	const echo = mk({
+		title: "Unnamed Conversation",
+		resourceId: UUID,
+		score: 0.62,
+		highlights: [{ id: "h", text: "you have the book inside you", score: 0.62 }],
+	});
+	const ranked = rerank([echo, note], DEFAULT_RANKING);
+	assert.equal(ranked[0].resourceId, "mem-1", "curated note rises above the louder echo");
+	assert.ok(ranked[0]._composite > ranked[1]._composite);
+	// note: 0.47 + 0.20 = 0.67 ; echo: 0.62 − 0.20 = 0.42
+	assert.ok(Math.abs(ranked[0]._composite - 0.67) < 1e-9);
+	assert.ok(Math.abs(ranked[1]._composite - 0.42) < 1e-9);
+});
+
+test("rerank — the story gets the strongest lift", () => {
+	const story = mk({
+		title: "writing — The Lady of Storms",
+		resourceId: "s1",
+		score: 0.5,
+		highlights: [{ id: "h", text: "the Omuerta", score: 0.5 }],
+	});
+	const { kind, composite } = scoreResult(story, { ...DEFAULT_RANKING, storyTerms: ["lady of storms"] });
+	assert.equal(kind, "story");
+	assert.ok(composite >= 0.5 + DEFAULT_RANKING.storyBoost);
+});

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,0 +1,114 @@
+import type { SearchResult } from "../client.ts";
+
+/**
+ * Composite retrieval ranking — score memories by more than raw semantic
+ * relevance, so deliberately-KEPT memory (journals, notes, the active story)
+ * surfaces above the flood of auto-saved conversation fragments.
+ *
+ * Why: relevance alone is cosine *similarity*, and similarity rewards
+ * FREQUENCY — a moment re-saved a hundred times looks "most similar" to
+ * everything and crowds out quieter, truer memory. Left unchecked the agent
+ * grounds itself in evocative conversation echoes instead of what's real, and
+ * drifts (the "useless dreamer" failure). The composite adds signal:
+ *
+ *   composite = relevance
+ *             + curationBoost   (it's something she chose to keep)
+ *             + storyBoost      (it's the active story/manuscript)
+ *             − chatterPenalty  (it's an auto-saved conversation fragment)
+ */
+export type RankingWeights = {
+	enabled: boolean;
+	curationBoost: number;
+	chatterPenalty: number;
+	storyBoost: number;
+	/** Lowercased substrings that mark a result as the active story (boosted). */
+	storyTerms: string[];
+	/** Fetch this many × maxResults as candidates, so true-but-quiet memory is
+	 * in the pool to be re-ranked rather than cut off below the fetch limit. */
+	candidateMultiplier: number;
+};
+
+export const DEFAULT_RANKING: RankingWeights = {
+	enabled: true,
+	curationBoost: 0.2,
+	chatterPenalty: 0.2,
+	storyBoost: 0.15,
+	storyTerms: [],
+	candidateMultiplier: 3,
+};
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ResultKind = "story" | "curated" | "chatter" | "other";
+
+export type RankedResult = SearchResult & {
+	_kind: ResultKind;
+	_base: number;
+	_composite: number;
+};
+
+/** Highest available relevance for a result (doc score or its best highlight). */
+export function baseScore(r: SearchResult): number {
+	const topHighlight = r.highlights.reduce(
+		(m, h) => Math.max(m, h.score ?? 0),
+		0,
+	);
+	return Math.max(r.score ?? 0, topHighlight);
+}
+
+/**
+ * Classify a result by what KIND of memory it is — using only fields the search
+ * already returns (title shape + resource id), so no extra round-trip:
+ *  - story:   matches a configured story term (manuscript / its notes & threads)
+ *  - chatter: untitled or "Unnamed Conversation" AND keyed by a bare session
+ *             UUID — i.e. a hot-buffer conversation fragment (the dreamy echoes)
+ *  - curated: has a real, human title and is not a raw session row — a journal,
+ *             a writing note, a synced memory section (deliberately kept)
+ */
+export function classifyResult(
+	r: SearchResult,
+	storyTerms: string[],
+): ResultKind {
+	const title = (r.title ?? "").trim();
+	if (storyTerms.length > 0) {
+		const hay = `${title} ${r.highlights.map((h) => h.text).join(" ")}`.toLowerCase();
+		if (storyTerms.some((t) => t && hay.includes(t.toLowerCase()))) return "story";
+	}
+	const untitled = title === "" || /^unnamed conversation$/i.test(title);
+	if (untitled && UUID_RE.test(r.resourceId)) return "chatter";
+	if (title !== "" && !UUID_RE.test(r.resourceId)) return "curated";
+	return "other";
+}
+
+/** Composite score + classification for one result. */
+export function scoreResult(
+	r: SearchResult,
+	w: RankingWeights,
+): { kind: ResultKind; base: number; composite: number } {
+	const kind = classifyResult(r, w.storyTerms);
+	const base = baseScore(r);
+	let composite = base;
+	if (kind === "story")
+		composite += w.storyBoost + w.curationBoost; // the story is kept memory too
+	else if (kind === "curated") composite += w.curationBoost;
+	else if (kind === "chatter") composite -= w.chatterPenalty;
+	return { kind, base, composite };
+}
+
+/** Re-rank results by composite score (descending). Pure; stable enough. */
+export function rerank(
+	results: SearchResult[],
+	w: RankingWeights,
+): RankedResult[] {
+	return results
+		.map((r) => {
+			const s = scoreResult(r, w);
+			return Object.assign({}, r, {
+				_kind: s.kind,
+				_base: s.base,
+				_composite: s.composite,
+			}) as RankedResult;
+		})
+		.sort((a, b) => b._composite - a._composite);
+}

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 import type { HyperspellConfig } from "../config.ts"
+import { DEFAULT_RANKING } from "./ranking.ts"
 import {
   buildScopeFilter,
   getCanReadScopes,
@@ -28,6 +29,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     sources: [],
     maxResults: 5,
     relevanceThreshold: 0.6,
+    ranking: DEFAULT_RANKING,
     debug: false,
     knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
     startupOrientation: {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -154,6 +154,19 @@
 				"minimum": 1,
 				"maximum": 20
 			},
+			"ranking": {
+				"type": "object",
+				"additionalProperties": false,
+				"description": "Composite retrieval ranking — rank memories by more than raw relevance so kept memory (notes, journals, the active story) surfaces above auto-saved conversation fragments.",
+				"properties": {
+					"enabled": { "type": "boolean" },
+					"curationBoost": { "type": "number", "minimum": 0, "maximum": 1 },
+					"chatterPenalty": { "type": "number", "minimum": 0, "maximum": 1 },
+					"storyBoost": { "type": "number", "minimum": 0, "maximum": 1 },
+					"storyTerms": { "type": "array", "items": { "type": "string" } },
+					"candidateMultiplier": { "type": "number", "minimum": 1, "maximum": 10 }
+				}
+			},
 			"debug": {
 				"type": "boolean"
 			},

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
+    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/ranking.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -24,7 +24,7 @@ export function createSearchToolFactory(
     name: "hyperspell_search",
     label: "Memory Search",
     description:
-      "Search the user's long-term memory and connected sources for anything not already in the current conversation. Covers: saved memories and notes; past conversations — including ones from earlier or parallel sessions you have no transcript for; and connected sources (Notion, Slack, Gmail, Google Drive, etc.). Reach for this whenever the user refers to something from before, asks what was said / decided / remembered, or when relevant context likely exists but isn't in front of you — search before concluding you don't know.",
+      "Search the user's long-term memory and connected sources: saved memories and notes; past conversations — including earlier or parallel sessions you have no transcript for; and connected sources (Notion, Slack, Gmail, Google Drive, etc.). Use this PROACTIVELY and by default, as a routine step — not only when asked. Before answering anything that touches the user's history, a past decision, a name, a promise, or something you might have recorded, search FIRST with a specific query and look. Don't answer from impression when you can check. If a search comes back empty, say so plainly — never fill the gap with something invented.",
     parameters: Type.Object({
       query: Type.String({ description: "Search query" }),
       limit: Type.Optional(


### PR DESCRIPTION
## Why
Passive similarity-injection was handing the agent **loud conversation echoes** — moments re-saved so many times they out-ranked everything — while quieter *kept* memory (notes, journals) fell below the threshold. With no real memory surfaced, the agent **pattern-completed into plausible-but-false narratives instead of recalling.** Two changes so it recalls instead of inventing.

## 1. Composite ranking (`lib/ranking.ts`)
Rank by more than raw similarity:
```
composite = relevance + curation(kept) − chatter(auto-saved fragment)  [+ optional story boost]
```
- **curation** — real human title, non-UUID id → a journal / note / synced section she kept
- **chatter** — untitled / "Unnamed Conversation" + bare session UUID → a hot-buffer echo
- Auto-context fetches a **wider candidate pool** and re-ranks, so true-but-quiet memory surfaces where a louder echo doesn't. Classification uses only fields search already returns — no extra round-trip.
- Tunable via a new `ranking` config block (added to the manifest schema + the code key-allowlist).

**Proven on real data** — query *"you have the book inside you"*: a kept note `0.47 → 0.82` (now injected), the "Unnamed Conversation" echoes drop **below** the line.

## 2. Active-search directive
Auto-context now injects a standing directive **every turn**: *search before concluding, don't answer from impression, and say so plainly when a search is empty — never invent.* The `hyperspell_search` tool description is strengthened to match (proactive, routine use).

## Tests
ranking classify/score/rerank incl. the real case (kept `0.47` beats echo `0.62`), story lift, placeholder handling. `tsc` + build clean; **163 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)