### PR TITLE
feat(auto-context): adaptive highlight budget — Spotlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ next-ranked *different* memory. Skipped copies never consume the chatter
 quota. Set `dedupThreshold: 0` to disable. Paraphrased duplicates (same fact,
 different words) are beyond a string measure and out of scope.
 
+Within each selected memory, the second excerpt earns its place: a result
+renders up to two highlight bullets, and the runner-up rides along only when
+its score is within 0.15 of the top one's — a .95/.40 pair renders one bullet
+(the distant second is usually a weaker paraphrase), a .95/.85 pair renders
+both. The top highlight is always kept, so a selected memory never disappears
+from the injection because of this rule.
+
 An optional **elbow cutoff** (`ranking.elbow`, **off by default**) stops
 injecting at a natural score cliff instead of always filling `maxResults`: a
 narrow query backed by 3 genuinely relevant memories no longer pads the

--- a/docs/proposals/12-adaptive-highlight-budget.md
+++ b/docs/proposals/12-adaptive-highlight-budget.md
@@ -1,0 +1,146 @@
+# Proposal 12 — Adaptive highlight budget (gap-based, not fixed-2)
+
+Idea #12 from the retrieval-relevance brainstorm ([#66](https://github.com/hyperspell/hyperspell-openclaw/issues/66)). Implementation guide only — no functional code in this PR.
+
+## 1. Summary
+
+`formatSelected` in `hooks/auto-context.ts` attaches up to 2 highlights per selected memory, requiring only that each highlight individually clears a floor — it never compares the two highlights against each other. A result whose top highlight nails the point at .95 can drag along a marginal .4 second highlight that adds tokens but no signal. This proposal adds a gap check: the second highlight is included only when its score is within a fixed absolute gap (default **0.15**) of the top highlight's score. The top highlight is always kept — only the second is ever conditionally dropped — so a selected result can never format to zero highlights that it wouldn't already format to today. Recommended as a fixed module constant, not a new config field, until real-world tuning proves otherwise.
+
+## 2. Problem
+
+Selection happens in two stages. `selectRanked` (`lib/ranking.ts:128-146`) decides *which results* get injected — composite threshold, chatter quota, `maxResults` cap. Then `formatSelected` (`hooks/auto-context.ts:75-96`) decides *which highlights within each selected result* to render:
+
+```ts
+function formatSelected(selected: RankedResult[], threshold: number): string | null {
+  const sections: string[] = []
+
+  for (const r of selected) {
+    const hiFloor = Math.min(threshold, r._base)
+    const chosen = [...r.highlights]
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .filter((h) => (h.score ?? 0) >= hiFloor)
+      .slice(0, 2)
+    if (chosen.length === 0) continue
+    ...
+```
+
+The floor is per-highlight and absolute: `hiFloor = Math.min(threshold, r._base)`. Nothing relates the second highlight's score to the first's. Two consequences:
+
+- A .95/.58 pair (with `hiFloor` at the default `relevanceThreshold` 0.6 — wait, .58 is below 0.6; take a boosted-but-quiet result where `r._base = 0.5`, so `hiFloor = 0.5`): both highlights render, though the second is barely half as relevant as the first and usually restates a weaker echo of the same content.
+- The `hiFloor = Math.min(threshold, r._base)` design (there deliberately, per the comment at `hooks/auto-context.ts:70-74`, so boosted-but-quiet memories aren't hidden) makes this *worse* for exactly those quiet results: a low `_base` lowers the floor for **both** highlights, so the weak second one rides in under a floor that was lowered to protect the strong first one.
+
+The chatter quota and relevance threshold can't touch this — they operate on whole results (`selectRanked` never looks inside `r.highlights`). This is fluff *within* a correct selection, and it directly costs injected-context tokens on every turn where auto-context fires (both the single-user path at `hooks/auto-context.ts:208` and the multi-user path at `hooks/auto-context.ts:345` call `formatSelected`).
+
+## 3. Proposed design
+
+### Gap form: absolute score difference
+
+Include the second highlight only when `topScore - secondScore <= HIGHLIGHT_GAP`.
+
+Absolute-difference, not ratio, for three reasons:
+
+1. **Codebase convention.** Every score comparison in this pipeline is absolute and additive: `hiFloor` is an absolute floor, `relevanceThreshold` (default 0.6) is an absolute cut, and the composite ranking works in absolute score deltas (`curationBoost` 0.2, `chatterPenalty` 0.2, `storyBoost` 0.15 — `lib/ranking.ts:36-44`). A ratio rule ("second must be ≥ 80% of top") would be the only multiplicative comparison in the file.
+2. **Behavior at the scores that matter.** Selected results skew high (they cleared a ~0.6 composite threshold). In the .8–1.0 band, an absolute 0.15 gap and an ~84% ratio behave nearly identically, so the ratio buys nothing — while at low top scores a ratio gets *stricter* in absolute terms (80% of .5 demands the second be within .1) for no principled reason.
+3. **Simplicity of reasoning.** "Within 0.15 of the top" composes mentally with the existing constants; "within 84%" doesn't.
+
+### Default value: `0.15`
+
+- Matches the magnitude of the existing score-space nudges (`storyBoost` is exactly 0.15; boosts/penalties cluster at 0.15–0.2), so the tolerance is "one boost's worth of score."
+- The issue's motivating fixture (.95/.4, gap .55) is dropped decisively; a close pair (.95/.85, gap .10) is kept; a middling pair (.95/.75, gap .20) is dropped, which is the intent — at that spread the second highlight is usually a weaker paraphrase of the first.
+- Boundary is inclusive (`<=`): a gap of exactly 0.15 keeps the second highlight, consistent with `>=` on `hiFloor`.
+
+### Modified `formatSelected` sketch
+
+```ts
+const HIGHLIGHT_GAP = 0.15
+
+function formatSelected(selected: RankedResult[], threshold: number): string | null {
+  const sections: string[] = []
+
+  for (const r of selected) {
+    const hiFloor = Math.min(threshold, r._base)
+    const passing = [...r.highlights]
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .filter((h) => (h.score ?? 0) >= hiFloor)
+    if (passing.length === 0) continue
+
+    // Top highlight is always kept; the second rides along only when it is
+    // nearly as strong — a distant second is dilution inside a correct pick.
+    const [top, second] = passing
+    const chosen =
+      second && (top.score ?? 0) - (second.score ?? 0) <= HIGHLIGHT_GAP
+        ? [top, second]
+        : [top]
+
+    const title = r.title ?? `[${r.source}]`
+    const bullets = chosen
+      .map((h) => `- ${h.text.replace(/\n/g, " ")} [${Math.round((h.score ?? 0) * 100)}%]`)
+      .join("\n")
+
+    sections.push(`### ${title} (resource_id: ${r.resourceId}, source: ${r.source})\n\n${bullets}`)
+  }
+
+  if (sections.length === 0) return null
+  return sections.join("\n\n")
+}
+```
+
+Notes on the sketch:
+
+- **Invariant — top highlight always kept.** The gap logic only decides whether `second` joins `top`; `top` is unconditional once it passes `hiFloor`. A result selected by `selectRanked` therefore renders at least as many highlights as it would need to render today to appear at all — the change can never turn a selected result into an empty section. The existing `if (passing.length === 0) continue` degrade path (a selected result whose highlights all miss `hiFloor`) is unchanged.
+- The gap check runs **after** the `hiFloor` filter, on the sorted survivors, so the two rules compose: floor first (is this highlight relevant at all?), gap second (is the runner-up close enough to the winner to be worth its tokens?).
+- Keep the `(h.score ?? 0)` coalescing convention from the current code (`Highlight.score` is typed non-optional in `client.ts` but the code defends anyway; the gap comparison should too).
+- `slice(0, 2)` disappears; destructuring `[top, second]` replaces it. Highlights beyond the second were never rendered and still aren't.
+
+### Fixed constant vs. config field: fixed constant
+
+Recommendation: a module-level `const HIGHLIGHT_GAP = 0.15` in `hooks/auto-context.ts`.
+
+The repo's dividing line is visible in `config.ts`: things a deployment plausibly needs to tune for its own data are config (`maxResults`, `relevanceThreshold`, the whole `ranking` block parsed by `parseRanking` at `config.ts:230-247`); internal mechanics with one sane answer are constants (`MAX_ATTEMPTS` in `hooks/startup-orientation.ts`, retry/debounce internals). The gap threshold is the latter today: it's a formatting heuristic two levels below anything a user reasons about, there is no evidence yet that different vaults need different values, and every config field added to `parseRanking` is permanent API surface on a published npm package.
+
+Escape hatch: if live tuning shows real variance across deployments, promote it to `ranking.highlightGap` later — `parseRanking` + `DEFAULT_RANKING` make that a three-line additive change (`num(r.highlightGap, DEFAULT_RANKING.highlightGap)`), fully backward compatible. Start constant; earn the config field.
+
+## 4. Test plan
+
+### Export `formatSelected`
+
+`formatSelected` is currently private. Recommend exporting it and testing it directly rather than through `buildAutoContextHandler`: it is already a pure function of `(selected, threshold)` with a string-or-null return, whereas handler-level testing requires stubbing `HyperspellClient.search`, session resolution, and config, then asserting against the fully wrapped `<hyperspell-context>` envelope — far more fixture for far less precision. Precedent: `dropCurrentSession` was exported from the same file for exactly this kind of direct testing (`hooks/auto-context.test.ts`). Add `export` to the function; no other code change.
+
+Tests go in the existing `hooks/auto-context.test.ts`, same conventions (`node:test` + `node:assert/strict`, a small `result(...)` fixture builder extended to take highlights). Run with `node --test --experimental-strip-types hooks/auto-context.test.ts`.
+
+### Cases
+
+Fixture builder: a `RankedResult` with `_kind: "curated"`, `_base` set so `hiFloor` doesn't interfere (see each case), threshold `0.6`.
+
+1. **Characterization first — current behavior attaches the marginal second.** Fixture: highlights `[.95, .4]`, `_base: 0.4` (so `hiFloor = min(0.6, 0.4) = 0.4` and the .4 highlight passes the floor today). Assert the output contains **both** bullets (`[95%]` and `[40%]`). Write and commit this expectation *before* the change (or write it, watch it pass, then flip it) — it proves the bug is real, not hypothetical.
+2. **Gap cutoff drops the weak second.** Same fixture after the change: output contains the `[95%]` bullet and does **not** contain `[40%]`. Exactly one `- ` bullet line in the section.
+3. **Close pair keeps both.** Highlights `[.95, .85]`, `_base: 0.85`: gap .10 ≤ .15 → both bullets present.
+4. **Boundary is inclusive.** Highlights `[.95, .80]`: gap exactly .15 → both kept.
+5. **Invariant — top always survives.** Single-highlight result (`[.95]`) renders its one bullet; and a `[.95, .4]` result still renders a non-empty section (never formats a selected result to nothing).
+6. **Floor still composes.** Highlights `[.95, .9]` but `_base`/threshold such that `hiFloor = 0.92`: the .9 fails the floor before the gap is consulted → one bullet, no crash.
+
+### Live inspection before changing anything
+
+Confirm today's real behavior on actual injected blocks — the rendered bullets already carry their scores as `[NN%]` suffixes, so no new instrumentation is needed:
+
+1. On a live install (e.g. alinea — read-only, nothing mutated), set `debug: true` and let auto-context fire for a few turns; or grep recent session transcripts for `<hyperspell-context>` blocks.
+2. For every `### ...` section with two bullets, extract the two `[NN%]` values and compute the gap. Tally: how many two-bullet sections exist, and what fraction have gap > 0.15.
+3. Alternatively (no live agent needed): a one-off probe script in the style of the existing `docs/probe.mjs` scripts — call `client.search` with a handful of realistic prompts, run results through `rerank` → `selectRanked` → the current `formatSelected`, print each section's highlight-score pairs. This directly answers the issue's test bullet ("check whether formatSelected actually attaches marginal second highlights today") and also calibrates the 0.15 default against real gap distributions before committing to it.
+
+## 5. Risks / tradeoffs
+
+- **Gap too strict (e.g. 0.05–0.10):** genuinely complementary second highlights get dropped — two facets of one document (a decision and its rationale) often score .95/.78, and losing the second loses real context. Mitigation: the live-inspection step calibrates against the actual gap distribution before the value is locked; 0.15 was chosen to sit above typical same-document facet spreads at high scores.
+- **Gap too loose (e.g. 0.3+):** almost every second highlight survives and the change is a no-op that adds code without fixing the fluff.
+- **Score calibration assumption.** An absolute gap assumes highlight scores are on a comparable scale across sources (vault, Slack, Drive). If the backend's per-source scoring drifts, a fixed 0.15 means different strictness per source. Acceptable now (the absolute `relevanceThreshold` and `hiFloor` already make this assumption); revisit if the probe data shows per-source skew.
+- **Interaction with the `hiFloor` protection.** The `Math.min(threshold, r._base)` floor exists to keep boosted-but-quiet memories visible. The gap rule tightens output for exactly those results (their lowered floor is what let weak seconds in), which is the point — but it must never touch the top highlight, or it would re-hide the quiet memories the floor protects. The always-keep-top invariant is load-bearing; test case 5 pins it.
+
+## 6. Rollout
+
+- Default `HIGHLIGHT_GAP = 0.15`, fixed constant, no new config surface — config-wise fully backward compatible, nothing to migrate.
+- **This is still a behavior change worth calling out:** the shape of injected context changes — some memories that rendered two bullets will render one. Any downstream prompt-shape expectations (token budgeting, transcript diffing, eval fixtures asserting on injected blocks) will see shorter sections. Ship as a minor version with a changelog entry naming the new rule and the constant, and note the `formatSelected` export.
+- Applies uniformly to both call sites (single-user and multi-user paths) since both go through `formatSelected`; `formatHighlightBullets` (the `ranking.enabled: false` path) is intentionally untouched — it has no per-result cap semantics to preserve and is the legacy path.
+- Post-rollout check: rerun the step-4 live inspection; expect the two-bullet-with-large-gap sections to be gone and close-pair sections unchanged.
+
+## 7. Effort estimate
+
+**S** — one pure function edited in place (plus its export), ~6 focused unit tests in an existing test file, and a read-only probe; no config, schema, or API changes.

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -5,9 +5,9 @@ import path from "node:path"
 import { test } from "node:test"
 import type { HyperspellClient, SearchResult } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
-import { DEFAULT_RANKING } from "../lib/ranking.ts"
+import { DEFAULT_RANKING, type RankedResult } from "../lib/ranking.ts"
 import { initLogger } from "../logger.ts"
-import { buildAutoContextHandler, dropCurrentSession } from "./auto-context.ts"
+import { buildAutoContextHandler, dropCurrentSession, formatSelected } from "./auto-context.ts"
 
 function result(resourceId: string): SearchResult {
   return {
@@ -295,4 +295,59 @@ test("auto-context — debug lines carry cut reasons and the injected composite 
     injectLine.includes(`{"curated":1,"chatter":2} from 5 candidates (chatter cap 2, composite 0.65–0.90)`),
     `tally line extended with the injected composite range: ${injectLine}`,
   )
+})
+
+// ---- adaptive highlight budget (proposal 12) ----
+
+function selectedResult(id: string, base: number, scores: number[]): RankedResult {
+  return {
+    ...result(id),
+    title: `Note ${id}`,
+    highlights: scores.map((score, i) => ({ id: `h${i}`, score, text: `highlight at ${score}` })),
+    _kind: "curated",
+    _base: base,
+    _composite: base + DEFAULT_RANKING.curationBoost,
+  }
+}
+
+test("formatSelected — gap cutoff: the marginal second highlight is dropped", () => {
+  // Pre-change characterization: _base 0.4 lowers hiFloor to 0.4, so the .4
+  // highlight passed the floor and rendered — the exact fluff the gap removes.
+  const out = formatSelected([selectedResult("a", 0.4, [0.95, 0.4])], 0.6)
+  assert.ok(out?.includes("[95%]"))
+  assert.ok(!out?.includes("[40%]"), "0.55 gap > 0.15 — the weak second is dilution")
+  assert.equal(out?.split("\n").filter((l) => l.startsWith("- ")).length, 1)
+})
+
+test("formatSelected — close pair keeps both highlights", () => {
+  const out = formatSelected([selectedResult("a", 0.85, [0.95, 0.85])], 0.6)
+  assert.ok(out?.includes("[95%]"))
+  assert.ok(out?.includes("[85%]"), "gap 0.10 <= 0.15")
+})
+
+test("formatSelected — boundary is inclusive: gap of exactly 0.15 keeps the second", () => {
+  const out = formatSelected([selectedResult("a", 0.8, [0.95, 0.8])], 0.6)
+  assert.ok(out?.includes("[95%]"))
+  assert.ok(out?.includes("[80%]"))
+})
+
+test("formatSelected — top highlight always survives: never formats a selected result to nothing", () => {
+  const single = formatSelected([selectedResult("a", 0.95, [0.95])], 0.6)
+  assert.ok(single?.includes("[95%]"))
+  const withWeakSecond = formatSelected([selectedResult("b", 0.4, [0.95, 0.4])], 0.6)
+  assert.ok(withWeakSecond !== null && withWeakSecond.includes("### Note b"), "section still renders")
+})
+
+test("formatSelected — hiFloor composes before the gap: a second failing the floor never reaches it", () => {
+  // threshold 0.92 and _base 0.92 → hiFloor 0.92; the .9 highlight fails the
+  // floor (not the gap) and only one bullet renders. No crash on the missing
+  // second.
+  const out = formatSelected([selectedResult("a", 0.92, [0.95, 0.9])], 0.92)
+  assert.ok(out?.includes("[95%]"))
+  assert.ok(!out?.includes("[90%]"))
+})
+
+test("formatSelected — all highlights below floor still degrade to a skipped section", () => {
+  const out = formatSelected([selectedResult("a", 0.9, [0.3, 0.2])], 0.6)
+  assert.equal(out, null)
 })

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -73,22 +73,41 @@ function formatHighlightBullets(
   return sections.join("\n\n")
 }
 
+// A second highlight rides along only when it is within this much of the top
+// one's score — a distant second is dilution inside a correct pick (proposal
+// 12). Absolute difference (not a ratio) to match every other score rule in
+// this pipeline; 0.15 is "one storyBoost's worth" on the composite scale.
+// Deliberately a constant, not config: a formatting heuristic two levels
+// below anything a user reasons about — promote to ranking.highlightGap only
+// if live tuning proves deployments actually differ.
+const HIGHLIGHT_GAP = 0.15
+
 /**
  * Format already-SELECTED composite-ranked results (threshold + chatter quota
  * applied upstream by selectRanked). Highlights are floored at the lower of
  * (threshold, the result's own base relevance), so we don't hide the very lines
- * that define a boosted-but-quiet memory.
+ * that define a boosted-but-quiet memory. Exported for direct testing.
  */
-function formatSelected(selected: RankedResult[], threshold: number): string | null {
+export function formatSelected(selected: RankedResult[], threshold: number): string | null {
   const sections: string[] = []
 
   for (const r of selected) {
     const hiFloor = Math.min(threshold, r._base)
-    const chosen = [...r.highlights]
+    const passing = [...r.highlights]
       .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
       .filter((h) => (h.score ?? 0) >= hiFloor)
-      .slice(0, 2)
-    if (chosen.length === 0) continue
+    if (passing.length === 0) continue
+
+    // Floor first (is this highlight relevant at all?), gap second (is the
+    // runner-up close enough to the winner to be worth its tokens?). The TOP
+    // highlight is always kept — the lowered hiFloor exists to protect
+    // boosted-but-quiet memories, and the gap rule must never re-hide them; a
+    // selected result can never format to fewer sections than today.
+    const [top, second] = passing
+    const chosen =
+      second && (top.score ?? 0) - (second.score ?? 0) <= HIGHLIGHT_GAP
+        ? [top, second]
+        : [top]
 
     const title = r.title ?? `[${r.source}]`
     const bullets = chosen


### PR DESCRIPTION
Implements `docs/proposals/12-adaptive-highlight-budget.md` (idea #12 from #66). **Spotlight** — one beam on what matters; the second light comes on only when it's nearly as bright.

## What Problem This Solves

`formatSelected` attached up to 2 highlights per selected memory with only a per-highlight floor — it never compared the two against each other. The deliberate `hiFloor = min(threshold, r._base)` protection for boosted-but-quiet memories made it worse: a low `_base` lowered the floor for **both** highlights, so a .95 top highlight dragged a marginal .40 second in under a floor that was lowered to protect the first. Tokens spent, no signal added — on every turn auto-context fires.

## Why This Change Was Made

Absolute gap (not a ratio): every score rule in this pipeline is absolute and additive (`hiFloor`, `relevanceThreshold`, boosts of 0.15–0.2), the two behave identically in the .8–1.0 band where selected results live, and "within 0.15 of the top" composes mentally with the existing constants. `0.15` is one `storyBoost`'s worth. It's a **fixed module constant, deliberately not config** — a formatting heuristic two levels below anything a user reasons about; the escape hatch (`ranking.highlightGap`) is a documented three-line additive change if live tuning ever proves deployments differ.

## User Impact

- The second highlight renders only when its score is within 0.15 (inclusive) of the top's: `.95/.40` → one bullet; `.95/.85` → both; `.95/.80` → both (boundary).
- Floor first, gap second — the rules compose; a second failing the floor never reaches the gap.
- **Load-bearing invariant:** the top highlight is always kept, so the gap rule can never re-hide the boosted-but-quiet memories the lowered floor exists to protect, and a selected result never formats to fewer sections than today.
- Injected context shape changes: sections that used to carry a weak second bullet get shorter. `formatSelected` is now exported for direct testing (same precedent as `dropCurrentSession`).

## Evidence

- **The Ruler:** 17/17 unchanged — selection is untouched; this is downstream formatting, covered by unit tests instead.
- Tests 370 → 376, including the proposal's **characterization fixture** (`[.95, .4]` with `_base: 0.4` — the exact case where the lowered floor let the fluff in, previously rendering both bullets, now one), close-pair keep, inclusive boundary, top-always-survives (single-highlight and weak-second variants), floor-before-gap composition, and the all-below-floor degrade path. `tsc --noEmit` clean.
- Live calibration path (owner-run, per §4): rendered bullets already carry `[NN%]` scores, so grepping recent `<hyperspell-context>` blocks for two-bullet sections with gap > 0.15 measures the before/after directly — no new instrumentation needed.