### PR TITLE
fix: sync package-lock with zod 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7658,9 +7658,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {


### PR DESCRIPTION
package.json requires zod@4.4.3 but the committed lock still had 4.3.6, so the release workflow's npm ci failed (v0.18.0 run 28608106365). Lock-only sync; diff is the single zod entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)