### PR TITLE
chore: release 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperspell/openclaw-hyperspell",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
@@ -21,7 +21,7 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.17.1",
+      "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.17.1.tgz",
       "integrity": "sha512-yjyIn8POL18IOXioLySYiL0G44kZ/IZctAls7vS3AC3X+qLhFXbWmzABSZehwRnWFShMXT+ODa/HJG1+mGXZ1A==",
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "type": "module",
   "description": "OpenClaw Hyperspell memory plugin",
   "license": "MIT",


### PR DESCRIPTION
Version bump for 0.18.0: channel memory quarantine (excludeChannels), hot-buffer origin metadata tags, and the mood-weather groundwork fix (#62). Tag v0.18.0 follows after merge to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)