### PR TITLE
feat(ranking): near-duplicate diversity check in selection — Chorus

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,17 @@ to break ties, never to override a real relevance gap. Typos in weight keys
 are not schema errors (new backend sources must not fail validation); with
 `debug: true` unknown keys are flagged once at startup in `gateway.log`.
 
+Selected results are also checked against each other for **near-duplicates**:
+when the same memory exists in several forms (a re-synced doc section, a
+`remember` note quoting it, a curated copy of a hot-buffer row), every copy
+clears the threshold, none is chatter, and pre-dedup they filled multiple
+injection slots with one piece of information. Each candidate's lead text is
+compared against already-selected results by token overlap; above
+`dedupThreshold` (0.8) the copy is skipped and its slot passes to the
+next-ranked *different* memory. Skipped copies never consume the chatter
+quota. Set `dedupThreshold: 0` to disable. Paraphrased duplicates (same fact,
+different words) are beyond a string measure and out of scope.
+
 Age matters too, gently: results accrue a small **recency penalty** that grows
 with age (exponential decay, 90-day half-life by default) and is hard-capped at
 `recencyMaxPenalty` (0.1) so it can break near-ties toward current information
@@ -336,7 +347,7 @@ Tips:
   The `hyperspell_search` tool and `/getcontext` return raw relevance order —
   don't test `storyTerms` there and conclude it's broken.
 - To verify it's working, enable `debug: true` and watch `gateway.log` for the
-  per-search tally (`auto-context: ranked {...} candidates → selected {...}`) —
+  per-search tally (`auto-context: ranked {...} candidates → selected {...}`) and the cut tally (threshold / max-results / near-duplicate / chatter-quota) —
   it appears at default host log levels. The per-candidate lines
   (`[story] 0.47→0.82 The Lighthouse Keeper — Chapter 3`), which show story
   matches even when they lose to the threshold, are debug-level and also need
@@ -356,7 +367,8 @@ Full knobs and defaults:
   "recencyHalfLifeDays": 90,  // age at which half the recency penalty has accrued (0 = off)
   "recencyMaxPenalty": 0.1,   // ceiling on the recency penalty — a tiebreaker, never a burial
   "recencyCuratedFactor": 0.5, // kept memory (curated/story) ages at this fraction of the rate
-  "sourceWeights": {}         // per-source multiplier on base relevance; unlisted = 1.0
+  "sourceWeights": {},        // per-source multiplier on base relevance; unlisted = 1.0
+  "dedupThreshold": 0.8       // token-overlap ratio that skips a near-duplicate (0 = off)
 }
 ```
 

--- a/config.test.ts
+++ b/config.test.ts
@@ -464,3 +464,14 @@ test("parseConfig — explicit non-positive sourceWeights throw with the sources
     )
   }
 })
+
+test("parseConfig — dedupThreshold defaults to 0.8, clamps to [0,1]", () => {
+  assert.equal(parseConfig({ ...base, ranking: {} }).ranking.dedupThreshold, 0.8)
+  assert.equal(
+    parseConfig({ ...base, ranking: { dedupThreshold: 0 } }).ranking.dedupThreshold,
+    0,
+    "0 is a valid explicit off-switch",
+  )
+  assert.equal(parseConfig({ ...base, ranking: { dedupThreshold: 1.5 } }).ranking.dedupThreshold, 1)
+  assert.equal(parseConfig({ ...base, ranking: { dedupThreshold: -1 } }).ranking.dedupThreshold, 0)
+})

--- a/config.ts
+++ b/config.ts
@@ -348,6 +348,10 @@ function parseRanking(raw: unknown): RankingWeights {
 			),
 		),
 		sourceWeights: parseSourceWeights(r.sourceWeights),
+		dedupThreshold: Math.min(
+			1,
+			Math.max(0, num(r.dedupThreshold, DEFAULT_RANKING.dedupThreshold)),
+		),
 	};
 }
 

--- a/docs/proposals/09-result-diversity-dedup.md
+++ b/docs/proposals/09-result-diversity-dedup.md
@@ -1,0 +1,268 @@
+# Proposal 09 — Diversity/dedup check across the selected result set
+
+Idea #9 from the retrieval-relevance brainstorm ([#66](https://github.com/hyperspell/hyperspell-openclaw/issues/66)). Implementation guide only — no functional code in this PR.
+
+## 1. Summary
+
+`selectRanked` in `lib/ranking.ts` currently selects the top-N results purely by composite score, with a threshold cutoff and a chatter quota — but with no check that the selected items differ from each other. When several near-identical "curated" results exist on one theme (a re-synced doc, a memory saved in multiple forms, a journal entry quoted in a note), all of them can clear the threshold, none of them classify as chatter, and they fill every injection slot with the same information. This proposal adds a cheap, dependency-free near-duplicate check inside `selectRanked`: as each candidate is considered in score order, its top highlight text is compared against the top highlight texts of already-accepted results using a token overlap coefficient; candidates above a similarity threshold (default 0.8) are skipped — with `continue`, not `break` — so genuinely different lower-scored memory fills the freed slot. The check runs before the chatter-quota increment so a diversity-skipped chatter item never consumes quota.
+
+## 2. Problem
+
+The selection loop is `selectRanked` at `lib/ranking.ts:128-146`:
+
+```ts
+export function selectRanked(
+	ranked: RankedResult[],
+	maxResults: number,
+	threshold: number,
+	chatterQuota: number,
+): RankedResult[] {
+	const out: RankedResult[] = [];
+	let chatter = 0;
+	for (const r of ranked) {
+		if (r._composite < threshold) continue;
+		if (r._kind === "chatter") {
+			if (chatter >= chatterQuota) continue;
+			chatter++;
+		}
+		out.push(r);
+		if (out.length >= maxResults) break;
+	}
+	return out;
+}
+```
+
+Three gates exist — threshold, chatter quota, `maxResults` — and none of them looks at *content*. Two (or five) near-identical results on the same theme each individually pass all three gates:
+
+- They score high, so the threshold doesn't cut them.
+- They classify as `curated` via `classifyResult` (`lib/ranking.ts:75-88`) — real title, non-UUID resource id — so the chatter quota never applies. This is the key difference from the chatter-flood failure that `chatterQuota` was built for: none of these results individually looks like noise.
+- `maxResults` just counts them; it doesn't care that slots 1–4 say the same thing.
+
+Downstream, `formatSelected` in `hooks/auto-context.ts:75-96` formats whatever `selectRanked` returned (up to 2 highlights per result) into the injected context block. The dedup must happen in `selectRanked`, not `formatSelected`: skipping a duplicate during selection frees the slot for the next-ranked *different* result, whereas deduping at format time would just shrink the block and waste the slot.
+
+Concrete failure mode observed in the wild: a memory that exists both as a synced Drive doc section and as a `hyperspell remember` note (or a hot-buffer row later curated into a titled memory) surfaces twice, and the second copy displaces the one genuinely different memory that would have made the injection useful.
+
+## 3. Proposed design
+
+### 3.1 What text to compare
+
+Each result's **dedup key**: the text of its highest-scored highlight (`Highlight.text` from `client.ts`), falling back to `title ?? ""` when `highlights` is empty. This is exactly the text `formatSelected` would lead with, so "near-duplicate keys" ≈ "near-duplicate injected content". Comparing full concatenated highlights is possible but adds cost for little gain — the top highlight is what both copies of a duplicated memory match the query with.
+
+```ts
+export function dedupKey(r: SearchResult): string {
+	let best = "";
+	let bestScore = -1;
+	for (const h of r.highlights) {
+		const s = h.score ?? 0;
+		if (s > bestScore) {
+			bestScore = s;
+			best = h.text;
+		}
+	}
+	return best !== "" ? best : (r.title ?? "");
+}
+```
+
+### 3.2 Similarity measure: token **overlap coefficient**
+
+No embedding vectors exist client-side — only strings — and the repo has no NLP/similarity dependency (`@sinclair/typebox`, `hyperspell`, `@clack/prompts` only) and shouldn't grow one for this. The check also runs synchronously in the hot ranking path on every auto-context injection, over at most `maxResults × candidates` pairs (in practice ≤ ~10 × ~30 short strings). That rules anything fancy out and makes simple token-set math the right tool.
+
+Candidates considered:
+
+- **Normalized string equality** — too brittle: a re-saved memory usually differs by a date prefix, a trailing sentence, or whitespace.
+- **Substring containment** — catches snippet-of-larger-doc cases but misses "same text, one word edited", and is asymmetric/ad-hoc.
+- **Jaccard on token sets** (`|A∩B| / |A∪B|`) — good general measure, but it punishes length asymmetry: a 10-token highlight fully contained in a 40-token highlight scores Jaccard 0.25 despite being an obvious duplicate. Duplicated memories in this system frequently differ mainly by length (a note vs. the doc it quotes), so this is a real miss.
+- **Overlap coefficient on token sets** (`|A∩B| / min(|A|, |B|)`) — **recommended.** Same O(|A|+|B|) cost as Jaccard, dependency-free, and it treats containment as high similarity: the 10-in-40 case above scores 1.0. That matches the actual failure mode (same content at different granularities).
+
+Tokenization: lowercase, strip everything but letters/digits, split on whitespace, drop empty tokens, build a `Set`. Deliberately no stemming/stopwords — not worth the code for near-*duplicate* detection, where the shared text is literal.
+
+```ts
+function tokens(s: string): Set<string> {
+	return new Set(
+		s
+			.toLowerCase()
+			.replace(/[^\p{L}\p{N}\s]/gu, " ")
+			.split(/\s+/)
+			.filter((t) => t.length > 0),
+	);
+}
+
+export function nearDuplicate(a: string, b: string, threshold: number): boolean {
+	if (threshold <= 0) return false;
+	const ta = tokens(a);
+	const tb = tokens(b);
+	const min = Math.min(ta.size, tb.size);
+	if (min === 0) return false;
+	// Tiny keys (short titles, 2-3 common words) make overlap-coefficient
+	// trigger-happy; require exact token-set equality below 5 tokens.
+	if (min < 5) {
+		if (ta.size !== tb.size) return false;
+		for (const t of ta) if (!tb.has(t)) return false;
+		return true;
+	}
+	let inter = 0;
+	for (const t of ta) if (tb.has(t)) inter++;
+	return inter / min >= threshold;
+}
+```
+
+The `min < 5` guard is the mitigation for the overlap coefficient's one weakness (a 3-token key like "the writing notes" would otherwise "duplicate" any longer text containing those words).
+
+### 3.3 Near-duplicate threshold: **0.8**
+
+Chosen so that:
+
+- **≥ 0.8 catches** the target cases: identical text, identical-plus-a-date-prefix, one-sentence edits, and full containment (containment scores 1.0 under overlap coefficient regardless of length difference).
+- **< 0.8 spares** thematically related but distinct memories. Two different journal entries about the same project share vocabulary (names, project terms) but rarely share 80 % of one side's token *set* — token sets, not sequences, means shared topic words alone can't reach 0.8 unless the shorter text is mostly made of them, which the ≥5-token minimum plus real sentence structure makes unlikely.
+
+This is a judgment call, not a measurement; §6 makes it configurable so it can be tuned from debug logs without a release.
+
+### 3.4 Modified `selectRanked`
+
+Additive optional parameter — every existing call site and test keeps working unchanged, and `0` disables the check entirely:
+
+```ts
+export function selectRanked(
+	ranked: RankedResult[],
+	maxResults: number,
+	threshold: number,
+	chatterQuota: number,
+	dedupThreshold = 0,
+): RankedResult[] {
+	const out: RankedResult[] = [];
+	const keys: string[] = [];
+	let chatter = 0;
+	for (const r of ranked) {
+		if (r._composite < threshold) continue;
+		const key = dedupKey(r);
+		if (keys.some((k) => nearDuplicate(k, key, dedupThreshold))) continue;
+		if (r._kind === "chatter") {
+			if (chatter >= chatterQuota) continue;
+			chatter++;
+		}
+		out.push(r);
+		keys.push(key);
+		if (out.length >= maxResults) break;
+	}
+	return out;
+}
+```
+
+Load-bearing ordering decisions:
+
+1. **`continue`, not `break`, on a duplicate.** Iteration proceeds to the next-ranked candidate, so a genuinely different lower-scored result fills the freed slot. This is the whole point — the filter must *replace* duplicates with different content, not merely shrink the output.
+2. **Diversity check runs BEFORE the chatter-quota increment.** A chatter item skipped for diversity injects nothing, so it must not consume quota. If the order were quota-first, a duplicate chatter echo would burn a quota slot and then get diversity-skipped — silently blocking a later *distinct* chatter item. That's the double-count bug called out in the issue; the ordering above makes it structurally impossible. Symmetrically, an over-quota chatter item is skipped *after* the dedup check but its key is **not** recorded (only accepted results push to `keys`), so a quota-rejected echo can't shadow a later curated result that happens to share its text — dedup compares only against content that will actually be injected.
+3. **`keys` mirrors `out`** (push in lockstep). Dedup state is exactly "what was accepted", nothing more. `keys` is a parallel array rather than recomputing `dedupKey(out[i])` per comparison — keys are computed once per candidate.
+
+Cost: worst case `candidates × accepted` calls to `nearDuplicate`, each linear in the two token counts. With defaults (`maxResults` ~5–10, `candidateMultiplier: 3`) that's a few hundred set operations on short strings per injection — negligible next to the network search that precedes it.
+
+### 3.5 Config plumbing and the quota interaction summary
+
+- `RankingWeights` (`lib/ranking.ts:19-34`): add `/** Token-overlap ratio above which a candidate is skipped as a near-duplicate of an already-selected result. 0 disables. */ dedupThreshold: number`.
+- `DEFAULT_RANKING` (`lib/ranking.ts:36-44`): `dedupThreshold: 0.8`.
+- `parseRanking` in `config.ts:230-247`: `dedupThreshold: Math.min(1, Math.max(0, num(r.dedupThreshold, DEFAULT_RANKING.dedupThreshold)))`.
+- Call site `hooks/auto-context.ts:202-207`: pass `ranking.dedupThreshold` as the fifth argument. Extend the existing debug line at `hooks/auto-context.ts:215` to include a dedup-skip count (thread a counter out or recompute the tally) so threshold tuning has data.
+- `openclaw.plugin.json`: add the field to the ranking config schema alongside `chatterQuota`.
+
+Quota interaction, stated once as the invariant to test: **only accepted results consume chatter quota, and only accepted results participate in future dedup comparisons.** Skipped-for-any-reason candidates leave both counters/sets untouched.
+
+All new functions stay pure and side-effect-free, per `lib/ranking.ts` convention.
+
+## 4. Test plan
+
+New tests in `lib/ranking.test.ts`, matching existing fixture style (`mk`, and the `ranked(kind, composite, id)` helper at `lib/ranking.test.ts:86-91` — extended to accept highlight text). Run with `node --test --experimental-strip-types lib/ranking.test.ts`.
+
+```ts
+const rankedH = (
+	kind: RankedResult["_kind"],
+	composite: number,
+	id: string,
+	text: string,
+): RankedResult => ({
+	...mk({ resourceId: id, title: `note ${id}`, highlights: [{ id: "h", text, score: composite }] }),
+	_kind: kind,
+	_base: composite,
+	_composite: composite,
+});
+
+const THEME =
+	"Heath finally confronts Junii about the Omuerta binding and what it cost Tevre on the night of storms";
+
+test("selectRanked — five near-identical curated hits: today they flood, dedup caps them", () => {
+	const five = [
+		rankedH("curated", 0.9, "d1", THEME),
+		rankedH("curated", 0.88, "d2", `2026-02-09 — ${THEME}`),
+		rankedH("curated", 0.86, "d3", `${THEME}. She kept the letter.`),
+		rankedH("curated", 0.84, "d4", THEME.replace("finally", "at last")),
+		rankedH("curated", 0.82, "d5", THEME),
+	];
+	// Baseline: current behavior (dedup disabled) selects all up to maxResults.
+	assert.equal(selectRanked(five, 4, 0.6, 2).length, 4, "status quo floods the slots");
+	// Diversity filter collapses the theme to one entry.
+	const sel = selectRanked(five, 4, 0.6, 2, 0.8);
+	assert.equal(sel.length, 1);
+	assert.equal(sel[0].resourceId, "d1", "highest-ranked copy wins");
+});
+
+test("selectRanked — freed slot goes to genuinely different lower-scored content", () => {
+	const list = [
+		rankedH("curated", 0.9, "d1", THEME),
+		rankedH("curated", 0.88, "d2", `2026-02-09 — ${THEME}`),
+		rankedH("curated", 0.86, "d3", `${THEME}. She kept the letter.`),
+		rankedH("curated", 0.7, "k1", "Grocery run Thursday; Alinea prefers oat milk and dark rye"),
+	];
+	const sel = selectRanked(list, 2, 0.6, 2, 0.8);
+	assert.deepEqual(
+		sel.map((r) => r.resourceId),
+		["d1", "k1"],
+		"duplicates are skipped with continue, not break — k1 fills the freed slot",
+	);
+});
+
+test("selectRanked — a diversity-skipped chatter item does not consume chatter quota", () => {
+	const list = [
+		rankedH("chatter", 0.9, "c1", THEME),
+		rankedH("chatter", 0.88, "c2", `${THEME}.`), // near-dup of c1 → diversity-skipped
+		rankedH("chatter", 0.86, "c3", "we argued about whether the sandbox should allow git push"),
+		rankedH("curated", 0.7, "k1", "Grocery run Thursday; Alinea prefers oat milk and dark rye"),
+	];
+	const sel = selectRanked(list, 10, 0.6, 2, 0.8);
+	// If the quota were charged before the dedup skip, c2 would burn slot 2 and c3 would be blocked.
+	assert.deepEqual(sel.map((r) => r.resourceId), ["c1", "c3", "k1"]);
+	assert.equal(sel.filter((r) => r._kind === "chatter").length, 2);
+});
+
+test("selectRanked — over-quota chatter does not shadow later results in the dedup set", () => {
+	const list = [
+		rankedH("chatter", 0.9, "c1", "morning chatter about coffee"),
+		rankedH("chatter", 0.88, "c2", "afternoon chatter about trains"),
+		rankedH("chatter", 0.86, "c3", THEME), // over quota (quota=2) → skipped, key NOT recorded
+		rankedH("curated", 0.8, "k1", THEME), // must still be accepted
+	];
+	const sel = selectRanked(list, 10, 0.6, 2, 0.8);
+	assert.deepEqual(sel.map((r) => r.resourceId), ["c1", "c2", "k1"]);
+});
+
+test("nearDuplicate — containment counts, tiny keys require equality, 0 disables", () => {
+	assert.ok(nearDuplicate(THEME, `${THEME} and more happened after, much more, that evening`, 0.8));
+	assert.ok(!nearDuplicate("the writing notes", THEME, 0.8), "short key needs exact match");
+	assert.ok(!nearDuplicate(THEME, THEME, 0), "threshold 0 disables");
+});
+```
+
+Also verify (no code change needed, just assert): existing `selectRanked` tests at `lib/ranking.test.ts:93-113` pass untouched, proving the default-off parameter is backward compatible.
+
+## 5. Risks / tradeoffs
+
+- **False-positive dedup** (distinct memories skipped): two genuinely different memories that quote the same passage — e.g. two journal entries both citing one line of the manuscript — can exceed 0.8 overlap on their *top highlight* even though the underlying documents differ. Cost: one real memory silently dropped from injection. Mitigations: the ≥5-token guard, the high threshold, comparing only against *accepted* items (at most `maxResults` comparisons), and the debug-log skip count making over-firing visible. Residual risk is acceptable because the skipped item is by construction the lower-ranked of the pair and its information content largely survives via the accepted twin.
+- **False-negative dedup** (duplicates that slip through): paraphrased duplicates — same fact re-saved in different words, or summarized vs. verbatim — share little literal token overlap and won't be caught by any cheap string measure. This is a known ceiling of the approach: without client-side embeddings, semantic dedup isn't reachable, and shipping literal/containment dedup still removes the most common duplicate class (re-saves and re-syncs are near-verbatim). If paraphrase duplicates prove common in practice, that's a future server-side concern (dedup at write time in Hyperspell), not a reason to add an NLP dependency here.
+- **Top-highlight-only comparison**: two results could be duplicates on their *second* highlight while their top highlights differ. `formatSelected` injects up to 2 highlights, so some duplicated text can still co-occur. Accepted for v1 — comparing all-pairs of highlights quadruples the cost for a rarer case; revisit only with evidence.
+- **Ordering bias**: the highest-composite copy always wins the dedup contest. That's the right bias (it's the copy the ranker trusts most), but it means the *kind* of the surviving copy is score-determined — a chatter echo can outlive a curated twin if it outscores it post-penalty. Fine: the chatter quota still bounds echoes, and the information is identical by definition of the check.
+
+## 6. Rollout
+
+Make the threshold configurable as `ranking.dedupThreshold` (see §3.5), consistent with how `chatterQuota` and the boost weights are already exposed. **Default: `0.8`, enabled out of the box** — near-verbatim duplication is unambiguous enough that shipping it dark would just delay the benefit; `0` is the escape hatch (disables the check entirely and reproduces today's behavior exactly, which is also what keeps every existing caller/test green). Tuning path: watch the dedup-skip count in the extended `auto-context` debug line for a few days on a live install; if legitimate distinct memories are being skipped, raise toward 0.9; if obvious duplicates survive, consider lowering to 0.7 before considering measure changes.
+
+## 7. Effort estimate
+
+**S** — two small pure functions plus a five-line change to an existing pure function, one optional config field, one call-site argument, and tests; no I/O, no API surface, no migration.

--- a/eval/fixtures.ts
+++ b/eval/fixtures.ts
@@ -389,6 +389,43 @@ export const EVAL_CASES: EvalCase[] = [
 		},
 	},
 	{
+		name: "near-duplicate dedup: the re-saved memory yields its slot to different content",
+		note:
+			"Proposal 09's core case: the same memory exists as a synced doc section " +
+			"AND a remembered note — both curated, both clear every gate, and " +
+			"pre-dedup the copy displaced the one genuinely different memory. With " +
+			"dedupThreshold 0.8 the second copy (date-prefixed, so not string-equal) " +
+			"is skipped with continue and the quieter distinct note fills the slot.",
+		pool: [
+			curated(
+				"doc-omuerta",
+				"The Lady of Storms — Omuerta notes",
+				0.62,
+				"Heath finally confronts Junii about the Omuerta binding and what it cost Tevre on the night of storms",
+			),
+			curated(
+				"note-omuerta-copy",
+				"2026-02-09 — remembered",
+				0.6,
+				"2026-02-09 — Heath finally confronts Junii about the Omuerta binding and what it cost Tevre on the night of storms",
+			),
+			curated(
+				"note-grocery",
+				"Household notes",
+				0.55,
+				"Grocery run Thursday; Alinea prefers oat milk and dark rye",
+			),
+		],
+		weights: { ...DEFAULT_RANKING },
+		maxResults: 2,
+		threshold: 0.5,
+		expect: {
+			mustSelect: ["doc-omuerta", "note-grocery"],
+			mustNotSelect: ["note-omuerta-copy"],
+			order: [["doc-omuerta", "note-grocery"]],
+		},
+	},
+	{
 		name: "source weights: the journaled page outranks the same-topic titled aside",
 		note:
 			"Proposal 11's core case: a Notion doc and a Slack message with the SAME " +

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -84,6 +84,7 @@ export function runCase(c: EvalCase): CaseResult {
 		c.maxResults,
 		c.threshold,
 		c.weights.chatterQuota,
+		c.weights.dedupThreshold,
 	);
 	const ids = selected.map((r) => r.resourceId);
 

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -259,6 +259,7 @@ export function buildAutoContextHandler(
           cfg.maxResults,
           cfg.relevanceThreshold,
           ranking.chatterQuota,
+          ranking.dedupThreshold,
         )
         logScoreSamples(prompt, currentSessionId, "single", explained, cfg.relevanceThreshold)
         const selected = explained.filter((e) => e.selected).map((e) => e.result)

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_RANKING,
 	explainSelection,
 	kindTally,
+	nearDuplicate,
 	rerank,
 	type RankedResult,
 	scoreResult,
@@ -534,4 +535,105 @@ test("sourceWeights — empty map is a strict no-op (default behavior unchanged)
 	const r = mk({ title: "A note", resourceId: "n", score: 0.47 });
 	const { composite } = scoreResult(r, DEFAULT_RANKING);
 	assert.ok(Math.abs(composite - 0.67) < 1e-9, "0.47 + 0.2, bit-identical to pre-weighting");
+});
+
+// ---- diversity / near-duplicate dedup (proposal 09) ----
+
+const rankedH = (
+	kind: RankedResult["_kind"],
+	composite: number,
+	id: string,
+	text: string,
+): RankedResult => ({
+	...mk({ resourceId: id, title: `note ${id}`, highlights: [{ id: "h", text, score: composite }] }),
+	_kind: kind,
+	_base: composite,
+	_composite: composite,
+});
+
+const THEME =
+	"Heath finally confronts Junii about the Omuerta binding and what it cost Tevre on the night of storms";
+
+test("selectRanked — five near-identical curated hits: default-off floods, dedup collapses to one", () => {
+	const five = [
+		rankedH("curated", 0.9, "d1", THEME),
+		rankedH("curated", 0.88, "d2", `2026-02-09 — ${THEME}`),
+		rankedH("curated", 0.86, "d3", `${THEME}. She kept the letter.`),
+		rankedH("curated", 0.84, "d4", THEME.replace("finally", "at last")),
+		rankedH("curated", 0.82, "d5", THEME),
+	];
+	// Backward compat: the omitted parameter reproduces today's flood exactly.
+	assert.equal(selectRanked(five, 4, 0.6, 2).length, 4, "status quo floods the slots");
+	const sel = selectRanked(five, 4, 0.6, 2, 0.8);
+	assert.equal(sel.length, 1);
+	assert.equal(sel[0].resourceId, "d1", "highest-ranked copy wins");
+});
+
+test("selectRanked — freed slot goes to genuinely different lower-scored content", () => {
+	const list = [
+		rankedH("curated", 0.9, "d1", THEME),
+		rankedH("curated", 0.88, "d2", `2026-02-09 — ${THEME}`),
+		rankedH("curated", 0.86, "d3", `${THEME}. She kept the letter.`),
+		rankedH("curated", 0.7, "k1", "Grocery run Thursday; Alinea prefers oat milk and dark rye"),
+	];
+	const sel = selectRanked(list, 2, 0.6, 2, 0.8);
+	assert.deepEqual(
+		sel.map((r) => r.resourceId),
+		["d1", "k1"],
+		"duplicates are skipped with continue, not break — k1 fills the freed slot",
+	);
+});
+
+test("selectRanked — a diversity-skipped chatter item does not consume chatter quota", () => {
+	const list = [
+		rankedH("chatter", 0.9, "c1", THEME),
+		rankedH("chatter", 0.88, "c2", `${THEME}.`), // near-dup of c1 → diversity-skipped
+		rankedH("chatter", 0.86, "c3", "we argued about whether the sandbox should allow git push"),
+		rankedH("curated", 0.7, "k1", "Grocery run Thursday; Alinea prefers oat milk and dark rye"),
+	];
+	const sel = selectRanked(list, 10, 0.6, 2, 0.8);
+	// If the quota were charged before the dedup skip, c2 would burn slot 2 and c3 would be blocked.
+	assert.deepEqual(sel.map((r) => r.resourceId), ["c1", "c3", "k1"]);
+	assert.equal(sel.filter((r) => r._kind === "chatter").length, 2);
+});
+
+test("selectRanked — over-quota chatter does not shadow later results in the dedup set", () => {
+	const list = [
+		rankedH("chatter", 0.9, "c1", "morning chatter about coffee and half-remembered dreams"),
+		rankedH("chatter", 0.88, "c2", "afternoon chatter about trains and the queue at the station"),
+		rankedH("chatter", 0.86, "c3", THEME), // over quota (quota=2) → skipped, key NOT recorded
+		rankedH("curated", 0.8, "k1", THEME), // must still be accepted
+	];
+	const sel = selectRanked(list, 10, 0.6, 2, 0.8);
+	assert.deepEqual(sel.map((r) => r.resourceId), ["c1", "c2", "k1"]);
+});
+
+test("explainSelection — cut attribution: duplicate reads 'near-duplicate'; past a full cap it reads 'max-results'", () => {
+	const dupWithinCap = [
+		rankedH("curated", 0.9, "d1", THEME),
+		rankedH("curated", 0.88, "d2", `${THEME}.`),
+	];
+	assert.deepEqual(
+		explainSelection(dupWithinCap, 5, 0.6, 2, 0.8).map((e) => e.cut),
+		[null, "near-duplicate"],
+	);
+	// Cap already full: the dup would have been cut regardless — the cap, not
+	// the dedup, was the binding constraint (same semantics as chatter-quota).
+	const dupPastCap = [
+		rankedH("curated", 0.9, "a", "an entirely different first memory about the garden"),
+		rankedH("curated", 0.88, "d2", `${THEME}.`),
+		rankedH("curated", 0.86, "d3", THEME),
+	];
+	assert.deepEqual(
+		explainSelection(dupPastCap, 1, 0.6, 2, 0.8).map((e) => e.cut),
+		[null, "max-results", "max-results"],
+	);
+});
+
+test("nearDuplicate — containment counts, tiny keys require equality, 0 disables", () => {
+	assert.ok(nearDuplicate(THEME, `${THEME} and more happened after, much more, that evening`, 0.8));
+	assert.ok(!nearDuplicate("the writing notes", THEME, 0.8), "short key needs exact match");
+	assert.ok(!nearDuplicate(THEME, THEME, 0), "threshold 0 disables");
+	assert.ok(nearDuplicate("The Writing Notes!", "the writing notes", 0.8), "tiny keys: exact set equality matches");
+	assert.ok(!nearDuplicate("", THEME, 0.8), "empty key never duplicates");
 });

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -46,6 +46,10 @@ export type RankingWeights = {
 	 * boost/penalty). Keyed by Hyperspell source name; any source not listed —
 	 * including sources that don't exist yet — is neutral (1.0). */
 	sourceWeights: Record<string, number>;
+	/** Token-overlap ratio above which a candidate is skipped as a near-
+	 * duplicate of an already-SELECTED result (its slot passes to different
+	 * content). 0 disables the check. */
+	dedupThreshold: number;
 };
 
 export const DEFAULT_RANKING: RankingWeights = {
@@ -60,6 +64,7 @@ export const DEFAULT_RANKING: RankingWeights = {
 	recencyMaxPenalty: 0.1,
 	recencyCuratedFactor: 0.5,
 	sourceWeights: {},
+	dedupThreshold: 0.8,
 };
 
 const UUID_RE =
@@ -225,10 +230,65 @@ export function rerank(
 		.sort((a, b) => b._composite - a._composite);
 }
 
+/** The text a result would lead its injection with: its highest-scored
+ * highlight, falling back to the title. Near-duplicate KEYS ≈ near-duplicate
+ * injected content, which is exactly what the diversity check must catch. */
+export function dedupKey(r: SearchResult): string {
+	let best = "";
+	let bestScore = -1;
+	for (const h of r.highlights) {
+		const s = h.score ?? 0;
+		if (s > bestScore) {
+			bestScore = s;
+			best = h.text;
+		}
+	}
+	return best !== "" ? best : (r.title ?? "");
+}
+
+function tokens(s: string): Set<string> {
+	return new Set(
+		s
+			.toLowerCase()
+			.replace(/[^\p{L}\p{N}\s]/gu, " ")
+			.split(/\s+/)
+			.filter((t) => t.length > 0),
+	);
+}
+
+/**
+ * Token-set OVERLAP COEFFICIENT (|A∩B| / min|A|,|B|), not Jaccard: duplicated
+ * memories here typically differ mainly by length (a note vs the doc it
+ * quotes), and containment must read as duplication — 10 tokens fully inside
+ * 40 scores 1.0 here but only 0.25 under Jaccard. Dependency-free and linear;
+ * this runs synchronously in the ranking hot path.
+ */
+export function nearDuplicate(a: string, b: string, threshold: number): boolean {
+	if (threshold <= 0) return false;
+	const ta = tokens(a);
+	const tb = tokens(b);
+	const min = Math.min(ta.size, tb.size);
+	if (min === 0) return false;
+	// Tiny keys (short titles, 2-3 common words) make overlap-coefficient
+	// trigger-happy; require exact token-set equality below 5 tokens.
+	if (min < 5) {
+		if (ta.size !== tb.size) return false;
+		for (const t of ta) if (!tb.has(t)) return false;
+		return true;
+	}
+	let inter = 0;
+	for (const t of ta) if (tb.has(t)) inter++;
+	return inter / min >= threshold;
+}
+
 /** Why a candidate was cut from injection. Closed set — the tuning analysis
  * (proposal 02) and the chatter-quota instrumentation (proposal 03) both key
  * off it. */
-export type SelectionCut = "threshold" | "max-results" | "chatter-quota";
+export type SelectionCut =
+	| "threshold"
+	| "max-results"
+	| "near-duplicate"
+	| "chatter-quota";
 
 /** Selected entries carry `cut: null`; cut entries carry the binding reason.
  * Discriminated on `selected` so a cut entry can never lack a reason. */
@@ -252,8 +312,15 @@ export function explainSelection(
 	maxResults: number,
 	threshold: number,
 	chatterQuota: number,
+	dedupThreshold = 0,
 ): SelectionExplained[] {
 	const out: SelectionExplained[] = [];
+	// Dedup state is exactly "what was accepted": only SELECTED results record
+	// keys (and only they consume quota), so a skipped candidate — whatever cut
+	// it — can never shadow later different-kind content sharing its text, and
+	// a diversity-skipped chatter echo never burns a quota slot (proposal 09's
+	// double-count invariant).
+	const keys: string[] = [];
 	let chatter = 0;
 	let kept = 0;
 	for (const r of ranked) {
@@ -265,12 +332,21 @@ export function explainSelection(
 			out.push({ result: r, selected: false, cut: "max-results" });
 			continue;
 		}
+		// After max-results (a dup past a full cap was cut regardless — the cap
+		// was binding), before chatter-quota (a dup echo injects nothing, so the
+		// quota was not the binding constraint and must not be charged).
+		const key = dedupKey(r);
+		if (keys.some((k) => nearDuplicate(k, key, dedupThreshold))) {
+			out.push({ result: r, selected: false, cut: "near-duplicate" });
+			continue;
+		}
 		if (r._kind === "chatter" && chatter >= chatterQuota) {
 			out.push({ result: r, selected: false, cut: "chatter-quota" });
 			continue;
 		}
 		if (r._kind === "chatter") chatter++;
 		kept++;
+		keys.push(key);
 		out.push({ result: r, selected: true, cut: null });
 	}
 	return out;
@@ -293,8 +369,9 @@ export function selectRanked(
 	maxResults: number,
 	threshold: number,
 	chatterQuota: number,
+	dedupThreshold = 0,
 ): RankedResult[] {
-	return explainSelection(ranked, maxResults, threshold, chatterQuota)
+	return explainSelection(ranked, maxResults, threshold, chatterQuota, dedupThreshold)
 		.filter((e) => e.selected)
 		.map((e) => e.result);
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -77,7 +77,7 @@
 		},
 		"ranking": {
 			"label": "Composite Ranking",
-			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights }",
+			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights, dedupThreshold }",
 			"advanced": true
 		},
 		"debug": {
@@ -189,6 +189,7 @@
 					"recencyHalfLifeDays": { "type": "number", "minimum": 0, "maximum": 3650 },
 					"recencyMaxPenalty": { "type": "number", "minimum": 0, "maximum": 1 },
 					"recencyCuratedFactor": { "type": "number", "minimum": 0, "maximum": 1 },
+					"dedupThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
 					"sourceWeights": {
 						"type": "object",
 						"additionalProperties": { "type": "number", "exclusiveMinimum": 0, "maximum": 5 },

--- a/scripts/eval-retrieval.ts
+++ b/scripts/eval-retrieval.ts
@@ -73,6 +73,7 @@ async function main() {
 					cfg.maxResults,
 					cfg.relevanceThreshold,
 					cfg.ranking.chatterQuota,
+					cfg.ranking.dedupThreshold,
 				)
 			: // Membership rule of formatHighlightBullets (ranking off): top
 				// maxResults, doc score AND at least one highlight over threshold.


### PR DESCRIPTION
Implements `docs/proposals/09-result-diversity-dedup.md` (idea #9 from #66). **Chorus** — many voices, one line each: the same memory doesn't get to sing every part.

## What Problem This Solves

Selection had three gates (threshold, chatter quota, maxResults) and none looked at *content*. A memory existing in several forms — a re-synced doc section, a `remember` note quoting it, a curated copy of a hot-buffer row — cleared every gate with every copy and filled multiple injection slots with one piece of information, displacing the genuinely different memory that would have made the injection useful.

## Why This Change Was Made

Reconciled onto the Cutting Room refactor (#100): selection policy lives in `explainSelection`, so dedup ships as a new closed cut reason **`"near-duplicate"`** — the cut-tally diag line picks it up automatically, no logging fork. Similarity is a token-set **overlap coefficient** (`|A∩B| / min(|A|,|B|)`): dependency-free, linear, and containment reads as duplication (a 10-token note fully inside a 40-token doc scores 1.0; Jaccard says 0.25) — which is the actual failure shape. Keys under 5 tokens require exact token-set equality (short titles would otherwise be trigger-happy).

## User Impact

- Each candidate's lead text (top highlight, title fallback — exactly what `formatSelected` would inject) is compared against **already-selected** results; above `ranking.dedupThreshold` (default **0.8, on by default**) the copy is cut with `continue`, so its slot passes to the next-ranked *different* memory.
- Invariants: only accepted results record dedup keys and consume chatter quota — a diversity-skipped echo never burns quota; an over-quota echo never shadows a later curated twin; a dup past a full cap attributes `max-results` (it was cut regardless).
- `dedupThreshold: 0` disables and reproduces today's behavior exactly. Paraphrase duplicates (same fact, different words) are a known ceiling of any string measure — out of scope, noted in README.

## Evidence

- **The Ruler:** 15/15 → 16/16; all 15 pre-existing cases **byte-identical with dedup live at 0.8** (the harness now forwards `weights.dedupThreshold`, mirroring the production path).
- New eval case (re-saved memory yields its slot to different content) proven **fail-old/pass-new**: 15/16 on old `lib/ranking.ts`+harness, 16/16 on new.
- Tests 353 → 361: flood-collapse, freed-slot replacement, quota-not-charged, no-shadowing, cut-attribution precedence, `nearDuplicate` edge cases (containment, tiny-key equality, 0-disable, empty key), config clamp incl. explicit-0 off-switch. `tsc --noEmit` clean.