### PR TITLE
fix(recall): cap chatter with a quota + make the search nudge conditional

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -225,6 +225,7 @@ function parseRanking(raw: unknown): RankingWeights {
 			1,
 			num(r.candidateMultiplier, DEFAULT_RANKING.candidateMultiplier),
 		),
+		chatterQuota: Math.max(0, num(r.chatterQuota, DEFAULT_RANKING.chatterQuota)),
 	};
 }
 

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -7,7 +7,7 @@ import {
   type ResolvedUser,
 } from "../lib/sender.ts"
 import { excludeFilterFor, mergeWithExclude } from "../lib/filters.ts"
-import { type RankedResult, rerank } from "../lib/ranking.ts"
+import { type RankedResult, rerank, selectRanked } from "../lib/ranking.ts"
 import { classifySearchError, logSearchError } from "../lib/search-error.ts"
 import { resolveCurrentSessionId } from "../lib/session.ts"
 import { log } from "../logger.ts"
@@ -66,23 +66,15 @@ function formatHighlightBullets(
 }
 
 /**
- * Like formatHighlightBullets, but for composite-RANKED results: a result is
- * kept on its composite score (relevance + curation/story boost − chatter), not
- * raw relevance — so a deliberately-kept memory that's quietly relevant clears
- * the bar where a louder conversation echo doesn't. Highlights are floored at
- * the lower of (threshold, the result's own base relevance), so we don't then
- * hide the very lines that define a boosted-but-quiet memory.
+ * Format already-SELECTED composite-ranked results (threshold + chatter quota
+ * applied upstream by selectRanked). Highlights are floored at the lower of
+ * (threshold, the result's own base relevance), so we don't hide the very lines
+ * that define a boosted-but-quiet memory.
  */
-function formatRankedBullets(
-  ranked: RankedResult[],
-  maxResults: number,
-  threshold: number,
-): string | null {
+function formatSelected(selected: RankedResult[], threshold: number): string | null {
   const sections: string[] = []
 
-  for (const r of ranked) {
-    if (r._composite < threshold) continue
-
+  for (const r of selected) {
     const hiFloor = Math.min(threshold, r._base)
     const chosen = [...r.highlights]
       .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
@@ -96,7 +88,6 @@ function formatRankedBullets(
       .join("\n")
 
     sections.push(`### ${title} (resource_id: ${r.resourceId}, source: ${r.source})\n\n${bullets}`)
-    if (sections.length >= maxResults) break
   }
 
   if (sections.length === 0) return null
@@ -108,20 +99,17 @@ const INTRO =
 const DISCLAIMER =
   "Draw on it when relevant — including indirect connections — but don't force it into every response or make assumptions beyond what's stated."
 
-// Injected EVERY turn (even when nothing cleared the bar): this passive match is
-// a starting point, not the whole of memory. The point is to make her LOOK —
-// actively search before concluding — rather than answer from whatever happened
-// to surface, which is what lets an agent invent instead of recall.
-const SEARCH_DIRECTIVE =
-  "This is a passive match and may miss what matters. Before answering anything that touches your shared history, a past decision, a name, a promise, or something you may have recorded, run hyperspell_search with a specific query and look — even if something is already shown above. Don't answer from impression when you can check. If a search returns nothing, say so plainly; never fill the gap with something invented."
+// A short, CONDITIONAL reminder appended only to a real memory block (not a
+// standing every-turn imperative — that reads as ambient framing and trains
+// search-as-ritual; the agent's own instructions carry the standing rule). The
+// point here is just: what surfaced is a passive match, not all of memory.
+const SEARCH_REMINDER =
+  "This is a passive match, not all of memory — if the answer turns on a specific past decision, promise, name, or something recorded, search for it directly before concluding, and say so plainly if it isn't there."
 
-/** Wrap the per-turn context: the standing search directive always, plus the
- * surfaced memory when anything cleared the bar. */
-function wrapContext(memorySection: string | null): string {
-  if (memorySection) {
-    return `<hyperspell-context>\n${INTRO}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_DIRECTIVE}\n</hyperspell-context>`
-  }
-  return `<hyperspell-context>\n${SEARCH_DIRECTIVE}\n</hyperspell-context>`
+/** Wrap a real memory block. No memory → no injection (caller returns nothing);
+ * the standing search rule lives in the agent's own instructions, not here. */
+function wrapContext(memorySection: string): string {
+  return `<hyperspell-context>\n${INTRO}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_REMINDER}\n</hyperspell-context>`
 }
 
 /**
@@ -189,15 +177,22 @@ export function buildAutoContextHandler(
       let formatted: string | null
       if (ranking.enabled) {
         const ranked = rerank(results, ranking)
-        formatted = formatRankedBullets(ranked, cfg.maxResults, cfg.relevanceThreshold)
+        // Threshold + chatter quota applied here, so a high-similarity echo can
+        // inform but never flood (the quota bounds count; the penalty bounds rank).
+        const selected = selectRanked(
+          ranked,
+          cfg.maxResults,
+          cfg.relevanceThreshold,
+          ranking.chatterQuota,
+        )
+        formatted = formatSelected(selected, cfg.relevanceThreshold)
         if (formatted) {
-          const kept = ranked.filter((r) => r._composite >= cfg.relevanceThreshold)
-          const tally = kept.slice(0, cfg.maxResults).reduce(
+          const tally = selected.reduce(
             (acc, r) => ((acc[r._kind] = (acc[r._kind] ?? 0) + 1), acc),
             {} as Record<string, number>,
           )
           log.debug(
-            `auto-context: injecting (ranked) ${JSON.stringify(tally)} from ${results.length} candidates`,
+            `auto-context: injecting (ranked) ${JSON.stringify(tally)} from ${results.length} candidates (chatter cap ${ranking.chatterQuota})`,
           )
         }
       } else {
@@ -205,11 +200,12 @@ export function buildAutoContextHandler(
         if (formatted) log.debug(`auto-context: injecting ${results.length} memories`)
       }
 
-      // Always inject the standing search directive so she's prompted to LOOK
-      // every turn — with the surfaced memory appended when anything cleared the
-      // bar. (#issue: passive injection alone let her answer from impression.)
+      // No memory cleared the bar → no injection. The standing "search before you
+      // conclude" rule lives in the agent's own instructions, not an ambient
+      // every-turn banner (which reads as framing and trains search-as-ritual).
       if (!formatted) {
-        log.debug("auto-context: nothing cleared the bar — injecting search directive only")
+        log.debug("auto-context: no relevant memories found")
+        return
       }
       return { prependContext: wrapContext(formatted) }
     } catch (err) {

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -1,7 +1,14 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import type { SearchResult } from "../client.ts";
-import { classifyResult, DEFAULT_RANKING, rerank, scoreResult } from "./ranking.ts";
+import {
+	classifyResult,
+	DEFAULT_RANKING,
+	rerank,
+	type RankedResult,
+	scoreResult,
+	selectRanked,
+} from "./ranking.ts";
 
 const mk = (over: Partial<SearchResult>): SearchResult => ({
 	resourceId: "r1",
@@ -74,4 +81,33 @@ test("rerank — the story gets the strongest lift", () => {
 	const { kind, composite } = scoreResult(story, { ...DEFAULT_RANKING, storyTerms: ["lady of storms"] });
 	assert.equal(kind, "story");
 	assert.ok(composite >= 0.5 + DEFAULT_RANKING.storyBoost);
+});
+
+const ranked = (kind: RankedResult["_kind"], composite: number, id: string): RankedResult => ({
+	...mk({ resourceId: id }),
+	_kind: kind,
+	_base: composite,
+	_composite: composite,
+});
+
+test("selectRanked — caps chatter at the quota regardless of score, keeps real memory", () => {
+	// 4 high-scoring echoes + 1 curated; quota=2 must let only 2 echoes through.
+	const list = [
+		ranked("chatter", 0.9, "c1"),
+		ranked("chatter", 0.85, "c2"),
+		ranked("chatter", 0.8, "c3"),
+		ranked("curated", 0.7, "k1"),
+		ranked("chatter", 0.65, "c4"),
+	];
+	const sel = selectRanked(list, 10, 0.6, 2);
+	assert.equal(sel.filter((r) => r._kind === "chatter").length, 2, "no more than 2 chatter");
+	assert.ok(sel.some((r) => r._kind === "curated"), "real memory still surfaces");
+	assert.deepEqual(sel.map((r) => r.resourceId), ["c1", "c2", "k1"]);
+});
+
+test("selectRanked — drops below-threshold and honors maxResults", () => {
+	const list = [ranked("curated", 0.9, "a"), ranked("curated", 0.8, "c"), ranked("other", 0.5, "b")];
+	const sel = selectRanked(list, 1, 0.6, 2);
+	assert.equal(sel.length, 1, "maxResults respected");
+	assert.equal(sel[0].resourceId, "a");
 });

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -26,6 +26,11 @@ export type RankingWeights = {
 	/** Fetch this many × maxResults as candidates, so true-but-quiet memory is
 	 * in the pool to be re-ranked rather than cut off below the fetch limit. */
 	candidateMultiplier: number;
+	/** Hard cap on how many CHATTER (auto-saved conversation echo) results may be
+	 * injected, regardless of score. A high-similarity echo can clear any penalty;
+	 * the quota guarantees it can inform but never flood, keeping slots for real
+	 * memory. Penalty alone can't bound the count. */
+	chatterQuota: number;
 };
 
 export const DEFAULT_RANKING: RankingWeights = {
@@ -35,6 +40,7 @@ export const DEFAULT_RANKING: RankingWeights = {
 	storyBoost: 0.15,
 	storyTerms: [],
 	candidateMultiplier: 3,
+	chatterQuota: 2,
 };
 
 const UUID_RE =
@@ -111,4 +117,30 @@ export function rerank(
 			}) as RankedResult;
 		})
 		.sort((a, b) => b._composite - a._composite);
+}
+
+/**
+ * Choose which ranked results to inject: keep those clearing `threshold` on
+ * their composite, cap CHATTER at `chatterQuota` regardless of score (so a
+ * high-similarity echo can inform but never flood — the penalty bounds rank,
+ * the quota bounds count), and stop at `maxResults`.
+ */
+export function selectRanked(
+	ranked: RankedResult[],
+	maxResults: number,
+	threshold: number,
+	chatterQuota: number,
+): RankedResult[] {
+	const out: RankedResult[] = [];
+	let chatter = 0;
+	for (const r of ranked) {
+		if (r._composite < threshold) continue;
+		if (r._kind === "chatter") {
+			if (chatter >= chatterQuota) continue;
+			chatter++;
+		}
+		out.push(r);
+		if (out.length >= maxResults) break;
+	}
+	return out;
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -164,7 +164,8 @@
 					"chatterPenalty": { "type": "number", "minimum": 0, "maximum": 1 },
 					"storyBoost": { "type": "number", "minimum": 0, "maximum": 1 },
 					"storyTerms": { "type": "array", "items": { "type": "string" } },
-					"candidateMultiplier": { "type": "number", "minimum": 1, "maximum": 10 }
+					"candidateMultiplier": { "type": "number", "minimum": 1, "maximum": 10 },
+					"chatterQuota": { "type": "number", "minimum": 0, "maximum": 20 }
 				}
 			},
 			"debug": {

--- a/tools/search.ts
+++ b/tools/search.ts
@@ -24,7 +24,7 @@ export function createSearchToolFactory(
     name: "hyperspell_search",
     label: "Memory Search",
     description:
-      "Search the user's long-term memory and connected sources: saved memories and notes; past conversations — including earlier or parallel sessions you have no transcript for; and connected sources (Notion, Slack, Gmail, Google Drive, etc.). Use this PROACTIVELY and by default, as a routine step — not only when asked. Before answering anything that touches the user's history, a past decision, a name, a promise, or something you might have recorded, search FIRST with a specific query and look. Don't answer from impression when you can check. If a search comes back empty, say so plainly — never fill the gap with something invented.",
+      "Search the user's long-term memory and connected sources: saved memories and notes; past conversations — including earlier or parallel sessions you have no transcript for; and connected sources (Notion, Slack, Gmail, Google Drive, etc.). Use this proactively, not only when asked — but on content, not as ritual: before answering anything that touches the user's history, a past decision, a name, a promise, or something you might have recorded, search FIRST with a specific query and look. Don't answer from impression when you can check. If a search comes back empty, say so plainly — never fill the gap with something invented.",
     parameters: Type.Object({
       query: Type.String({ description: "Search query" }),
       limit: Type.Optional(


### PR DESCRIPTION
Follow-up to #56, driven by live behavior + the agent's own analysis.

## 1. Chatter quota
A high-similarity conversation echo clears *any* penalty — on one live turn **nine echoes flooded** a single injection (`{"curated":1,"chatter":9}`). Penalty bounds *rank*; nothing bounded *count*. Added `selectRanked` with a hard **chatter quota** (default 2): an echo can inform but never flood, and slots stay open for real memory.

## 2. Conditional search nudge (not every-turn)
The every-turn injected directive from #56 was **ambient** — read as framing, not a command (**0 active searches across ~7 turns**) — *and* framed the wrong norm: "search every turn" trains search-as-ritual (the lab-coat failure, ported to tool-calls). Replaced with a short **conditional** reminder appended only to a real memory block; no standing every-turn banner. The canonical rule — *search before you conclude, on content not ritual; say so plainly when empty* — belongs in the agent's **own standing instructions**, not ambient per-turn context. Tool description aligned (conditional, not "routine step").

## Tests
`selectRanked` caps chatter at the quota + honors threshold/maxResults. **165 pass**; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)