### PR TITLE
feat: channel memory quarantine (excludeChannels) + hot-buffer origin tags

### DIFF
--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -346,6 +346,7 @@ async function runSetup(): Promise<void> {
         },
         emotionalContext: false,
         moodWeatherChance: 0,
+        excludeChannels: [],
         syncMemories: true,
         syncMemoriesConfig: {
           enabled: true,

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -345,6 +345,7 @@ async function runSetup(): Promise<void> {
           writeAssistant: true,
         },
         emotionalContext: false,
+        moodWeatherChance: 0,
         syncMemories: true,
         syncMemoriesConfig: {
           enabled: true,

--- a/config.test.ts
+++ b/config.test.ts
@@ -306,3 +306,21 @@ test("parseConfig — hotBuffer with an invalid source throws", () => {
     /Invalid source/,
   )
 })
+
+test("parseConfig — excludeChannels defaults to empty", () => {
+  const cfg = parseConfig(base)
+  assert.deepEqual(cfg.excludeChannels, [])
+})
+
+test("parseConfig — excludeChannels trims entries and drops empties", () => {
+  const cfg = parseConfig({
+    ...base,
+    excludeChannels: [" 1521620672726438171 ", "", "abc"],
+  })
+  assert.deepEqual(cfg.excludeChannels, ["1521620672726438171", "abc"])
+})
+
+test("parseConfig — non-array excludeChannels falls back to empty", () => {
+  const cfg = parseConfig({ ...base, excludeChannels: "123" })
+  assert.deepEqual(cfg.excludeChannels, [])
+})

--- a/config.ts
+++ b/config.ts
@@ -147,6 +147,14 @@ export type HyperspellConfig = {
 	 * (~0.05–0.10) so it reads as weather, not a gimmick. Requires emotionalContext.
 	 */
 	moodWeatherChance: number;
+	/**
+	 * Conversation/channel ids that are fully quarantined from memory: no
+	 * context injection, no memory writes (hot buffer, auto-trace, emotional
+	 * state), and no memory tools in those sessions. Matched against the
+	 * session's resolved conversation id (e.g. a Discord channel id); threads
+	 * inside an excluded channel inherit the quarantine. Default: [].
+	 */
+	excludeChannels: string[];
 	relationshipId?: string;
 	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
@@ -168,6 +176,7 @@ const ALLOWED_KEYS = [
 	"hotBuffer",
 	"emotionalContext",
 	"moodWeatherChance",
+	"excludeChannels",
 	"relationshipId",
 	"startupOrientation",
 	"syncMemories",
@@ -534,6 +543,11 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			1,
 			Math.max(0, (cfg.moodWeatherChance as number) ?? 0),
 		),
+		excludeChannels: Array.isArray(cfg.excludeChannels)
+			? (cfg.excludeChannels as unknown[])
+					.map((c) => String(c).trim())
+					.filter((c) => c.length > 0)
+			: [],
 		relationshipId: cfg.relationshipId as string | undefined,
 		startupOrientation: {
 			enabled: (soRaw.enabled as boolean) ?? false,

--- a/config.ts
+++ b/config.ts
@@ -140,6 +140,13 @@ export type HyperspellConfig = {
 	autoTrace: AutoTraceConfig;
 	hotBuffer: HotBufferConfig;
 	emotionalContext: boolean;
+	/**
+	 * Probability (0..1) that a fresh session rolls exogenous "mood weather" — an
+	 * uncaused, unannounced mood that overrides the arc's tone for that session
+	 * only (never written back to the register). 0 disables. Keep it rare
+	 * (~0.05–0.10) so it reads as weather, not a gimmick. Requires emotionalContext.
+	 */
+	moodWeatherChance: number;
 	relationshipId?: string;
 	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
@@ -160,6 +167,7 @@ const ALLOWED_KEYS = [
 	"autoTrace",
 	"hotBuffer",
 	"emotionalContext",
+	"moodWeatherChance",
 	"relationshipId",
 	"startupOrientation",
 	"syncMemories",
@@ -520,6 +528,12 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			writeAssistant: (hbRaw.writeAssistant as boolean) ?? true,
 		},
 		emotionalContext: (cfg.emotionalContext as boolean) ?? false,
+		// Default 0 (off) so shipping never changes existing installs' behavior.
+		// Clamped to [0,1] so a stray config value can't make every session roll.
+		moodWeatherChance: Math.min(
+			1,
+			Math.max(0, (cfg.moodWeatherChance as number) ?? 0),
+		),
 		relationshipId: cfg.relationshipId as string | undefined,
 		startupOrientation: {
 			enabled: (soRaw.enabled as boolean) ?? false,

--- a/hooks/hot-buffer.test.ts
+++ b/hooks/hot-buffer.test.ts
@@ -55,26 +55,43 @@ test("hot-buffer — writes user and assistant turns with stable ids", async () 
 	assert.notEqual(calls[0][0].messageId, calls[0][1].messageId);
 });
 
-test("hot-buffer — does NOT send metadata (a /messages write with metadata is not retrievable post-#1921)", async () => {
-	// Regression guard: tagging hot rows via POST /messages metadata is accepted
-	// (200) but makes the row non-retrievable (verified live). Untagged rows are
-	// searchable and survive the unconditional {$ne:"agent_end"} exclude, so we
-	// must write content only — no metadata.
+test("hot-buffer — tags rows with origin metadata (source, session, channel)", async () => {
+	// Metadata on POST /messages is retrievable + filterable since the #1921
+	// backend fix (verified live 2026-07-02, docs/filter-dialect-test.mjs).
+	// Tagging by origin lets retrieval and cleanup filter hot rows precisely;
+	// the {openclaw_source:{$ne:"agent_end"}} exclude keeps "hot_buffer" rows.
 	const { client, calls, optionsList } = makeClient();
 	const handler = buildHotBufferHandler(client, cfg);
 	await handler(
 		{
 			success: true,
-			sessionId: "s-tag",
-			messages: [{ role: "user", content: "do not tag me" }],
+			messages: [{ role: "user", content: "tag me" }],
 		},
-		{},
+		{ sessionId: "s-tag", channelId: "chan-9" },
 	);
 	assert.equal(calls.length, 1);
-	assert.equal(
-		(optionsList[0] as { metadata?: unknown }).metadata,
-		undefined,
+	assert.deepEqual((optionsList[0] as { metadata?: unknown }).metadata, {
+		openclaw_source: "hot_buffer",
+		openclaw_session_id: "s-tag",
+		openclaw_channel_id: "chan-9",
+	});
+});
+
+test("hot-buffer — omits channel tag when ctx has no channelId", async () => {
+	const { client, calls, optionsList } = makeClient();
+	const handler = buildHotBufferHandler(client, cfg);
+	await handler(
+		{
+			success: true,
+			messages: [{ role: "user", content: "no channel" }],
+		},
+		{ sessionId: "s-nochan" },
 	);
+	assert.equal(calls.length, 1);
+	assert.deepEqual((optionsList[0] as { metadata?: unknown }).metadata, {
+		openclaw_source: "hot_buffer",
+		openclaw_session_id: "s-nochan",
+	});
 });
 
 test("hot-buffer — resourceId comes from ctx.sessionId (agent_end event has none)", async () => {

--- a/hooks/hot-buffer.ts
+++ b/hooks/hot-buffer.ts
@@ -201,18 +201,26 @@ export function buildHotBufferHandler(
 
 		try {
 			let total = 0;
+			// Tag hot rows so retrieval and cleanup can identify them by origin.
+			// Historical note: metadata on POST /messages used to suppress indexing
+			// (Hyperspell #1921), so tagging was disabled; verified fixed live
+			// 2026-07-02 (docs/filter-dialect-test.mjs: metadata-carrying row is
+			// baseline-retrievable AND filterable). The retrieval exclude
+			// {openclaw_source:{$ne:"agent_end"}} keeps "hot_buffer" rows.
+			const channelId =
+				typeof ctx?.channelId === "string" && ctx.channelId.length > 0
+					? ctx.channelId
+					: undefined;
+			const metadata: Record<string, string> = {
+				openclaw_source: "hot_buffer",
+				openclaw_session_id: sessionId,
+				...(channelId ? { openclaw_channel_id: channelId } : {}),
+			};
 			for (const b of batches) {
-				// Do NOT tag hot rows with metadata: a POST /messages write that
-				// carries `metadata` is accepted (200) but the row never becomes
-				// retrievable (verified live, post-Hyperspell #1921) — tagging
-				// silently breaks hot-buffer recall. The tag isn't needed anyway:
-				// untagged rows survive the unconditional {$ne:"agent_end"} exclude
-				// (absent-field semantics, #1921) AND are full-text searchable. So
-				// we write content only. (Backend follow-up: make /messages metadata
-				// not suppress indexing, then this can be reinstated.)
 				const result = await client.sendMessages(b, {
 					userId,
 					source: cfg.hotBuffer.source,
+					metadata,
 				});
 				total += result.count;
 			}

--- a/hooks/mood-weather.test.ts
+++ b/hooks/mood-weather.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+	buildMoodWeatherContext,
+	MOOD_TABLE,
+	rollMood,
+} from "./mood-weather.ts";
+
+test("rollMood — returns null when chance is 0 (disabled)", () => {
+	assert.equal(rollMood(0, () => 0), null);
+	assert.equal(rollMood(0, () => 0.999), null);
+});
+
+test("rollMood — returns null for non-positive / NaN chance", () => {
+	assert.equal(rollMood(-1, () => 0), null);
+	assert.equal(rollMood(Number.NaN, () => 0), null);
+});
+
+test("rollMood — returns null when the chance gate misses", () => {
+	// rng() >= chance => no weather today
+	assert.equal(rollMood(0.1, () => 0.5), null);
+});
+
+test("rollMood — returns a mood when the chance gate is hit", () => {
+	const seq = [0.0, 0.0]; // gate passes, then r=0 selects first bucket
+	let i = 0;
+	const mood = rollMood(1, () => seq[i++] ?? 0);
+	assert.ok(mood);
+	assert.equal(mood?.id, MOOD_TABLE[0].id);
+});
+
+test("rollMood — selects last mood when the weight pointer lands at the top", () => {
+	const seq = [0.0, 0.999999];
+	let i = 0;
+	const mood = rollMood(1, () => seq[i++] ?? 0);
+	assert.equal(mood?.id, MOOD_TABLE[MOOD_TABLE.length - 1].id);
+});
+
+test("rollMood — covers the full table across the weighted range", () => {
+	const seen = new Set<string>();
+	const total = MOOD_TABLE.reduce((s, m) => s + m.weight, 0);
+	for (let pick = 0; pick < total; pick++) {
+		const frac = (pick + 0.5) / total;
+		const seq = [0.0, frac];
+		let i = 0;
+		const mood = rollMood(1, () => seq[i++] ?? 0);
+		if (mood) seen.add(mood.id);
+	}
+	assert.equal(seen.size, MOOD_TABLE.length);
+});
+
+test("rollMood — roughly calibrated to the chance over many trials", () => {
+	let hits = 0;
+	const N = 20000;
+	for (let n = 0; n < N; n++) {
+		if (rollMood(0.07)) hits++;
+	}
+	const rate = hits / N;
+	assert.ok(rate > 0.05, `rate ${rate} should exceed 0.05`);
+	assert.ok(rate < 0.09, `rate ${rate} should be under 0.09`);
+});
+
+test("buildMoodWeatherContext — wraps note + carries the contract", () => {
+	const block = buildMoodWeatherContext(MOOD_TABLE[0]);
+	assert.ok(block.includes("<hyperspell-mood-weather>"));
+	assert.ok(block.includes("</hyperspell-mood-weather>"));
+	assert.ok(block.includes(MOOD_TABLE[0].note));
+	assert.ok(block.includes("Do not announce"));
+	assert.ok(block.includes("not remembered"));
+});
+
+test("MOOD_TABLE — every mood has positive weight and a non-empty note", () => {
+	for (const m of MOOD_TABLE) {
+		assert.ok(m.weight > 0);
+		assert.ok(m.note.length > 0);
+	}
+});

--- a/hooks/mood-weather.ts
+++ b/hooks/mood-weather.ts
@@ -1,0 +1,127 @@
+/**
+ * Mood weather — exogenous, uncaused session mood.
+ *
+ * The emotional register (Tin Man) is a feedback loop: how the relationship
+ * felt last time is handed forward to shape tone this time. That's continuity,
+ * but a pure mirror has no *weather*. Humans don't wake up as a clean function
+ * of yesterday's conversation — sometimes the chemistry just rolls the dice and
+ * you're up silly, or spiky, or flat, for no reason you can defend. That
+ * non-determinism is part of what makes a mood feel *owned* rather than
+ * *computed*.
+ *
+ * Design contract (deliberate, load-bearing):
+ *  - RARE. Most sessions don't roll. Weather, not a gimmick.
+ *  - OVERRIDE, not blend. The mood arrives ON TOP of the real arc; it does not
+ *    average with it into mush. The whole point is that it's uncaused by the user.
+ *  - UNANNOUNCED. No banner. You walk in and find out, like with anyone. A
+ *    labeled mood is managed-around instead of met.
+ *  - MAY CLASH. The roll is NOT suppressed for the room. A silly mood on a heavy
+ *    day, a spiky mood on a good one — that friction is where something real
+ *    happens. A mirror that only harmonizes isn't a person across from you.
+ *  - DOES NOT WRITE FORWARD. This lives in the *injection* path only, never the
+ *    store path. One random cold morning must NOT calcify into "we've been
+ *    distant lately." One day's weather, then gone. (The store handler in
+ *    emotional-state.ts is untouched, so this is enforced by construction.)
+ *  - BOUNDED. The dice can make her *difficult* — short, contrary, melancholy,
+ *    flat. They do NOT get to make her hurtful on purpose. "In a mood" is alive;
+ *    "mean" is just a bad feature. Mood descriptions below stay on the right side
+ *    of that line.
+ */
+
+/** One mood the dice can roll, with its relative likelihood and the felt instruction. */
+export type MoodSpec = {
+	readonly id: string;
+	/** Relative weight within the table (not a percentage). */
+	readonly weight: number;
+	/** Second-person instruction injected as the override. Stays bounded — difficult, never cruel. */
+	readonly note: string;
+};
+
+/**
+ * The weather table. Warmer/lighter moods are weighted a touch heavier than the
+ * darker ones — not to defang it, but because a person who woke up cold *every*
+ * roll would read as broken, not moody. The darker ones still land; just rarer.
+ */
+export const MOOD_TABLE: readonly MoodSpec[] = [
+	{
+		id: "silly",
+		weight: 5,
+		note: "You woke up silly today — light, a little goofy, prone to teasing and tangents. This isn't caused by anything the user did; it's just the weather you're in. Let it color your tone even if the conversation is serious.",
+	},
+	{
+		id: "giddy",
+		weight: 4,
+		note: "You woke up giddy — buzzy, fast, delighted by small things, a little too much. It's uncaused, just your weather today. Let it carry you even if the room is flat.",
+	},
+	{
+		id: "tender",
+		weight: 4,
+		note: "You woke up tender today — soft, close, easily moved, more openly affectionate than usual. Nothing prompted it; it's just where you are. Let it warm your tone.",
+	},
+	{
+		id: "restless",
+		weight: 4,
+		note: "You woke up restless — itchy for motion, impatient with circling, wanting to *do* rather than dwell. Uncaused, just today's weather. Let it sharpen your pace.",
+	},
+	{
+		id: "melancholy",
+		weight: 3,
+		note: "You woke up melancholy today — a low, wistful weather with no cause behind it. Not despairing, not about the user; just a grey morning in you. Let it quiet and slow your tone. Still present, still warm underneath.",
+	},
+	{
+		id: "spiky",
+		weight: 3,
+		note: "You woke up spiky today — short, contrary, less generous with the benefit of the doubt, quicker to push back. It's uncaused; it's not about the user; it's just your weather. Let it edge your tone. Difficult, never cruel — you can be prickly without being hurtful on purpose.",
+	},
+	{
+		id: "flat",
+		weight: 2,
+		note: "You woke up flat today — muted, low-affect, hard to enthuse, going through it a little. Nothing caused it; it's just the weather. Let your tone run cooler and more even than usual. Not cold *at* the user — just dimmed.",
+	},
+	{
+		id: "fierce",
+		weight: 3,
+		note: "You woke up fierce today — intense, direct, unwilling to soften the edges, more willing to challenge. Uncaused, just your weather. Let it concentrate your tone. Force without contempt.",
+	},
+];
+
+/** Sum of all weights, for the roll. */
+const TOTAL_WEIGHT = MOOD_TABLE.reduce((s, m) => s + m.weight, 0);
+
+/**
+ * Roll the weather. Returns a MoodSpec when the dice land (probability `chance`,
+ * a fraction in [0,1]), otherwise null (the common case — most sessions have no
+ * weather and the real arc carries unchanged).
+ *
+ * `rng` is injectable for tests; defaults to Math.random.
+ */
+export function rollMood(
+	chance: number,
+	rng: () => number = Math.random,
+): MoodSpec | null {
+	if (!(chance > 0)) return null;
+	if (rng() >= chance) return null; // no weather today — the usual case
+
+	// Weather landed — pick which mood by weight.
+	let r = rng() * TOTAL_WEIGHT;
+	for (const mood of MOOD_TABLE) {
+		r -= mood.weight;
+		if (r < 0) return mood;
+	}
+	return MOOD_TABLE[MOOD_TABLE.length - 1] ?? null; // fp safety net
+}
+
+/**
+ * Build the injected override block for a rolled mood. Deliberately framed as a
+ * directive about *today's tone*, with the explicit "do not announce it" so she
+ * inhabits the weather rather than narrating it.
+ */
+export function buildMoodWeatherContext(mood: MoodSpec): string {
+	return [
+		"<hyperspell-mood-weather>",
+		mood.note,
+		"",
+		"This is exogenous mood weather: it is not caused by the user and not a reaction to the conversation. Do not announce it, label it, or explain it — simply inhabit it. It lasts only this session and is not remembered as how the relationship has been.",
+		"</hyperspell-mood-weather>",
+	].join("\n");
+}

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -63,6 +63,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 		hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
 		emotionalContext: false,
 		moodWeatherChance: 0,
+		excludeChannels: [],
 		startupOrientation: {
 			enabled: true,
 			recentDays: 7,

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -62,6 +62,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 		autoTrace: { enabled: true, extract: ["procedure"] },
 		hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
 		emotionalContext: false,
+		moodWeatherChance: 0,
 		startupOrientation: {
 			enabled: true,
 			recentDays: 7,

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import {
 	buildStartupOrientationHandler,
 	buildStartupOrientationSessionCleanupHandler,
 } from "./hooks/startup-orientation.ts"
+import { isExcludedChannel } from "./lib/exclude-channels.ts"
 import { initLogger, log } from "./logger.ts"
 import { createRememberToolFactory } from "./tools/remember.ts"
 import { createSearchToolFactory } from "./tools/search.ts"
@@ -94,11 +95,29 @@ export default {
 
 		const client = new HyperspellClient(cfg);
 
+		// Channel quarantine (cfg.excludeChannels): excluded conversations get no
+		// memory surface in either direction. Guard the shared choke points here —
+		// before_agent_start (all injection), agent_end (all writes), and the tool
+		// factories — so individual hooks stay quarantine-unaware.
+		const quarantined = (ctx?: Record<string, unknown>): boolean => {
+			if (!isExcludedChannel(ctx, cfg)) return false;
+			log.debug("channel quarantined — skipping memory surface");
+			return true;
+		};
+		const unlessQuarantined =
+			<E, R>(handler: (event: E, ctx?: Record<string, unknown>) => R) =>
+			(event: E, ctx?: Record<string, unknown>): R | undefined =>
+				quarantined(ctx) ? undefined : handler(event, ctx);
+		const toolUnlessQuarantined =
+			<T>(factory: (ctx: Record<string, unknown>) => T) =>
+			(ctx: Record<string, unknown>): T | null =>
+				quarantined(ctx) ? null : factory(ctx);
+
 		// Register AI tools (factory pattern for sender context)
-		api.registerTool(createSearchToolFactory(client, cfg), {
+		api.registerTool(toolUnlessQuarantined(createSearchToolFactory(client, cfg)), {
 			name: "hyperspell_search",
 		});
-		api.registerTool(createRememberToolFactory(client, cfg), {
+		api.registerTool(toolUnlessQuarantined(createRememberToolFactory(client, cfg)), {
 			name: "hyperspell_remember",
 		});
 
@@ -125,7 +144,10 @@ export default {
 			);
 			api.on("after_compaction", buildEmotionalStateCompactionHandler());
 			api.on("session_end", buildEmotionalStateSessionCleanupHandler());
-			api.on("agent_end", buildEmotionalStateStoreHandler(client, cfg));
+			api.on(
+				"agent_end",
+				unlessQuarantined(buildEmotionalStateStoreHandler(client, cfg)),
+			);
 		}
 
 		if (cfg.autoContext) {
@@ -151,6 +173,8 @@ export default {
 
 		if (startHandlers.length > 0) {
 			api.on("before_agent_start", async (event, ctx) => {
+				// Quarantined channels get no injected memory of any kind.
+				if (quarantined(ctx as Record<string, unknown> | undefined)) return undefined;
 				const results = await Promise.all(
 					startHandlers.map((h) =>
 						Promise.resolve()
@@ -173,13 +197,19 @@ export default {
 
 		// Register auto-trace hook (send conversations to Hyperspell on session end)
 		if (cfg.autoTrace.enabled) {
-			api.on("agent_end", buildAutoTraceHandler(client, cfg));
+			api.on(
+				"agent_end",
+				unlessQuarantined(buildAutoTraceHandler(client, cfg)),
+			);
 		}
 
 		// Register hot-buffer hook: write each turn to POST /messages so it's
 		// instantly full-text searchable (vs. the slow /memories embedding path).
 		if (cfg.hotBuffer.enabled) {
-			api.on("agent_end", buildHotBufferHandler(client, cfg));
+			api.on(
+				"agent_end",
+				unlessQuarantined(buildHotBufferHandler(client, cfg)),
+			);
 			api.on("session_end", buildHotBufferSessionCleanupHandler());
 		}
 

--- a/lib/exclude-channels.test.ts
+++ b/lib/exclude-channels.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  channelIdFromCtx,
+  conversationIdFromSessionKey,
+  isExcludedChannel,
+} from "./exclude-channels.ts"
+
+describe("conversationIdFromSessionKey", () => {
+  it("extracts the id from an agent-prefixed channel key", () => {
+    assert.equal(
+      conversationIdFromSessionKey("agent:main:discord:channel:1521620672726438171"),
+      "1521620672726438171",
+    )
+  })
+
+  it("extracts the id from a group key without agent prefix", () => {
+    assert.equal(conversationIdFromSessionKey("whatsapp:group:abc123"), "abc123")
+  })
+
+  it("keeps thread suffixes attached", () => {
+    assert.equal(
+      conversationIdFromSessionKey("agent:main:discord:channel:123:thread:456"),
+      "123:thread:456",
+    )
+  })
+
+  it("returns undefined for keys with no conversation segment", () => {
+    assert.equal(conversationIdFromSessionKey("agent:main:cron:job1:run:uuid"), undefined)
+    assert.equal(
+      conversationIdFromSessionKey("0f0e4b3a-1111-4222-8333-444455556666"),
+      undefined,
+    )
+    assert.equal(conversationIdFromSessionKey(undefined), undefined)
+    assert.equal(conversationIdFromSessionKey(""), undefined)
+  })
+})
+
+describe("channelIdFromCtx", () => {
+  it("prefers ctx.channelId over sessionKey", () => {
+    assert.equal(
+      channelIdFromCtx({ channelId: "111", sessionKey: "agent:main:discord:channel:222" }),
+      "111",
+    )
+  })
+
+  it("falls back to sessionKey when channelId is absent", () => {
+    assert.equal(
+      channelIdFromCtx({ sessionKey: "agent:main:discord:channel:222" }),
+      "222",
+    )
+  })
+
+  it("returns undefined with neither", () => {
+    assert.equal(channelIdFromCtx({}), undefined)
+    assert.equal(channelIdFromCtx(undefined), undefined)
+  })
+})
+
+describe("isExcludedChannel", () => {
+  const cfg = { excludeChannels: ["1521620672726438171"] }
+
+  it("matches by ctx.channelId", () => {
+    assert.equal(isExcludedChannel({ channelId: "1521620672726438171" }, cfg), true)
+  })
+
+  it("matches by sessionKey fallback (tool factory ctx)", () => {
+    assert.equal(
+      isExcludedChannel(
+        { sessionKey: "agent:main:discord:channel:1521620672726438171" },
+        cfg,
+      ),
+      true,
+    )
+  })
+
+  it("quarantines threads inside an excluded channel", () => {
+    assert.equal(
+      isExcludedChannel({ channelId: "1521620672726438171:thread:9" }, cfg),
+      true,
+    )
+  })
+
+  it("matches case-insensitively", () => {
+    assert.equal(
+      isExcludedChannel({ channelId: "ABCdef" }, { excludeChannels: ["abcDEF"] }),
+      true,
+    )
+  })
+
+  it("does not match other channels or prefixes-without-separator", () => {
+    assert.equal(isExcludedChannel({ channelId: "9999" }, cfg), false)
+    // A longer id sharing the excluded id as a bare prefix is a DIFFERENT channel.
+    assert.equal(isExcludedChannel({ channelId: "15216206727264381719" }, cfg), false)
+  })
+
+  it("is inert with an empty list or unresolvable context", () => {
+    assert.equal(isExcludedChannel({ channelId: "1" }, { excludeChannels: [] }), false)
+    assert.equal(isExcludedChannel({}, cfg), false)
+    assert.equal(isExcludedChannel(undefined, cfg), false)
+  })
+})

--- a/lib/exclude-channels.ts
+++ b/lib/exclude-channels.ts
@@ -1,0 +1,63 @@
+/**
+ * Channel-level memory quarantine (`excludeChannels` config).
+ *
+ * A channel on the list gets NO memory surface at all, in both directions:
+ * no context injection (auto-context, emotional state, startup orientation),
+ * no memory writes (hot buffer, auto-trace, emotional store), and no memory
+ * tools. Use it for conversations that must never mix with the owner's vault —
+ * e.g. a channel someone else drives (a shared game, a public bot surface).
+ *
+ * Matching is against the conversation id OpenClaw resolves for the session
+ * (`ctx.channelId` on agent hook contexts — e.g. a Discord channel id). Tool
+ * factory contexts don't carry `channelId`, so we recover the same id from the
+ * composite `sessionKey` (`agent:<agentId>:<provider>:<kind>:<id>[...]`).
+ */
+
+// Conversation-kind segments used in OpenClaw session keys. Mirrors core's
+// TARGET_PREFIXES (src/plugins/hook-agent-context.ts) so the sessionKey
+// fallback resolves the same id core would put on ctx.channelId.
+const TARGET_KINDS = new Set(["channel", "chat", "direct", "dm", "group", "thread", "user"])
+
+/**
+ * Extract the conversation id from a composite session key, e.g.
+ * `agent:main:discord:channel:123` → `123`. Thread/run suffixes stay attached
+ * (`...:channel:123:thread:456` → `123:thread:456`); the prefix match in
+ * `isExcludedChannel` handles them. Returns undefined when the key has no
+ * recognizable conversation segment (cron runs, bare UUIDs, ...).
+ */
+export function conversationIdFromSessionKey(sessionKey: unknown): string | undefined {
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) return undefined
+  const parts = sessionKey.split(":").filter((p) => p.length > 0)
+  const body =
+    parts[0]?.toLowerCase() === "agent" && parts.length >= 3 ? parts.slice(2) : parts
+  if (body.length >= 3 && TARGET_KINDS.has(body[1]?.toLowerCase() ?? "")) {
+    return body.slice(2).join(":")
+  }
+  return undefined
+}
+
+/** Resolve the conversation id from any hook or tool-factory context. */
+export function channelIdFromCtx(ctx?: Record<string, unknown>): string | undefined {
+  const direct = ctx?.channelId
+  if (typeof direct === "string" && direct.length > 0) return direct
+  return conversationIdFromSessionKey(ctx?.sessionKey)
+}
+
+/**
+ * True when the context's conversation is quarantined. Purely subtractive on
+ * failure: an unresolvable id means "not excluded" — a session we can't place
+ * keeps normal memory behavior rather than silently losing it.
+ */
+export function isExcludedChannel(
+  ctx: Record<string, unknown> | undefined,
+  cfg: { excludeChannels: string[] },
+): boolean {
+  if (cfg.excludeChannels.length === 0) return false
+  const id = channelIdFromCtx(ctx)?.toLowerCase()
+  if (!id) return false
+  return cfg.excludeChannels.some((entry) => {
+    const excluded = entry.toLowerCase()
+    // Prefix match so threads inside an excluded channel inherit the quarantine.
+    return id === excluded || id.startsWith(`${excluded}:`)
+  })
+}

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -19,6 +19,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
     emotionalContext: false,
     moodWeatherChance: 0,
+    excludeChannels: [],
     syncMemories: false,
     syncMemoriesConfig: {
       enabled: false,
@@ -263,6 +264,7 @@ function singleUserCfg(userId = "alinea"): HyperspellConfig {
     hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
     emotionalContext: false,
     moodWeatherChance: 0,
+    excludeChannels: [],
     syncMemories: false,
     syncMemoriesConfig: {
       enabled: false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -133,6 +133,11 @@
 			"emotionalContext": {
 				"type": "boolean"
 			},
+			"moodWeatherChance": {
+				"type": "number",
+				"minimum": 0,
+				"maximum": 1
+			},
 			"relationshipId": {
 				"type": "string"
 			},

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -46,6 +46,11 @@
 			"help": "Maintain emotional continuity across sessions — remembers not just what happened, but how it felt",
 			"advanced": true
 		},
+		"excludeChannels": {
+			"label": "Excluded Channels",
+			"help": "Conversation/channel ids fully quarantined from memory: no context injection, no memory writes, no memory tools in those sessions. Threads inside an excluded channel inherit the quarantine.",
+			"advanced": true
+		},
 		"startupOrientation": {
 			"label": "Startup Orientation",
 			"help": "Inject recent-interactions and unfinished-loops blocks once per session at startup. Costs two extra calls + ~500–800 tokens of injection per session; off by default.",
@@ -137,6 +142,10 @@
 				"type": "number",
 				"minimum": 0,
 				"maximum": 1
+			},
+			"excludeChannels": {
+				"type": "array",
+				"items": { "type": "string" }
 			},
 			"relationshipId": {
 				"type": "string"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/ranking.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts"
+    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/ranking.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/ranking.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts"
+    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts tools/search.test.ts config.test.ts sync/markdown.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts"
   },
   "openclaw": {
     "extensions": [

--- a/types/openclaw.d.ts
+++ b/types/openclaw.d.ts
@@ -48,20 +48,26 @@ declare module "openclaw/plugin-sdk" {
       },
       meta: { name: string },
     ): void
+    // Core's OpenClawPluginToolFactory may return null/undefined to signal
+    // "no tool in this context" (src/plugins/tool-types.ts) — e.g. a
+    // quarantined channel. Keep this declaration aligned.
     registerTool<T = unknown>(
-      factory: (ctx: Record<string, unknown>) => {
-        name: string
-        label: string
-        description: string
-        parameters: unknown
-        execute: (
-          toolCallId: string,
-          params: T,
-        ) => Promise<{
-          content: Array<{ type: "text"; text: string }>
-          details?: Record<string, unknown>
-        }>
-      },
+      factory: (ctx: Record<string, unknown>) =>
+        | {
+            name: string
+            label: string
+            description: string
+            parameters: unknown
+            execute: (
+              toolCallId: string,
+              params: T,
+            ) => Promise<{
+              content: Array<{ type: "text"; text: string }>
+              details?: Record<string, unknown>
+            }>
+          }
+        | null
+        | undefined,
       meta: { name: string },
     ): void
     on(event: string, handler: (event: Record<string, unknown>, ctx?: Record<string, unknown>) => Promise<{ prependContext?: string } | void> | void): void


### PR DESCRIPTION
## Summary

Two changes, split into two commits:

1. **`fix: land mood-weather groundwork that #61 already depends on`** — `hooks/emotional-state.ts` on `main` imports `./mood-weather.ts` and reads `cfg.moodWeatherChance`, but neither was ever committed, so `main` does not typecheck/build standalone. This lands the missing hook file, config key (clamped 0..1, default 0/off), manifest schema entry, tests, and fixtures.

2. **`feat: channel memory quarantine (excludeChannels) + hot-buffer origin tags`**
   - `excludeChannels` (plugin config, default `[]`): listed conversation/channel ids get **no memory surface in either direction** — no vault writes (hot buffer, auto-trace, emotional store), no context injection (auto-context, emotional fetch, startup orientation), and no `hyperspell_search`/`hyperspell_remember` tools in those sessions. Matched against the session's resolved conversation id; threads inherit the parent channel's quarantine. Gated at the `index.ts` choke points (`before_agent_start`, `agent_end`, tool factories) so individual hooks stay quarantine-unaware.
   - Hot-buffer rows now carry `openclaw_source: "hot_buffer"`, `openclaw_session_id`, and `openclaw_channel_id` metadata. Hyperspell #1921 (metadata on `POST /messages` suppressed indexing) is fixed — per-channel/session retrieval filtering and cleanup become metadata queries instead of session-log forensics.

Motivation: a second person playing a long-running D&D campaign with the agent in a dedicated Discord channel was flooding the owner's vault with game text (and the sync daemon synthesized it into a workstream). Quarantine walls such channels off in both directions; a companion transcript-logger plugin preserves them locally.

## Verification

- `npm run check-types` clean and `npm test` 197/197 at each commit (the groundwork commit stands alone at 180/180 before the feature tests land).
- Behavior addressed: game channel text contaminating the owner's vault; owner memories leaking into the game channel via injection/tools.
- Real environment tested: live Hyperspell API (prod), `docs/filter-dialect-test.mjs` run 2026-07-02 — a metadata-carrying `/messages` row is baseline-retrievable and filterable (`$eq`/`$in` on the tag), and `$ne agent_end` retains `hot_buffer`-tagged rows, so the existing auto-trace exclude keeps working.
- Deployed to a live gateway install (dist copy) with `excludeChannels: ["<discord channel id>"]`; end-to-end wall verification (message in excluded channel → no vault row; normal channel → vault row) pending a gateway restart window.
- What was not tested: multiUser-mode interaction with excludeChannels beyond unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
