### PR TITLE
Implementation guide: startup log when moodWeatherChance leaves emotionalContext inert

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Open the Hyperspell connect page to link your accounts (Notion, Slack, Google Dr
 | `apiKey` | string | `${HYPERSPELL_API_KEY}` | Hyperspell API key |
 | `userId` | string | - | User ID for multi-tenant memory (can be your email) |
 | `autoContext` | boolean | `true` | Auto-inject relevant memories before each AI turn |
+| `emotionalContext` | boolean | `false` | Persist an emotional-state register at session end and inject the recent arc at session start |
+| `moodWeatherChance` | number | `0` | Probability (0–1) that a fresh session rolls exogenous "mood weather". `0` disables. Suggested starting value: `0.03`–`0.05` — rare enough to read as weather, not a gimmick. Requires `emotionalContext`. |
 | `syncMemories` | boolean | `false` | Sync markdown files in `workspace/memory/` to Hyperspell |
 | `sources` | string | - | Comma-separated sources to search (e.g., `vault,notion,slack`) |
 | `maxResults` | number | `10` | Maximum memories per context injection |

--- a/config.test.ts
+++ b/config.test.ts
@@ -324,3 +324,7 @@ test("parseConfig — non-array excludeChannels falls back to empty", () => {
   const cfg = parseConfig({ ...base, excludeChannels: "123" })
   assert.deepEqual(cfg.excludeChannels, [])
 })
+
+test("parseConfig — moodWeatherChance defaults to 0 (mood weather off)", () => {
+  assert.equal(parseConfig(base).moodWeatherChance, 0)
+})

--- a/docs/plans/issue-72-moodweatherchance-log.md
+++ b/docs/plans/issue-72-moodweatherchance-log.md
@@ -12,6 +12,8 @@ moodWeatherChance: Math.min(1, Math.max(0, (cfg.moodWeatherChance as number) ?? 
 
 The roll itself is gated in `hooks/emotional-state.ts:196` (`cfg.moodWeatherChance > 0 ? rollMood(...) : null`), so with the default an operator who turned on `emotionalContext` gets zero mood-weather behavior and zero signal about it. The parsed shape is a plain `number`, always defined, so the check is exactly `cfg.moodWeatherChance === 0`.
 
+**⚠️ Landing-order note: three separate guides touch `index.ts`'s `register()` near the same spot.** #69 edits the *existing* `allowConversationAccess` warn block (downgrading it to `info`). This guide and #81 (Memory Network discoverability) each *add a new* info-level log block nearby, following #69's pattern as precedent. Suggested order: land **#69 first** if it hasn't already — it has the smallest conflict surface, and this guide's log block should be placed right after it, matching its wording/level style. This guide and #81 can land in either order relative to each other; whichever lands second just needs a trivial rebase past the other's insertion.
+
 ## 1. Startup log — `index.ts`
 
 Add the check inside the existing `if (cfg.emotionalContext)` block at `index.ts:167`, as its first statement. This mirrors the existing nested-discoverability-check pattern in the `startupOrientation` block just below it (`index.ts:187-196`, the "recent-interactions will be empty" warn). Use `log.info`, not `log.warn` — `moodWeatherChance: 0` is a valid, intentional-by-default state, not a misconfiguration; this is purely a discoverability nudge. (The `logger.ts` `log` facade is initialized at `index.ts:101`, well before this point.)

--- a/docs/plans/issue-72-moodweatherchance-log.md
+++ b/docs/plans/issue-72-moodweatherchance-log.md
@@ -14,6 +14,8 @@ The roll itself is gated in `hooks/emotional-state.ts:196` (`cfg.moodWeatherChan
 
 **⚠️ Landing-order note: three separate guides touch `index.ts`'s `register()` near the same spot.** #69 edits the *existing* `allowConversationAccess` warn block (downgrading it to `info`). This guide and #81 (Memory Network discoverability) each *add a new* info-level log block nearby, following #69's pattern as precedent. Suggested order: land **#69 first** if it hasn't already — it has the smallest conflict surface, and this guide's log block should be placed right after it, matching its wording/level style. This guide and #81 can land in either order relative to each other; whichever lands second just needs a trivial rebase past the other's insertion.
 
+**⚠️ Also note: issue #76 (`hyperspell_emotional_arc` tool)** inserts its `api.registerTool(...)` call as content inside this same `if (cfg.emotionalContext) {` block. Purely a textual rebase — this guide's log line and #76's tool registration are independent statements in the same block, compatible in either order — but whoever lands second should place their addition without deleting the other's.
+
 ## 1. Startup log — `index.ts`
 
 Add the check inside the existing `if (cfg.emotionalContext)` block at `index.ts:167`, as its first statement. This mirrors the existing nested-discoverability-check pattern in the `startupOrientation` block just below it (`index.ts:187-196`, the "recent-interactions will be empty" warn). Use `log.info`, not `log.warn` — `moodWeatherChance: 0` is a valid, intentional-by-default state, not a misconfiguration; this is purely a discoverability nudge. (The `logger.ts` `log` facade is initialized at `index.ts:101`, well before this point.)

--- a/docs/plans/issue-72-moodweatherchance-log.md
+++ b/docs/plans/issue-72-moodweatherchance-log.md
@@ -1,0 +1,61 @@
+# Implementation guide: startup log when `emotionalContext` is on but mood weather is inert (#72)
+
+## Background
+
+`moodWeatherChance` defaults to `0` and is clamped in `config.ts:542-545`:
+
+```ts
+// Default 0 (off) so shipping never changes existing installs' behavior.
+// Clamped to [0,1] so a stray config value can't make every session roll.
+moodWeatherChance: Math.min(1, Math.max(0, (cfg.moodWeatherChance as number) ?? 0)),
+```
+
+The roll itself is gated in `hooks/emotional-state.ts:196` (`cfg.moodWeatherChance > 0 ? rollMood(...) : null`), so with the default an operator who turned on `emotionalContext` gets zero mood-weather behavior and zero signal about it. The parsed shape is a plain `number`, always defined, so the check is exactly `cfg.moodWeatherChance === 0`.
+
+## 1. Startup log — `index.ts`
+
+Add the check inside the existing `if (cfg.emotionalContext)` block at `index.ts:167`, as its first statement. This mirrors the existing nested-discoverability-check pattern in the `startupOrientation` block just below it (`index.ts:187-196`, the "recent-interactions will be empty" warn). Use `log.info`, not `log.warn` — `moodWeatherChance: 0` is a valid, intentional-by-default state, not a misconfiguration; this is purely a discoverability nudge. (The `logger.ts` `log` facade is initialized at `index.ts:101`, well before this point.)
+
+```ts
+if (cfg.emotionalContext) {
+	// moodWeatherChance defaults to 0, so mood weather is inert unless the
+	// operator opts in — say so once at startup rather than staying silent.
+	if (cfg.moodWeatherChance === 0) {
+		log.info(
+			"emotionalContext is on but moodWeatherChance is 0 — mood weather will never roll. Set moodWeatherChance (e.g. 0.03–0.05) to enable it.",
+		);
+	}
+	startHandlers.push({
+		...
+```
+
+Note: `index.ts` currently has uncommitted WIP (the `allowConversationAccess` warn block at lines 105-119). This change is independent of it — it slots into the `emotionalContext` block either way.
+
+## 2. Test — `config.test.ts`
+
+No test currently exercises `register()`'s log output (none of the existing startup warns are tested either — don't build a plugin-API harness for this). Instead pin the parsed default the log condition depends on, matching the file's existing one-liner style:
+
+```ts
+test("parseConfig — moodWeatherChance defaults to 0 (mood weather off)", () => {
+	assert.equal(parseConfig(base).moodWeatherChance, 0);
+});
+```
+
+Then verify the log manually: run the gateway with `emotionalContext: true` and no `moodWeatherChance` → the info line appears; set `moodWeatherChance: 0.05` → it does not.
+
+## 3. README note
+
+The `## Configuration Options` table (`README.md:128-139`) documents neither `emotionalContext` nor `moodWeatherChance`. Add a row for `moodWeatherChance` (and ideally `emotionalContext` while there):
+
+```md
+| `emotionalContext` | boolean | `false` | Persist and inject an emotional-state register across sessions. Requires `allowConversationAccess` (see above). |
+| `moodWeatherChance` | number | `0` | Probability (0–1) that a fresh session rolls exogenous "mood weather". `0` disables. Suggested starting value: `0.03`–`0.05` — rare enough to read as weather, not a gimmick. Requires `emotionalContext`. |
+```
+
+Keep the code default at `0` — bumping the actual default is a behavior change for existing installs and deserves its own opt-in/version-bump discussion; the README suggestion plus the startup log covers the discoverability gap.
+
+## Files touched
+
+- `index.ts` — new `log.info` discoverability check inside the `cfg.emotionalContext` block (~line 167)
+- `config.test.ts` — one test pinning `moodWeatherChance` default of `0`
+- `README.md` — `moodWeatherChance` (and `emotionalContext`) rows in the Configuration Options table with suggested `0.03–0.05` starting value

--- a/index.ts
+++ b/index.ts
@@ -151,6 +151,13 @@ export default {
 		const startHandlers: StartHandler[] = [];
 
 		if (cfg.emotionalContext) {
+			// moodWeatherChance defaults to 0, so mood weather is inert unless the
+			// operator opts in — say so once at startup rather than staying silent.
+			if (cfg.moodWeatherChance === 0) {
+				log.info(
+					"emotionalContext is on but moodWeatherChance is 0 — mood weather will never roll. Set moodWeatherChance (e.g. 0.03–0.05) to enable it.",
+				);
+			}
 			// On-demand arc re-fetch (issue #76): the session-start injection can be
 			// compacted out of history mid-session; this tool lets the agent pull the
 			// exact same block back without waiting for the next prompt build.


### PR DESCRIPTION
Detailed implementation guide for #72. See `docs/plans/issue-72-moodweatherchance-log.md` — a small, focused change: one info-level startup log, one config test, one README table addition.

Ref #72 — planning/design doc, not the implementation.