### PR TITLE
feat(ranking): opt-in elbow cutoff at natural score cliffs — Waterline

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,20 @@ next-ranked *different* memory. Skipped copies never consume the chatter
 quota. Set `dedupThreshold: 0` to disable. Paraphrased duplicates (same fact,
 different words) are beyond a string measure and out of scope.
 
+An optional **elbow cutoff** (`ranking.elbow`, **off by default**) stops
+injecting at a natural score cliff instead of always filling `maxResults`: a
+narrow query backed by 3 genuinely relevant memories no longer pads the
+context with a plateau of marginal ones that happen to clear the threshold.
+It is strictly conservative — it only ever cuts *earlier*, never later, never
+below `minResults` (default 3), and when no clear cliff exists (gradual
+decline, flat plateau) selection is identical to today. A cliff means the
+drop from the last accepted result is both large against the decline seen so
+far (`gapRatio` × mean gap, default 2.5×) *and* material in absolute terms
+(`minGap`, default 0.05). Before enabling, run
+`node --experimental-strip-types docs/elbow-scan.mjs` against your real data
+to check firing rate and cut depth (with `debug: true` the live verdict shows
+in `gateway.log` as `auto-context: elbow stopped at k (ceiling N)`).
+
 Age matters too, gently: results accrue a small **recency penalty** that grows
 with age (exponential decay, 90-day half-life by default) and is hard-capped at
 `recencyMaxPenalty` (0.1) so it can break near-ties toward current information
@@ -347,7 +361,7 @@ Tips:
   The `hyperspell_search` tool and `/getcontext` return raw relevance order —
   don't test `storyTerms` there and conclude it's broken.
 - To verify it's working, enable `debug: true` and watch `gateway.log` for the
-  per-search tally (`auto-context: ranked {...} candidates → selected {...}`) and the cut tally (threshold / max-results / near-duplicate / chatter-quota) —
+  per-search tally (`auto-context: ranked {...} candidates → selected {...}`) and the cut tally (threshold / max-results / elbow / near-duplicate / chatter-quota) —
   it appears at default host log levels. The per-candidate lines
   (`[story] 0.47→0.82 The Lighthouse Keeper — Chapter 3`), which show story
   matches even when they lose to the threshold, are debug-level and also need
@@ -368,7 +382,13 @@ Full knobs and defaults:
   "recencyMaxPenalty": 0.1,   // ceiling on the recency penalty — a tiebreaker, never a burial
   "recencyCuratedFactor": 0.5, // kept memory (curated/story) ages at this fraction of the rate
   "sourceWeights": {},        // per-source multiplier on base relevance; unlisted = 1.0
-  "dedupThreshold": 0.8       // token-overlap ratio that skips a near-duplicate (0 = off)
+  "dedupThreshold": 0.8,      // token-overlap ratio that skips a near-duplicate (0 = off)
+  "elbow": {                  // stop early at a natural score cliff (opt-in)
+    "enabled": false,
+    "minResults": 3,          // never cut below this many accepted results
+    "gapRatio": 2.5,          // cliff = drop >= this multiple of the mean gap so far...
+    "minGap": 0.05            // ...AND at least this big on the raw composite scale
+  }
 }
 ```
 

--- a/config.test.ts
+++ b/config.test.ts
@@ -475,3 +475,24 @@ test("parseConfig — dedupThreshold defaults to 0.8, clamps to [0,1]", () => {
   assert.equal(parseConfig({ ...base, ranking: { dedupThreshold: 1.5 } }).ranking.dedupThreshold, 1)
   assert.equal(parseConfig({ ...base, ranking: { dedupThreshold: -1 } }).ranking.dedupThreshold, 0)
 })
+
+test("parseConfig — elbow defaults off with documented parameters", () => {
+  const cfg = parseConfig({ ...base, ranking: {} })
+  assert.deepEqual(cfg.ranking.elbow, {
+    enabled: false,
+    minResults: 3,
+    gapRatio: 2.5,
+    minGap: 0.05,
+  })
+})
+
+test("parseConfig — elbow overrides respected; minResults clamps to >= 2, gapRatio to >= 1", () => {
+  const cfg = parseConfig({
+    ...base,
+    ranking: { elbow: { enabled: true, minResults: 1, gapRatio: 0.5, minGap: 0.08 } },
+  })
+  assert.equal(cfg.ranking.elbow.enabled, true)
+  assert.equal(cfg.ranking.elbow.minResults, 2, "one gap must exist before meanGap is defined")
+  assert.equal(cfg.ranking.elbow.gapRatio, 1)
+  assert.equal(cfg.ranking.elbow.minGap, 0.08)
+})

--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { DEFAULT_RANKING, type RankingWeights } from "./lib/ranking.ts";
+import {
+	DEFAULT_ELBOW,
+	DEFAULT_RANKING,
+	type ElbowOptions,
+	type RankingWeights,
+} from "./lib/ranking.ts";
 
 export type HyperspellSource =
 	| "reddit"
@@ -352,6 +357,20 @@ function parseRanking(raw: unknown): RankingWeights {
 			1,
 			Math.max(0, num(r.dedupThreshold, DEFAULT_RANKING.dedupThreshold)),
 		),
+		elbow: parseElbow(r.elbow),
+	};
+}
+
+function parseElbow(raw: unknown): ElbowOptions {
+	const e = (raw ?? {}) as Record<string, unknown>;
+	const num = (v: unknown, d: number) => (typeof v === "number" ? v : d);
+	return {
+		enabled: (e.enabled as boolean) ?? DEFAULT_ELBOW.enabled,
+		// >= 2: at least one gap must exist before meanGap is defined (the
+		// first accepted result never records a gap).
+		minResults: Math.max(2, num(e.minResults, DEFAULT_ELBOW.minResults)),
+		gapRatio: Math.max(1, num(e.gapRatio, DEFAULT_ELBOW.gapRatio)),
+		minGap: Math.max(0, num(e.minGap, DEFAULT_ELBOW.minGap)),
 	};
 }
 

--- a/docs/elbow-scan.mjs
+++ b/docs/elbow-scan.mjs
@@ -1,0 +1,153 @@
+// Elbow-cutoff live score-distribution scan (proposal 13, PR #91).
+//
+// OWNER-RUN validation instrument: the elbow ships OFF by default, and this
+// script is how real parameters get picked before anyone flips it on. It runs
+// real prompts through the EXACT production pipeline — HyperspellClient-style
+// search + rerank imported from ../lib/ranking.ts, never a reimplementation —
+// and prints each query's descending composite curve with per-pair gaps,
+// annotated with where the threshold falls, where the fixed maxResults cutoff
+// falls, and where each candidate elbow parameterization would stop.
+//
+// Acceptance bar (proposal 13 §4.1): on ~30-50 real prompts, eyeball each
+// distribution and mark where "the rest isn't really relevant"; a good
+// parameterization (a) fires on a meaningful fraction of narrow queries,
+// (b) lands within ±1 of your mark when it fires, and (c) essentially never
+// fires on broad queries where everything is decent. No parameterization
+// passing that bar → the feature stays off (and should be removed, not left
+// as dead config).
+//
+// Usage:
+//   node --experimental-strip-types docs/elbow-scan.mjs                 # built-in prompt mix
+//   node --experimental-strip-types docs/elbow-scan.mjs --prompts f.txt # newline-delimited prompts
+//   node --experimental-strip-types docs/elbow-scan.mjs -o scan.json    # JSON for parameter sweeps
+//
+// Reads the live plugin config (apiKey/userId/ranking/maxResults/threshold)
+// from ~/.openclaw/openclaw.json exactly like docs/hotbuffer-verify.mjs.
+
+import fs from "node:fs"
+import Hyperspell from "hyperspell"
+import { rerank, selectRanked } from "../lib/ranking.ts"
+
+const cfgAll = JSON.parse(fs.readFileSync(process.env.HOME + "/.openclaw/openclaw.json", "utf8"))
+const cfg = cfgAll.plugins.entries["openclaw-hyperspell"].config
+const client = new Hyperspell({ apiKey: cfg.apiKey, userID: cfg.userId })
+
+const args = process.argv.slice(2)
+const promptsFile = args[args.indexOf("--prompts") + 1]
+const jsonOut = args.includes("-o") ? args[args.indexOf("-o") + 1] : null
+
+const BUILTIN_PROMPTS = [
+  // narrow — a clear "right answer" should exist
+  "what is Heath's relationship to Junii",
+  "what did the Omuerta binding cost Tevre",
+  "what editor config do I use",
+  "when is the D&D session",
+  // broad — many decent memories, elbow should NOT fire
+  "what have we been working on lately",
+  "how has the writing been going",
+  "what do we usually talk about in the evenings",
+]
+
+const prompts =
+  args.includes("--prompts") && promptsFile
+    ? fs.readFileSync(promptsFile, "utf8").split("\n").map((l) => l.trim()).filter(Boolean)
+    : BUILTIN_PROMPTS
+
+// The sweep grid from proposal 13 §4.1.
+const GRID = []
+for (const gapRatio of [2, 2.5, 3])
+  for (const minGap of [0.03, 0.05, 0.08])
+    GRID.push({ enabled: true, minResults: 3, gapRatio, minGap })
+
+const ranking = {
+  // Live weights, with parse-time defaults mirrored for any field the live
+  // config omits (parseRanking isn't importable without the full config module
+  // graph; keep this list in sync with DEFAULT_RANKING).
+  enabled: true,
+  curationBoost: 0.2,
+  chatterPenalty: 0.2,
+  storyBoost: 0.15,
+  storyTerms: [],
+  candidateMultiplier: 3,
+  chatterQuota: 2,
+  recencyHalfLifeDays: 90,
+  recencyMaxPenalty: 0.1,
+  recencyCuratedFactor: 0.5,
+  sourceWeights: {},
+  dedupThreshold: 0.8,
+  elbow: { enabled: false, minResults: 3, gapRatio: 2.5, minGap: 0.05 },
+  ...(cfg.ranking ?? {}),
+}
+const maxResults = cfg.maxResults ?? 10
+const threshold = cfg.relevanceThreshold ?? 0.4
+
+const report = []
+for (const prompt of prompts) {
+  // Same call + mapping shape as HyperspellClient.search (client.ts).
+  const res = await client.memories.search(
+    {
+      query: prompt,
+      ...(Array.isArray(cfg.sources) && cfg.sources.length > 0 ? { sources: cfg.sources } : {}),
+      options: { max_results: maxResults * ranking.candidateMultiplier },
+    },
+    cfg.userId ? { headers: { "X-As-User": cfg.userId } } : undefined,
+  )
+  const results = (res.documents ?? []).map((doc) => ({
+    resourceId: doc.resource_id,
+    title: doc.title ?? null,
+    source: doc.source,
+    score: doc.score ?? null,
+    url: doc.metadata?.url ?? null,
+    createdAt: doc.metadata?.created_at ?? null,
+    highlights: (doc.highlights ?? []).map((h) => ({
+      id: h.id,
+      score: h.score,
+      text: h.text,
+    })),
+  }))
+  const ranked = rerank(results, ranking)
+  const baseSel = selectRanked(ranked, maxResults, threshold, ranking.chatterQuota, ranking.dedupThreshold)
+
+  const stops = GRID.map((elbow) => ({
+    elbow,
+    stop: selectRanked(ranked, maxResults, threshold, ranking.chatterQuota, ranking.dedupThreshold, elbow).length,
+  }))
+
+  console.log(`\n=== ${prompt}`)
+  let prev = null
+  ranked.forEach((r, i) => {
+    const gap = prev === null ? "" : `  (gap ${(prev - r._composite).toFixed(3)})`
+    const marks = [
+      i === baseSel.length ? "← fixed cutoff" : "",
+      r._composite < threshold && (prev === null || prev >= threshold) ? "← threshold line" : "",
+      ...stops.filter((s) => s.stop === i).map((s) => `← elbow(${s.elbow.gapRatio}/${s.elbow.minGap})`),
+    ].filter(Boolean).join("  ")
+    console.log(
+      `  ${String(i + 1).padStart(2)}. ${r._composite.toFixed(3)} [${r._kind}] ${(r.title ?? r.resourceId).slice(0, 55)}${gap}  ${marks}`,
+    )
+    prev = r._composite
+  })
+  report.push({
+    prompt,
+    baseline: baseSel.length,
+    curve: ranked.map((r) => ({ id: r.resourceId, kind: r._kind, composite: r._composite })),
+    stops: stops.map((s) => ({ gapRatio: s.elbow.gapRatio, minGap: s.elbow.minGap, stop: s.stop })),
+  })
+}
+
+// Aggregate: firing rate + median cut per parameterization.
+console.log("\n=== sweep aggregate")
+for (const g of GRID) {
+  const rows = report.map((r) => r.stops.find((s) => s.gapRatio === g.gapRatio && s.minGap === g.minGap))
+  const fired = report.filter((r, i) => rows[i].stop < r.baseline)
+  const cuts = fired.map((r) => r.stops.find((s) => s.gapRatio === g.gapRatio && s.minGap === g.minGap).stop).sort((a, b) => a - b)
+  const median = cuts.length ? cuts[Math.floor(cuts.length / 2)] : "-"
+  console.log(
+    `  gapRatio ${g.gapRatio} minGap ${g.minGap}: fired on ${fired.length}/${report.length} queries (${Math.round((100 * fired.length) / report.length)}%), median cut at ${median}`,
+  )
+}
+
+if (jsonOut) {
+  fs.writeFileSync(jsonOut, JSON.stringify({ maxResults, threshold, ranking, report }, null, 2))
+  console.log(`\nwrote ${jsonOut}`)
+}

--- a/docs/proposals/13-elbow-based-cutoff.md
+++ b/docs/proposals/13-elbow-based-cutoff.md
@@ -1,0 +1,260 @@
+# Proposal 13 — Elbow-based dynamic cutoff instead of a fixed `maxResults`
+
+> Idea #13 from the retrieval-relevance brainstorm ([#66](https://github.com/hyperspell/hyperspell-openclaw/issues/66)).
+> This is an implementation guide, not an implementation. No functional code changes ship with this PR.
+
+## 1. Summary
+
+`selectRanked` today stops injecting memories at a fixed count (`maxResults`, default 10) plus a flat score threshold — it has no notion of *where the signal actually runs out* for a given query. This proposal adds a cheap, online "elbow" rule to `selectRanked`: while accepting results, track the average score drop between consecutive accepted results, and stop early when the next drop is both a large multiple of that average **and** big in absolute terms — but never before a minimum-results floor, and never in a way that returns more than the existing threshold/quota/`maxResults` logic would. The elbow can only cut *earlier*; when no clear cliff exists, behavior is byte-for-byte identical to today. It ships behind a config flag (`ranking.elbow.enabled`, default `false`) and is validated against real score distributions collected by a small live-client script before any default change.
+
+## 2. Problem
+
+The stopping rule in `lib/ranking.ts` is purely a fixed count plus a flat threshold. `selectRanked` (`lib/ranking.ts:128-146`) is, in full:
+
+```ts
+export function selectRanked(
+	ranked: RankedResult[],
+	maxResults: number,
+	threshold: number,
+	chatterQuota: number,
+): RankedResult[] {
+	const out: RankedResult[] = [];
+	let chatter = 0;
+	for (const r of ranked) {
+		if (r._composite < threshold) continue;
+		if (r._kind === "chatter") {
+			if (chatter >= chatterQuota) continue;
+			chatter++;
+		}
+		out.push(r);
+		if (out.length >= maxResults) break;
+	}
+	return out;
+}
+```
+
+The input is already sorted descending by composite score (`rerank`, `lib/ranking.ts:106-120`). So the three stopping conditions today are:
+
+1. **Flat threshold** — `if (r._composite < threshold) continue` (line 137)
+2. **Chatter quota** — skip chatter beyond `chatterQuota` (lines 138-141)
+3. **Fixed count** — `if (out.length >= maxResults) break` (line 143)
+
+None of these look at the *shape* of the score curve. Two failure modes follow:
+
+- **Narrow query, thin signal**: 2 genuinely relevant memories at composite 0.82/0.80, then a cliff down to a plateau of marginal 0.55-ish results that still clear the default threshold. Today all of them are injected up to 10, padding the context with near-noise.
+- **Broad query, wide signal**: 15 comparably good candidates; the fixed cap truncates at 10. (This proposal does **not** fix the broad case — the elbow only cuts earlier, never later. Raising the ceiling is a separate, deliberate decision; see §5.)
+
+The single-user auto-context path already sets the elbow up to have something to work with: when ranking is enabled it fetches a widened candidate pool of `cfg.maxResults * ranking.candidateMultiplier` (`hooks/auto-context.ts:189-191`, default multiplier 3 → 30 candidates) and calls `selectRanked(ranked, cfg.maxResults, cfg.relevanceThreshold, ranking.chatterQuota)` (`hooks/auto-context.ts:202-207`). Config surface: `maxResults` defaults to 10 (`config.ts:575`), bounded 1-20 by the manifest schema (`openclaw.plugin.json:166-170`); ranking weights are parsed by `parseRanking` (`config.ts:230-247`) against the `ranking` schema object (`openclaw.plugin.json:171-184`).
+
+Scope note: the multi-user path formats personal/shared sections via `formatHighlightBullets`, not `selectRanked` (`hooks/auto-context.ts:334-356`), so the elbow initially applies only where composite ranking applies — the single-user ranked path. That is also where the chatter problem this brainstorm targets actually lives.
+
+## 3. Proposed design
+
+### 3.1 The elbow rule
+
+Work *online, inside the accept loop*, over the results actually accepted so far (post-threshold, post-quota) — not over the raw ranked list. For a small list (~10-30 candidates) this is O(1) extra work per candidate and needs no second pass, no derivatives, no kneedle-style curve fitting.
+
+Definitions, at the moment candidate `r` is about to be accepted:
+
+- `gap` = `out[out.length - 1]._composite - r._composite` — the drop from the last *accepted* result to this candidate.
+- `gapSum` = running sum of the gaps recorded when each accepted result (after the first) was pushed; `meanGap = gapSum / (out.length - 1)`.
+
+**Stop (break) before accepting `r` iff all of:**
+
+1. `elbow.enabled` is true,
+2. `out.length >= elbow.minResults` — the floor has been met (see §3.3),
+3. `gap >= elbow.minGap` — the drop is big in *absolute* terms (default `0.05`),
+4. `gap >= elbow.gapRatio * meanGap` — the drop is big *relative* to the decline seen so far (default ratio `2.5`).
+
+Condition 3 is what keeps a nearly-flat list from tripping the ratio test: if the accepted scores are 0.71, 0.709, 0.708, `meanGap` is ~0.001 and a routine 0.01 wobble would exceed `2.5 × meanGap` — but it cannot exceed the 0.05 absolute floor, so no elbow fires. Condition 4 is what keeps a *steadily* declining list from tripping the absolute test: gaps of exactly 0.05 each give `meanGap = 0.05`, and the next 0.05 gap fails `>= 0.125`. Both conditions must hold — the elbow fires only on a drop that is an outlier against the local trend *and* material on the raw score scale. Condition 4 is also trivially true when `meanGap` is 0 (all accepted scores equal), which is exactly right: any material drop off a flat plateau is a cliff, and condition 3 still gates it.
+
+Worked example (the narrow-query case): composites `[0.85, 0.82, 0.80, 0.55, 0.53, 0.52, …]`, `minResults = 3`. After accepting three, `gapSum = 0.03 + 0.02 = 0.05`, `meanGap = 0.025`. Candidate 4 has `gap = 0.25`: `0.25 >= 0.05` ✓ and `0.25 >= 2.5 × 0.025 = 0.0625` ✓ → stop with 3 results instead of padding to 10.
+
+Gradual-decline example: `[0.85, 0.80, 0.75, 0.70, 0.65, …]`. Every gap is 0.05; `meanGap` stays 0.05; the ratio test needs 0.125 and never sees it → the elbow never fires and selection proceeds exactly as today, out to `maxResults`/threshold.
+
+### 3.2 Composition with the existing stopping conditions
+
+The elbow is a **strictly earlier** `break` inserted into the existing loop. Nothing else moves:
+
+- The `threshold` skip (`continue`) runs first, unchanged. Results the threshold rejects are never accepted, never counted, and never contribute gaps.
+- The elbow check runs next, *before* the chatter-quota bookkeeping, so an elbow break never increments the chatter counter for a result it refuses. (Ordering vs. the quota check is otherwise immaterial: scores are sorted descending, so if the gap to *this* candidate clears the elbow, the gap to any later-accepted candidate is at least as large — the elbow would fire there anyway.)
+- The chatter quota skip runs unchanged.
+- `if (out.length >= maxResults) break` runs unchanged — **`maxResults` becomes the ceiling, the elbow an optional earlier stop.** No change to the `maxResults` schema or its meaning when the elbow is off.
+
+Because the elbow can only `break` and never `push`, it can never force MORE results than threshold + quota + `maxResults` allow. Because it is gated on `out.length >= minResults`, and because when it never fires the loop is untouched, `selectRanked` with `elbow.enabled: false` (or with `elbow` omitted) is behavior-identical to today — this satisfies the repo rule that the change must be strictly conservative and can never return zero results merely because no elbow was found. If the pool is thin (fewer than `minResults` clear the threshold), the elbow simply never activates and the caller gets exactly what today's logic gives.
+
+One subtlety worth a code comment: when the threshold or quota skips candidates *between* two accepted results, the recorded gap spans the skipped rows and looks larger than the raw adjacent-pair drop. That is intentional — the gap that matters is between results that could actually be injected — but it means quota-skipped chatter mildly increases the chance the elbow fires just after it. Acceptable: the skipped rows were never injectable anyway.
+
+### 3.3 The minimum-results floor
+
+`elbow.minResults`, default **3**, clamped to `>= 2` in `parseRanking` (at least one gap must exist before `meanGap` is defined; the first accepted result never records a gap). The elbow check is skipped entirely until `out.length >= minResults`, so even a pathological distribution like `[0.95, 0.40, 0.38, 0.37, …]` — a huge gap right after the first result — still yields at least 3 results (threshold permitting): the 0.55 drop between #1 and #2 is never examined because `out.length` is 1 at that point. The elbow can therefore never cut to 0 or 1 results; the only things that can are the pre-existing threshold and pool size, exactly as today.
+
+### 3.4 Code sketch
+
+New type + default in `lib/ranking.ts` (stays pure, no side effects):
+
+```ts
+export type ElbowOptions = {
+	enabled: boolean;
+	/** Never stop before this many accepted results (clamped >= 2). */
+	minResults: number;
+	/** Fire only if the drop is this multiple of the mean accepted-gap so far. */
+	gapRatio: number;
+	/** Fire only if the drop is at least this big in absolute composite terms. */
+	minGap: number;
+};
+
+export const DEFAULT_ELBOW: ElbowOptions = {
+	enabled: false,
+	minResults: 3,
+	gapRatio: 2.5,
+	minGap: 0.05,
+};
+```
+
+Modified `selectRanked` — the new parameter is optional, so every existing call site and test compiles and behaves unchanged:
+
+```ts
+export function selectRanked(
+	ranked: RankedResult[],
+	maxResults: number,
+	threshold: number,
+	chatterQuota: number,
+	elbow?: ElbowOptions,
+): RankedResult[] {
+	const out: RankedResult[] = [];
+	let chatter = 0;
+	let gapSum = 0;
+	for (const r of ranked) {
+		if (r._composite < threshold) continue;
+		if (elbow?.enabled && out.length >= Math.max(2, elbow.minResults)) {
+			const gap = out[out.length - 1]._composite - r._composite;
+			// Cliff = outlier vs the decline so far AND material in absolute terms;
+			// the two-part test keeps flat lists (tiny meanGap) and steady declines
+			// (every gap "big") from tripping it.
+			if (gap >= elbow.minGap && gap >= elbow.gapRatio * (gapSum / (out.length - 1)))
+				break;
+		}
+		if (r._kind === "chatter") {
+			if (chatter >= chatterQuota) continue;
+			chatter++;
+		}
+		if (out.length > 0) gapSum += out[out.length - 1]._composite - r._composite;
+		out.push(r);
+		if (out.length >= maxResults) break;
+	}
+	return out;
+}
+```
+
+Plumbing (all mechanical):
+
+- `RankingWeights` in `lib/ranking.ts` gains `elbow: ElbowOptions`; `DEFAULT_RANKING` gains `elbow: DEFAULT_ELBOW`.
+- `parseRanking` (`config.ts:230-247`) parses the nested object: `enabled` boolean defaulting false, `minResults: Math.max(2, num(...))`, `gapRatio: Math.max(1, num(...))`, `minGap: Math.max(0, num(...))`.
+- The single-user call site (`hooks/auto-context.ts:202-207`) passes `ranking.elbow` as the fifth argument, and the existing ranked-injection debug line gains the elbow verdict, e.g. `elbow stopped at 3 (ceiling 10)` vs `elbow: no cliff` — this log line is the primary live-validation instrument (§6).
+- `openclaw.plugin.json` `ranking` schema object (`lines 171-184`) gains:
+
+```json
+"elbow": {
+	"type": "object",
+	"additionalProperties": false,
+	"description": "Stop injecting early at a natural score cliff instead of always filling maxResults. Conservative: only ever cuts earlier, never later; falls back to plain maxResults/threshold when no clear cliff exists.",
+	"properties": {
+		"enabled": { "type": "boolean" },
+		"minResults": { "type": "number", "minimum": 2, "maximum": 20 },
+		"gapRatio": { "type": "number", "minimum": 1, "maximum": 10 },
+		"minGap": { "type": "number", "minimum": 0, "maximum": 1 }
+	}
+}
+```
+
+plus a matching `uiHints` entry if the other `ranking` fields have one.
+
+## 4. Test plan
+
+### 4.1 Live score-distribution collection (validates the idea, not just the code)
+
+Add `docs/elbow-scan.mjs`, mirroring the existing live-client scripts (`docs/hotbuffer-verify.mjs` pattern: read `~/.openclaw/openclaw.json` → `plugins.entries["openclaw-hyperspell"].config` for `apiKey`/`userId`, construct the `hyperspell` client directly). Run with `node --experimental-strip-types docs/elbow-scan.mjs` so it can import `rerank`/`selectRanked` straight from `../lib/ranking.ts` and score with the *exact* production math rather than a reimplementation.
+
+Per query it should:
+
+1. Read a batch of real prompts — from a `--prompts <file>` newline-delimited file (e.g. pulled from recent session transcripts), falling back to a small built-in mix of narrow ("what is Heath's relationship to Junii") and broad ("what have we been working on lately") queries.
+2. Search with `limit = maxResults * candidateMultiplier` and the live config's filter, exactly as `hooks/auto-context.ts:189-193` does.
+3. `rerank` with the live config's weights and print the full descending composite list with per-pair gaps, annotated with three markers: where the current fixed cutoff (10) falls, where each candidate elbow parameterization would stop, and the threshold line.
+4. Emit JSON (`-o` flag) so parameter sweeps are scriptable: for a grid of `gapRatio ∈ {2, 2.5, 3}` × `minGap ∈ {0.03, 0.05, 0.08}`, report per-query stop index and an aggregate "elbow fired on N% of queries, median cut at k".
+
+Acceptance for proceeding to rollout: on ~30-50 real prompts, a human eyeballs each printed distribution and marks where "the rest isn't really relevant"; the chosen parameterization should (a) fire on a meaningful fraction of narrow queries, (b) land within ±1 of the human mark when it fires, and (c) essentially never fire on the broad queries the human marked as "all decent". If no parameterization achieves that, the idea fails its own test cheaply, before any production wiring.
+
+### 4.2 Unit tests (`lib/ranking.test.ts`)
+
+Follow the existing conventions: `node --test --experimental-strip-types lib/ranking.test.ts`, plain `node:test` + `node:assert`, reusing the file's `ranked(kind, composite, id)` fixture helper (`lib/ranking.test.ts:86-91`). Define a local `const ELBOW = { enabled: true, minResults: 3, gapRatio: 2.5, minGap: 0.05 }`.
+
+**(i) Obvious early cliff → stops before `maxResults`:**
+
+```ts
+test("selectRanked — elbow: stops at a clear score cliff before maxResults", () => {
+	const list = [
+		ranked("curated", 0.85, "a"),
+		ranked("curated", 0.82, "b"),
+		ranked("curated", 0.80, "c"),
+		ranked("other", 0.55, "d"), // gap 0.25 vs meanGap 0.025 → cliff
+		ranked("other", 0.53, "e"),
+		ranked("other", 0.52, "f"),
+	];
+	const sel = selectRanked(list, 10, 0.4, 2, ELBOW);
+	assert.deepEqual(sel.map((r) => r.resourceId), ["a", "b", "c"]);
+});
+```
+
+**(ii) Gradual decline, no cliff → identical to the plain behavior:**
+
+```ts
+test("selectRanked — elbow: gradual decline falls through to maxResults/threshold unchanged", () => {
+	const list = [0.85, 0.80, 0.75, 0.70, 0.65, 0.60].map((s, i) =>
+		ranked("curated", s, `g${i}`),
+	);
+	const withElbow = selectRanked(list, 5, 0.4, 2, ELBOW);
+	const without = selectRanked(list, 5, 0.4, 2);
+	assert.deepEqual(withElbow, without, "no cliff → byte-identical selection");
+	assert.equal(withElbow.length, 5, "still fills to maxResults");
+});
+```
+
+**(iii) Extreme early gap → the floor holds:**
+
+```ts
+test("selectRanked — elbow: minResults floor holds even across a huge early gap", () => {
+	const list = [
+		ranked("curated", 0.95, "a"),
+		ranked("curated", 0.40, "b"), // 0.55 drop — but floor not met yet
+		ranked("curated", 0.38, "c"),
+		ranked("curated", 0.37, "d"),
+	];
+	const sel = selectRanked(list, 10, 0.3, 2, ELBOW);
+	assert.ok(sel.length >= 3, "never cut below the floor");
+	assert.deepEqual(sel.slice(0, 3).map((r) => r.resourceId), ["a", "b", "c"]);
+});
+```
+
+Additional cases worth writing while in there: flat list (all 0.70) never fires despite `meanGap = 0` (proves the `minGap` guard); `elbow` omitted / `enabled: false` leaves the two existing `selectRanked` tests' behavior untouched (regression guard for the optional-parameter contract); a cliff that sits exactly at `minResults` (fires on the first eligible check).
+
+## 5. Risks / tradeoffs
+
+- **Too aggressive → under-serving broad queries.** A broad query legitimately backed by many decent-but-not-great memories can contain a moderately large gap between its "good" and "decent" bands; an eager elbow trims context the agent would have used. Mitigations: the two-part (relative AND absolute) test, the `minResults` floor, defaults chosen from the §4.1 scan rather than intuition, and the off-by-default flag.
+- **Too conservative → dead code.** If `gapRatio`/`minGap` are set so no real distribution ever trips them, this is pure complexity for nothing. The §4.1 sweep must show a real firing rate before merge, and the debug log line makes the live firing rate observable after; if it rounds to zero on a real install, remove the feature rather than leaving it.
+- **Doesn't help the truncation half of the stated problem.** By design the elbow never extends past `maxResults`, so broad queries with 15 good candidates stay truncated at 10. That is deliberate (strictly conservative change); "elbow-aware ceiling raising" would be a separate proposal with its own risk profile (context-window pressure).
+- **Gap semantics interact with skips.** Threshold/quota-skipped rows widen the observed accepted-to-candidate gap (§3.2), so the elbow fires slightly more readily immediately after skipped chatter. Judged acceptable, but the §4.1 scan should run with the live chatter quota so the tuned parameters bake this in.
+- **Composite-scale coupling.** `minGap = 0.05` is meaningful on the current composite scale (base relevance ± boosts of 0.15-0.2). If ranking weights are retuned substantially, `minGap` needs revisiting — worth a sentence in the config description.
+
+## 6. Rollout
+
+Gate behind `ranking.elbow.enabled`, default **`false`** — with the flag off, `selectRanked`'s behavior is provably identical (the optional parameter short-circuits), so shipping the code is risk-free. Sequence:
+
+1. Land the pure-function change + tests + config plumbing, flag off everywhere.
+2. Run `docs/elbow-scan.mjs` against a real install's data to pick `gapRatio`/`minGap` (per §4.1 acceptance).
+3. Enable on one live install (alinea is the natural candidate — verify ranking is enabled there first) and watch the debug line `elbow stopped at k (ceiling N)` for a week or so: firing rate, cut depths, and any "that memory should have been there" complaints.
+4. Only then discuss flipping the default; keep the flag either way, since the right aggressiveness is corpus-dependent.
+
+## 7. Effort estimate
+
+**S** — a ~10-line change to one pure function, mechanical config/schema plumbing, straightforward unit tests, and a validation script that mirrors an existing pattern; the only genuinely open work is parameter tuning, which the scan script makes cheap.

--- a/eval/fixtures.ts
+++ b/eval/fixtures.ts
@@ -389,6 +389,35 @@ export const EVAL_CASES: EvalCase[] = [
 		},
 	},
 	{
+		name: "elbow cutoff: the narrow query stops at the cliff instead of padding with near-noise",
+		note:
+			"Proposal 13's core case: three genuinely relevant results (0.82/0.80/" +
+			"0.78 composite) then a cliff to a plateau of marginal 0.55-ish results " +
+			"that still clear the threshold. With elbow enabled (minResults 3, " +
+			"gapRatio 2.5, minGap 0.05) selection stops at 3; without it the " +
+			"plateau pads the context to maxResults. Elbow ships OFF by default — " +
+			"this case opts in explicitly, exactly like a tuned live config.",
+		pool: [
+			curated("note-a", "Heath and Junii — the confrontation", 0.62, "Heath confronts Junii at the tower"),
+			curated("note-b", "Omuerta binding notes", 0.6, "what the binding cost Tevre"),
+			curated("note-c", "Night of storms — draft", 0.58, "the storm scene as written"),
+			curated("pad-1", "Weather small talk", 0.35, "it rained again on Tuesday"),
+			curated("pad-2", "Errands list", 0.34, "post office then the market"),
+			curated("pad-3", "Old bookmark", 0.33, "an article about lighthouses"),
+		],
+		weights: {
+			...DEFAULT_RANKING,
+			elbow: { enabled: true, minResults: 3, gapRatio: 2.5, minGap: 0.05 },
+		},
+		maxResults: 6,
+		threshold: 0.5,
+		expect: {
+			mustSelect: ["note-a", "note-b", "note-c"],
+			mustNotSelect: ["pad-1", "pad-2", "pad-3"],
+			order: [["note-a", "note-c"]],
+		},
+	},
+	{
 		name: "near-duplicate dedup: the re-saved memory yields its slot to different content",
 		note:
 			"Proposal 09's core case: the same memory exists as a synced doc section " +

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -85,6 +85,7 @@ export function runCase(c: EvalCase): CaseResult {
 		c.threshold,
 		c.weights.chatterQuota,
 		c.weights.dedupThreshold,
+		c.weights.elbow,
 	);
 	const ids = selected.map((r) => r.resourceId);
 

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -260,6 +260,7 @@ export function buildAutoContextHandler(
           cfg.relevanceThreshold,
           ranking.chatterQuota,
           ranking.dedupThreshold,
+          ranking.elbow,
         )
         logScoreSamples(prompt, currentSessionId, "single", explained, cfg.relevanceThreshold)
         const selected = explained.filter((e) => e.selected).map((e) => e.result)
@@ -282,6 +283,14 @@ export function buildAutoContextHandler(
         // nothing is injected (e.g. chatterQuota 0 with only chatter clearing
         // the threshold). Stable "auto-context: cut" prefix for log greps.
         // flatMap (not filter) so TS narrows to the cut member of the union.
+        // Elbow verdict — the live-validation instrument for proposal 13's
+        // rollout: firing rate + cut depth come straight from this line.
+        if (ranking.elbow.enabled && explained.some((e) => e.cut === "elbow")) {
+          log.diag(
+            `auto-context: elbow stopped at ${selected.length} (ceiling ${cfg.maxResults})`,
+          )
+        }
+
         const cuts = explained.flatMap((e) => (e.selected ? [] : [e]))
         if (cuts.length > 0) {
           const cutTally = cuts.reduce(

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -4,6 +4,7 @@ import type { SearchResult } from "../client.ts";
 import {
 	classifyResult,
 	DEFAULT_RANKING,
+	DEFAULT_ELBOW,
 	explainSelection,
 	kindTally,
 	nearDuplicate,
@@ -636,4 +637,74 @@ test("nearDuplicate — containment counts, tiny keys require equality, 0 disabl
 	assert.ok(!nearDuplicate(THEME, THEME, 0), "threshold 0 disables");
 	assert.ok(nearDuplicate("The Writing Notes!", "the writing notes", 0.8), "tiny keys: exact set equality matches");
 	assert.ok(!nearDuplicate("", THEME, 0.8), "empty key never duplicates");
+});
+
+// ---- elbow cutoff (proposal 13) ----
+
+const ELBOW = { enabled: true, minResults: 3, gapRatio: 2.5, minGap: 0.05 };
+
+test("selectRanked — elbow: stops at a clear score cliff before maxResults", () => {
+	const list = [
+		ranked("curated", 0.85, "a"),
+		ranked("curated", 0.82, "b"),
+		ranked("curated", 0.8, "c"),
+		ranked("other", 0.55, "d"), // gap 0.25 vs meanGap 0.025 → cliff
+		ranked("other", 0.53, "e"),
+		ranked("other", 0.52, "f"),
+	];
+	const sel = selectRanked(list, 10, 0.4, 2, 0, ELBOW);
+	assert.deepEqual(sel.map((r) => r.resourceId), ["a", "b", "c"]);
+	// Attribution: everything past the cliff reads "elbow".
+	const ex = explainSelection(list, 10, 0.4, 2, 0, ELBOW);
+	assert.deepEqual(ex.map((e) => e.cut), [null, null, null, "elbow", "elbow", "elbow"]);
+});
+
+test("selectRanked — elbow: gradual decline falls through to maxResults/threshold unchanged", () => {
+	const list = [0.85, 0.8, 0.75, 0.7, 0.65, 0.6].map((s, i) => ranked("curated", s, `g${i}`));
+	const withElbow = selectRanked(list, 5, 0.4, 2, 0, ELBOW);
+	const without = selectRanked(list, 5, 0.4, 2);
+	assert.deepEqual(withElbow, without, "no cliff → byte-identical selection");
+	assert.equal(withElbow.length, 5, "still fills to maxResults");
+});
+
+test("selectRanked — elbow: minResults floor holds even across a huge early gap", () => {
+	const list = [
+		ranked("curated", 0.95, "a"),
+		ranked("curated", 0.4, "b"), // 0.55 drop — but floor not met yet
+		ranked("curated", 0.38, "c"),
+		ranked("curated", 0.37, "d"),
+	];
+	const sel = selectRanked(list, 10, 0.3, 2, 0, ELBOW);
+	assert.ok(sel.length >= 3, "never cut below the floor");
+	assert.deepEqual(sel.slice(0, 3).map((r) => r.resourceId), ["a", "b", "c"]);
+});
+
+test("selectRanked — elbow: flat plateau never fires (minGap guards the meanGap-0 case)", () => {
+	const list = ["a", "b", "c", "d", "e"].map((id) => ranked("curated", 0.7, id));
+	const sel = selectRanked(list, 5, 0.4, 2, 0, ELBOW);
+	assert.equal(sel.length, 5, "meanGap 0 makes the ratio test trivially true; minGap still blocks");
+});
+
+test("selectRanked — elbow: a cliff sitting exactly at the floor fires on the first eligible check", () => {
+	const list = [
+		ranked("curated", 0.85, "a"),
+		ranked("curated", 0.84, "b"),
+		ranked("curated", 0.83, "c"),
+		ranked("other", 0.5, "d"), // first check at kept==3 — fires immediately
+	];
+	const sel = selectRanked(list, 10, 0.4, 2, 0, ELBOW);
+	assert.deepEqual(sel.map((r) => r.resourceId), ["a", "b", "c"]);
+});
+
+test("selectRanked — elbow disabled or omitted: behavior identical to today", () => {
+	const list = [
+		ranked("curated", 0.85, "a"),
+		ranked("curated", 0.82, "b"),
+		ranked("curated", 0.8, "c"),
+		ranked("other", 0.55, "d"),
+	];
+	const plain = selectRanked(list, 10, 0.4, 2);
+	assert.deepEqual(selectRanked(list, 10, 0.4, 2, 0, { ...ELBOW, enabled: false }), plain);
+	assert.deepEqual(selectRanked(list, 10, 0.4, 2, 0, DEFAULT_ELBOW), plain, "shipped default is off");
+	assert.equal(plain.length, 4);
 });

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -50,6 +50,29 @@ export type RankingWeights = {
 	 * duplicate of an already-SELECTED result (its slot passes to different
 	 * content). 0 disables the check. */
 	dedupThreshold: number;
+	/** Elbow cutoff: stop injecting early at a natural score cliff instead of
+	 * always filling maxResults. Strictly conservative — only ever cuts
+	 * earlier, never later; off by default until live scans pick parameters. */
+	elbow: ElbowOptions;
+};
+
+export type ElbowOptions = {
+	enabled: boolean;
+	/** Never stop before this many accepted results (clamped >= 2). */
+	minResults: number;
+	/** Fire only if the drop is this multiple of the mean accepted-gap so far. */
+	gapRatio: number;
+	/** Fire only if the drop is at least this big in absolute composite terms.
+	 * Meaningful on the CURRENT composite scale (boosts of 0.15-0.2); revisit
+	 * if the ranking weights are substantially retuned. */
+	minGap: number;
+};
+
+export const DEFAULT_ELBOW: ElbowOptions = {
+	enabled: false,
+	minResults: 3,
+	gapRatio: 2.5,
+	minGap: 0.05,
 };
 
 export const DEFAULT_RANKING: RankingWeights = {
@@ -65,6 +88,7 @@ export const DEFAULT_RANKING: RankingWeights = {
 	recencyCuratedFactor: 0.5,
 	sourceWeights: {},
 	dedupThreshold: 0.8,
+	elbow: DEFAULT_ELBOW,
 };
 
 const UUID_RE =
@@ -287,6 +311,7 @@ export function nearDuplicate(a: string, b: string, threshold: number): boolean 
 export type SelectionCut =
 	| "threshold"
 	| "max-results"
+	| "elbow"
 	| "near-duplicate"
 	| "chatter-quota";
 
@@ -313,6 +338,7 @@ export function explainSelection(
 	threshold: number,
 	chatterQuota: number,
 	dedupThreshold = 0,
+	elbow?: ElbowOptions,
 ): SelectionExplained[] {
 	const out: SelectionExplained[] = [];
 	// Dedup state is exactly "what was accepted": only SELECTED results record
@@ -323,6 +349,12 @@ export function explainSelection(
 	const keys: string[] = [];
 	let chatter = 0;
 	let kept = 0;
+	// Elbow bookkeeping: gaps between consecutive ACCEPTED results only —
+	// threshold/quota/dup-skipped rows widen the observed gap on purpose (the
+	// drop that matters is between results that could actually be injected).
+	let gapSum = 0;
+	let lastAccepted = 0;
+	let elbowFired = false;
 	for (const r of ranked) {
 		if (r._composite < threshold) {
 			out.push({ result: r, selected: false, cut: "threshold" });
@@ -330,6 +362,20 @@ export function explainSelection(
 		}
 		if (kept >= maxResults) {
 			out.push({ result: r, selected: false, cut: "max-results" });
+			continue;
+		}
+		// Cliff = outlier vs the decline so far AND material in absolute terms;
+		// the two-part test keeps flat lists (tiny meanGap) and steady declines
+		// (every gap "big") from tripping it. Gated on the minResults floor, so
+		// a huge gap right after result #1 is never even examined — the elbow
+		// can only ever cut EARLIER than maxResults, never below the floor.
+		if (!elbowFired && elbow?.enabled && kept >= Math.max(2, elbow.minResults)) {
+			const gap = lastAccepted - r._composite;
+			if (gap >= elbow.minGap && gap >= elbow.gapRatio * (gapSum / (kept - 1)))
+				elbowFired = true;
+		}
+		if (elbowFired) {
+			out.push({ result: r, selected: false, cut: "elbow" });
 			continue;
 		}
 		// After max-results (a dup past a full cap was cut regardless — the cap
@@ -345,6 +391,8 @@ export function explainSelection(
 			continue;
 		}
 		if (r._kind === "chatter") chatter++;
+		if (kept > 0) gapSum += lastAccepted - r._composite;
+		lastAccepted = r._composite;
 		kept++;
 		keys.push(key);
 		out.push({ result: r, selected: true, cut: null });
@@ -370,8 +418,9 @@ export function selectRanked(
 	threshold: number,
 	chatterQuota: number,
 	dedupThreshold = 0,
+	elbow?: ElbowOptions,
 ): RankedResult[] {
-	return explainSelection(ranked, maxResults, threshold, chatterQuota, dedupThreshold)
+	return explainSelection(ranked, maxResults, threshold, chatterQuota, dedupThreshold, elbow)
 		.filter((e) => e.selected)
 		.map((e) => e.result);
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -77,7 +77,7 @@
 		},
 		"ranking": {
 			"label": "Composite Ranking",
-			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights, dedupThreshold }",
+			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights, dedupThreshold, elbow }",
 			"advanced": true
 		},
 		"debug": {
@@ -190,6 +190,17 @@
 					"recencyMaxPenalty": { "type": "number", "minimum": 0, "maximum": 1 },
 					"recencyCuratedFactor": { "type": "number", "minimum": 0, "maximum": 1 },
 					"dedupThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+					"elbow": {
+						"type": "object",
+						"additionalProperties": false,
+						"description": "Stop injecting early at a natural score cliff instead of always filling maxResults. Conservative: only ever cuts earlier, never later; falls back to plain maxResults/threshold when no clear cliff exists. minGap is calibrated to the current composite scale (boosts of 0.15-0.2).",
+						"properties": {
+							"enabled": { "type": "boolean" },
+							"minResults": { "type": "number", "minimum": 2, "maximum": 20 },
+							"gapRatio": { "type": "number", "minimum": 1, "maximum": 10 },
+							"minGap": { "type": "number", "minimum": 0, "maximum": 1 }
+						}
+					},
 					"sourceWeights": {
 						"type": "object",
 						"additionalProperties": { "type": "number", "exclusiveMinimum": 0, "maximum": 5 },

--- a/scripts/eval-retrieval.ts
+++ b/scripts/eval-retrieval.ts
@@ -74,6 +74,7 @@ async function main() {
 					cfg.relevanceThreshold,
 					cfg.ranking.chatterQuota,
 					cfg.ranking.dedupThreshold,
+					cfg.ranking.elbow,
 				)
 			: // Membership rule of formatHighlightBullets (ranking off): top
 				// maxResults, doc score AND at least one highlight over threshold.


### PR DESCRIPTION
Implements `docs/proposals/13-elbow-based-cutoff.md` (idea #13 from #66). **Waterline** — where the signal actually runs out, the injection stops.

## What Problem This Solves

The stopping rule was a fixed count plus a flat threshold — no notion of the score curve's *shape*. A narrow query backed by 3 genuinely relevant memories (0.82/0.80/0.78) followed by a cliff to a 0.55-ish plateau still padded the context to `maxResults` with near-noise, because the plateau cleared the threshold.

## Why This Change Was Made

Reconciled onto Cutting Room: the elbow is a new closed cut reason **`"elbow"`** in `explainSelection`, so the existing cut-tally diag reports it with zero logging changes. The firing test is deliberately two-part — the drop must be an outlier against the decline seen so far (`gapRatio` × mean accepted gap, default 2.5) **and** material on the raw composite scale (`minGap`, default 0.05) — so flat plateaus (tiny mean gap) and steady declines (every gap "big") can never trip it. Gaps are measured between *accepted* results only.

## User Impact

- **Ships OFF** (`ranking.elbow.enabled: false`). With the flag off — or when no clear cliff exists — selection is byte-identical to today.
- Strictly conservative: the elbow only ever cuts *earlier*, never later, and never below `minResults` (default 3, clamped ≥ 2) — a huge gap right after result #1 is never even examined. `maxResults` stays the ceiling.
- Rollout instrument shipped alongside: `docs/elbow-scan.mjs` (owner-run, reads the live config like `hotbuffer-verify.mjs`) prints each real query's composite curve with per-pair gaps and where each `gapRatio × minGap` grid point would stop, plus a firing-rate/median-cut aggregate. The proposal's acceptance bar is in the script header — if no parameterization passes it, the feature stays off and should be removed rather than left as dead config.
- Live verdict when enabled: `auto-context: elbow stopped at k (ceiling N)` via `log.diag` in `gateway.log`.

## Evidence

- **The Ruler:** 16/16 → 17/17; all 16 pre-existing cases **byte-identical**. New case (narrow-query cliff, elbow opted in like a tuned live config) proven **fail-old/pass-new**: 16/17 on old code, 17/17 on new.
- Tests 361 → 370: clear-cliff stop + `"elbow"` attribution, gradual-decline fall-through (byte-identical to plain call), minResults floor across a huge early gap, flat-plateau non-firing (the `minGap` guard on `meanGap = 0`), cliff-exactly-at-floor, disabled/omitted/default-off identity, and 2 config-parse tests (defaults, clamps). `tsc --noEmit` clean.