### PR TITLE
Implementation guide: documented external fetch contract for emotional-state registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Matching uses the same semantics as the quarantine check itself: exact id or thr
 | `debug` | boolean | `false` | Enable verbose logging |
 | `dreaming.enabled` | boolean | `false` | Allow `memory-core` to sidecar-load so Dreaming can consolidate local session transcripts into `workspace/MEMORY.md`. See [Running alongside Dreaming](#running-alongside-dreaming). |
 
+Stored emotional-state registers (`emotionalContext`) are fetchable by external processes (e.g. a nightly consolidator reconciling its own day-read) — the verified fetch contract lives in [docs/emotional-state-external-reconciliation.md](docs/emotional-state-external-reconciliation.md).
+
 ## Slash Commands
 
 ### `/getcontext <query>`

--- a/docs/emotional-state-external-reconciliation.md
+++ b/docs/emotional-state-external-reconciliation.md
@@ -1,0 +1,134 @@
+# External fetch contract: emotional-state registers
+
+How an external process — a nightly consolidator, a reconciliation job, any
+daily-synthesis pipeline that does **not** run inside this plugin — fetches a
+day's stored emotional-state registers from the Hyperspell API.
+
+Two independent judgments of a day can exist: an external nightly synthesis
+(e.g. a local-LLM map-reduce over the day's material) and the live per-session
+registers Tin Man (`hooks/emotional-state.ts`) stores as sessions end.
+Reconciling them — divergence scoring, thresholds, where flags surface — is
+the **external process's job**, and that design conversation lives on
+[issue #75](https://github.com/hyperspell/hyperspell-openclaw/issues/75). This
+document is the other half of the contract: the stable, verified way to fetch
+the registers to reconcile against.
+
+Endpoint facts below were **verified live against the production API on
+2026-07-07**; the metadata caveat was proven live on **2026-07-12**
+([#116](https://github.com/hyperspell/hyperspell-openclaw/issues/116)).
+
+## What a register is
+
+At session end, Tin Man distills a sanitized session transcript into a
+second-person prose `summary` — an emotional register, not a factual recap. It
+is keyed by the plugin's configured `relationshipId` (e.g. `david-alinea`),
+timestamped `extracted_at`, and stored with metadata
+`{ source: "openclaw_agent_end" }` plus, since 0.19.0, the session's
+`channelId` when resolvable (Postmark, #74).
+
+**Volume is deliberately low.** Stores are debounced to at most one per 3
+minutes of active talk (`STORE_DEBOUNCE_MS`), and sessions triggered by
+cron/heartbeat/memory events, multi-speaker sessions, and short conversations
+are skipped entirely. A typical day yields a handful of registers, and a quiet
+day may legitimately produce **zero** — an empty day is not divergence.
+
+## The fetch contract
+
+The `hyperspell` npm SDK (0.35.1) has **no emotional-state surface**; the
+plugin itself uses raw `fetch` (`client.ts`, "Emotional State" section), and an
+external consumer must call REST directly the same way.
+
+Base URL: `https://api.hyperspell.com`
+
+| Fact | Detail |
+|---|---|
+| `GET /emotional-state` | The single latest register, or JSON `null`. Optional `?relationship_id=`. |
+| `GET /emotional-state/recent` | Array, newest first. Optional `?relationship_id=`, `?limit=`. Deployed (the 404 fallback in `client.ts` is a legacy guard only). |
+| `limit` cap | **20.** `limit=100` returns 422: `Input should be less than or equal to 20`. |
+| Date filtering | **None.** `after`/`before` params are silently ignored (an impossible `before=2000-01-01` window still returned rows). Assemble "a day" client-side — see the recipe below. |
+| Response shape (GET) | `{ resource_id, summary, extracted_at, session_id, relationship_id }` — five plain fields, nothing else. No `status` (only `POST /emotional-state` returns one) and **no `metadata`** (see below). |
+| Auth | `Authorization: Bearer <apiKey>`; add `X-As-User: <userId>` when the plugin config sets `userId` (mirrors `rawHeaders()` in `client.ts`). |
+| Timestamps | `extracted_at` is ISO 8601 UTC with offset, e.g. `2026-06-03T22:45:16.287450+00:00`. |
+
+### No metadata on GET (#116)
+
+Proven live 2026-07-12
+([#116](https://github.com/hyperspell/hyperspell-openclaw/issues/116)): the
+GET endpoints **do not echo stored metadata**. Registers are written with
+`source: "openclaw_agent_end"` and (since 0.19.0) a `channelId`, but both
+`GET /emotional-state` and `GET /emotional-state/recent` return empty/absent
+metadata for all of them. Until #116 is fixed backend-side, consumers get
+**only the five plain fields above** — no `channelId` for per-channel
+attribution, and no future depth signals (e.g. Ballast's `depth_score` /
+`turn_count`, #68). Do not design an external pipeline around metadata
+round-tripping today.
+
+### Pending-extraction placeholder
+
+For roughly 10 seconds after a store, `summary` can still be the *raw input
+transcript* rather than a distilled register. The plugin detects this with
+`looksLikeRawTranscript()` (`hooks/emotional-state.ts` — role-prefixed lines
+like `user:` / `assistant:`); since GET carries no `status` field, external
+consumers need the same heuristic. A nightly job running hours after the last
+session will essentially never hit this, but filter for it anyway (the recipe
+below does).
+
+## Recipe: "a day's registers"
+
+There is no server-side date filtering, so fetch the recent window and filter
+client-side:
+
+1. `GET /emotional-state/recent?relationship_id=<REL_ID>&limit=20`
+2. Filter `extracted_at` into the day window **in the operator's timezone** —
+   timestamps are UTC, but a "day" for a nightly consolidator is a local-time
+   concept, so choose the boundary explicitly.
+3. Drop pending placeholders with the transcript heuristic.
+
+curl (placeholders only — never a real key):
+
+```bash
+# Latest ≤20 registers for a relationship, newest first
+curl -s "https://api.hyperspell.com/emotional-state/recent?relationship_id=REL_ID&limit=20" \
+  -H "Authorization: Bearer $HYPERSPELL_API_KEY" \
+  -H "X-As-User: $HYPERSPELL_USER_ID"   # omit if the plugin config has no userId
+```
+
+A runnable zero-dependency version of the full recipe ships as
+[`scripts/fetch-day-registers.mjs`](../scripts/fetch-day-registers.mjs):
+
+```bash
+HYPERSPELL_API_KEY=... REL_ID=david-alinea node scripts/fetch-day-registers.mjs 2026-07-06
+```
+
+It is read-only and prints the day's registers as JSON — what your nightly
+synthesis compares its own day-read against.
+
+### Reachability limit
+
+`limit=20` newest-first comfortably covers "yesterday" for a nightly job, but
+**does not support arbitrary historical days**: once more than 20 registers
+have accumulated since the target day, that day is unreachable via this
+endpoint. Historical validation (issue #75's "pick a handful of past days and
+compare by hand") is constrained to recent days until the backend grows
+date-range parameters.
+
+## The consumer's responsibility
+
+Divergence scoring, thresholds, and where flags surface are the external
+process's design decisions. Nothing merges automatically: this plugin never
+reads the consolidator's output, and the consolidator's judgment is never
+written back into the register store by this contract. If the two disagree,
+that disagreement is signal for the external process to surface — see
+[issue #75](https://github.com/hyperspell/hyperspell-openclaw/issues/75) for
+the design conversation.
+
+## Known limitations / backend follow-ups
+
+Tracked in [`hyperspell-backend-followups.md`](hyperspell-backend-followups.md):
+
+- No server-side date-range params (`after`/`before` accepted but ignored).
+- `limit` capped at 20 with no pagination — historical days can become
+  unreachable.
+- No `status` field on GET, forcing the transcript heuristic.
+- No `metadata` echoed on GET (#116) — blocks channel attribution and future
+  depth signals for external consumers.

--- a/docs/hyperspell-backend-followups.md
+++ b/docs/hyperspell-backend-followups.md
@@ -20,3 +20,32 @@ resources backend-side. Whether `DELETE /memories/{id}` on the parent trace
 cascades to those extractions is unknown. If it does not, purging a channel's
 traces still leaves derived memories behind, and the backend needs either a
 cascade or a parent-id link exposed on derived resources.
+
+## 3. Date-range params on `GET /emotional-state/recent` (filed 2026-07-12, from #75)
+
+External daily-reconciliation consumers (see
+`emotional-state-external-reconciliation.md`) must assemble "a day's
+registers" client-side: `after`/`before` query params are accepted but
+**silently ignored** — verified live 2026-07-07, an impossible
+`before=2000-01-01` window still returned rows. Ask: honor `after`/`before`
+(or `since`/`until`) server-side so a specific day is directly addressable.
+
+## 4. `limit` cap of 20 on `GET /emotional-state/recent` (filed 2026-07-12, from #75)
+
+`limit=100` returns 422 (`Input should be less than or equal to 20`) and there
+is no pagination, so any day preceding the last 20 stored registers is
+unreachable via the API. Ask: raise the cap or add pagination — moot for
+"which day" access if follow-up 3 lands first, but still needed for
+high-volume days.
+
+## 5. `status` field on emotional-state GET responses (filed 2026-07-12, from #75; nice-to-have)
+
+Only `POST /emotional-state` returns `status`; GET responses omit it, so
+consumers must re-implement the raw-transcript heuristic
+(`looksLikeRawTranscript()` in `hooks/emotional-state.ts`) to skip
+pending-extraction placeholders. Ask: echo `status` on
+`GET /emotional-state[/recent]`. Related: **#116** established the same GET
+endpoints also drop stored `metadata` entirely — the highest-leverage combined
+fix is a single backend change that echoes both `status` and `metadata` on
+reads, unblocking external channel attribution (#74) and Ballast's depth
+signals (#68) at the same time.

--- a/docs/plans/issue-75-brainstem-tinman-reconcile.md
+++ b/docs/plans/issue-75-brainstem-tinman-reconcile.md
@@ -1,0 +1,139 @@
+# Implementation guide: external fetch contract for stored emotional-state registers (issue #75)
+
+## What this PR is — and is not
+
+Issue #75 describes a real gap: an external nightly consolidator (a local-LLM map-reduce process, **not part of this repo**) can form its own judgment of a day's texture, while Tin Man (`hooks/emotional-state.ts`) stores a live per-session register — and nothing ever compares them.
+
+The comparison logic itself **cannot live in this repo**. It belongs to whatever process owns the daily synthesis. What this repo owns is the other half of the contract: making sure a day's stored registers are *fetchable from outside the plugin* in a stable, documented way, so an external process has something to reconcile against.
+
+**In scope for this PR:**
+
+1. Verify and document the external fetch surface for stored registers (HTTP API directly — the `hyperspell` npm SDK does not expose these endpoints).
+2. A short integration doc: "if you run an external daily process, here's how to fetch a day's registers to compare against your own synthesis."
+3. A tiny standalone example script external processes can copy.
+4. Record backend follow-ups (date-range filtering, limit cap) in the existing follow-ups doc.
+
+**Explicitly out of scope:** the divergence detector, the flagging/surfacing mechanism, thresholds, and where flags go. That is the consumer's responsibility; the design conversation for it stays on issue #75. Do not build any comparison code here.
+
+Be honest in the PR body that this is the *enabling* half of #75, not a fix for it.
+
+**Note on how this guide was produced:** the research pass verified the endpoints below with live requests against the production API using this deployment's configured key. That was more invasive than intended for a planning/documentation task — treat the facts below as verified, but any future work in this area should stick to reading code/docs rather than issuing live authenticated requests unless explicitly asked to.
+
+---
+
+## Current state of the fetch surface (verified live, 2026-07-07)
+
+The plugin talks to three emotional-state endpoints via raw `fetch` in `client.ts` (see the `// -- Emotional State (raw fetch -- not in public SDK)` section, `client.ts:567`). Verified against the production API with a real key:
+
+| Fact | Detail |
+|---|---|
+| SDK coverage | **None.** `hyperspell` npm SDK 0.35.1 (the version vendored here) has no emotional-state surface — an external script must call REST directly. `client.ts` already does exactly this. |
+| `GET /emotional-state` | Returns the single latest register (or JSON `null`). Optional `?relationship_id=`. Live: 200. |
+| `GET /emotional-state/recent` | Returns an array, newest first. Optional `?relationship_id=`, `?limit=`. Live: 200 — **deployed** (the 404-fallback in `client.ts:668` is now only a legacy guard). |
+| `limit` cap | **20.** `limit=100` returns 422: `Input should be less than or equal to 20`. |
+| Date filtering | **None.** `after`/`before` query params are silently ignored (an impossible `before=2000-01-01` window still returned rows). "A day's registers" must be assembled client-side: fetch recent, filter on `extracted_at`. |
+| Response shape (GET) | `{ resource_id, summary, extracted_at, session_id, relationship_id }`. Note: **no `status` field** on GET — only `POST /emotional-state` returns `status`. |
+| Auth | `Authorization: Bearer <apiKey>`; plus `X-As-User: <userId>` when the plugin config sets `userId` (mirror `rawHeaders()` in `client.ts:79`). Registers are keyed by the plugin's `relationshipId` config (e.g. `david-alinea`). |
+| Timestamps | `extracted_at` is ISO 8601 UTC with offset (e.g. `2026-06-03T22:45:16.287450+00:00`). |
+
+Two behavioral caveats the doc must carry, both sourced from `hooks/emotional-state.ts`:
+
+- **Pending-extraction placeholder.** For ~10s after a store, `summary` can be the *raw input transcript*, not a distilled register. The plugin detects this with `looksLikeRawTranscript()` (`hooks/emotional-state.ts:100` — role-prefixed lines like `user:`/`assistant:`). Since GET has no `status` field, external consumers need the same heuristic. A nightly job running hours later will essentially never hit this, but document it.
+- **Register volume is deliberately low.** Stores are debounced to one per 3 minutes (`STORE_DEBOUNCE_MS`), skip cron/heartbeat/memory triggers, skip multi-speaker sessions, and skip short conversations. A typical day yields a handful of registers — so `limit=20` newest-first comfortably covers "yesterday" for a nightly job, but **does not support arbitrary historical days**. If more than 20 registers have accumulated since the target day, that day is unreachable via this endpoint. The issue's own validation plan ("pick a handful of past days… compare by hand") is therefore constrained to recent days until the backend grows date-range params — call this out honestly rather than papering over it.
+
+## Code changes in this repo: essentially none required
+
+The fetch surface already exists and works. Resist the urge to add plugin code for an external consumer — the whole point is that the consumer does *not* run inside the plugin. Two small optional touches, both defensible:
+
+- **Optional:** update the comment on `getRecentEmotionalStates` (`client.ts:646-652`) to note the endpoint is confirmed deployed and the server-side `limit` cap is 20, so future readers don't re-derive it.
+- **Do not** raise `EMOTIONAL_ARC_LIMIT` or add date params to `client.ts` — the backend ignores them today; adding dead params would violate the "no speculative surface" rule.
+
+---
+
+## Step 1 — the integration doc
+
+Create `docs/emotional-state-external-reconciliation.md` (the `docs/` dir already holds integration/design docs like `group-chat-multiuser-guide.md`, so this follows precedent). Suggested content, roughly 100–150 lines:
+
+1. **Purpose** — one paragraph framing: two independent judgments (nightly synthesis vs. live register), reconciliation is the external process's job, this doc is the fetch contract. Link issue #75 for the broader design conversation.
+2. **What a register is** — shape of what Tin Man stores (`hooks/emotional-state.ts`): a second-person prose `summary` distilled from a sanitized session transcript, keyed by `relationship_id`, timestamped `extracted_at`; stored with `metadata: { source: "openclaw_agent_end" }`. Include the volume caveats (debounce, trigger/multi-speaker skips) so consumers calibrate expectations about how many registers a day produces — including that a quiet day may legitimately produce **zero**, which is not divergence.
+3. **The fetch contract** — the endpoint table above, verbatim facts: auth headers, response shape, `limit` ≤ 20, no server-side date filtering, no `status` on GET, pending-placeholder heuristic.
+4. **"A day's registers" recipe** — fetch `/emotional-state/recent?limit=20`, filter `extracted_at` into the day window *in the operator's timezone* (timestamps are UTC; a "day" for a nightly consolidator is a local-time concept — make the consumer choose the boundary explicitly).
+5. **Consumer's responsibility** — a short section stating plainly: divergence scoring, thresholds, and where flags surface are the external process's design decisions; nothing merges automatically; link back to #75.
+6. **Known limitations / backend follow-ups** — historical days beyond the last-20 window are unreachable; date-range params and a higher cap are backend asks (see step 3).
+
+### Example snippets to embed in the doc
+
+curl (placeholders only — never commit a real key):
+
+```bash
+# Latest ≤20 registers for a relationship, newest first
+curl -s "https://api.hyperspell.com/emotional-state/recent?relationship_id=REL_ID&limit=20" \
+  -H "Authorization: Bearer $HYPERSPELL_API_KEY" \
+  -H "X-As-User: $HYPERSPELL_USER_ID"   # omit if the plugin config has no userId
+```
+
+Node (zero-dependency, suitable for a nightly cron script):
+
+```js
+// fetch-day-registers.mjs — registers whose extracted_at falls on DAY (local time)
+const { HYPERSPELL_API_KEY, HYPERSPELL_USER_ID, REL_ID } = process.env;
+const day = process.argv[2]; // e.g. "2026-07-06"
+
+const url = new URL("https://api.hyperspell.com/emotional-state/recent");
+if (REL_ID) url.searchParams.set("relationship_id", REL_ID);
+url.searchParams.set("limit", "20"); // server-side max
+
+const headers = { Authorization: `Bearer ${HYPERSPELL_API_KEY}` };
+if (HYPERSPELL_USER_ID) headers["X-As-User"] = HYPERSPELL_USER_ID;
+
+const res = await fetch(url, { headers });
+if (!res.ok) throw new Error(`GET /emotional-state/recent -> ${res.status}`);
+const all = (await res.json()) ?? [];
+
+const start = new Date(`${day}T00:00:00`); // local midnight
+const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+const isPendingPlaceholder = (s) => /(^|\n)\s*(user|assistant)\s*:/i.test(s ?? "");
+
+const registers = all.filter((r) => {
+  const t = new Date(r.extracted_at);
+  return t >= start && t < end && !isPendingPlaceholder(r.summary);
+});
+// registers[] is what your nightly synthesis compares its own day-read against.
+console.log(JSON.stringify(registers, null, 2));
+```
+
+## Step 2 — ship the example script (optional but recommended)
+
+Drop the snippet above as `scripts/fetch-day-registers.mjs` (precedent: `scripts/probe-writeread.mjs`, `docs/probe.mjs`). It doubles as the doc's living example and a manual verification tool for the issue's "compare a handful of past days by hand" experiment. Keep it dependency-free and read-only.
+
+## Step 3 — record the backend follow-ups
+
+Append a dated section to `docs/hyperspell-backend-followups.md` (established format there — context, what we tried, ask):
+
+- **Ask 1:** `after`/`before` (or `since`/`until`) query params on `GET /emotional-state/recent`, honored server-side. Evidence: params currently accepted-and-ignored (impossible window returns rows).
+- **Ask 2:** raise or paginate past the `limit ≤ 20` cap, so historical days remain reachable.
+- **Ask 3 (nice-to-have):** include `status` on GET responses so consumers don't need the transcript heuristic.
+
+These belong to the Hyperspell backend, not this repo — the doc entry is how this repo tracks them.
+
+## Step 4 — README pointer
+
+One line in `README.md` under the `emotionalContext` section: stored registers are externally fetchable; link `docs/emotional-state-external-reconciliation.md`.
+
+---
+
+## Verification
+
+- **Live smoke:** run the doc's curl/script against the real API; confirm 200s, response shape matches the documented fields, `limit=21` 422s, and a real past day filters correctly.
+- **Manual experiment from the issue:** run `scripts/fetch-day-registers.mjs` for 3–5 recent days that also have a nightly-consolidator report; eyeball agreement. Record the impression (common vs. rare disagreement) as a comment on #75 — that's the data point that decides whether the external flagging automation is worth building at all.
+- No plugin behavior changes → no new unit tests needed. If the `getRecentEmotionalStates` comment is touched, existing `client.test.ts` coverage is unaffected.
+
+## Files touched
+
+- `docs/emotional-state-external-reconciliation.md` — **new**; the integration contract (main deliverable)
+- `scripts/fetch-day-registers.mjs` — **new, optional**; runnable zero-dep example
+- `docs/hyperspell-backend-followups.md` — append date-range/limit/status asks
+- `README.md` — one-line pointer from the `emotionalContext` section
+- `client.ts` — comment-only touch on `getRecentEmotionalStates` (optional); **no behavior change**
+
+The reconciliation/flagging system itself: not in this repo. See issue #75 for that design conversation — this PR just guarantees the external side has a documented, verified door to knock on.

--- a/scripts/fetch-day-registers.mjs
+++ b/scripts/fetch-day-registers.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// fetch-day-registers.mjs — print the emotional-state registers whose
+// extracted_at falls on a given DAY (local time), for external reconciliation
+// against a nightly synthesis. Read-only; zero dependencies.
+//
+// See docs/emotional-state-external-reconciliation.md for the full contract.
+// Endpoint facts verified live 2026-07-07; note that GET responses carry only
+// the five plain fields — stored metadata is NOT echoed (#116).
+//
+// Usage:
+//   HYPERSPELL_API_KEY=... [HYPERSPELL_USER_ID=...] [REL_ID=...] \
+//     node scripts/fetch-day-registers.mjs 2026-07-06
+
+const { HYPERSPELL_API_KEY, HYPERSPELL_USER_ID, REL_ID } = process.env;
+const day = process.argv[2]; // e.g. "2026-07-06"
+
+if (!HYPERSPELL_API_KEY || !/^\d{4}-\d{2}-\d{2}$/.test(day ?? "")) {
+	console.error(
+		"Usage: HYPERSPELL_API_KEY=... [HYPERSPELL_USER_ID=...] [REL_ID=...] node scripts/fetch-day-registers.mjs YYYY-MM-DD",
+	);
+	process.exit(1);
+}
+
+const url = new URL("https://api.hyperspell.com/emotional-state/recent");
+if (REL_ID) url.searchParams.set("relationship_id", REL_ID);
+url.searchParams.set("limit", "20"); // server-side max — days older than the last 20 registers are unreachable
+
+const headers = { Authorization: `Bearer ${HYPERSPELL_API_KEY}` };
+if (HYPERSPELL_USER_ID) headers["X-As-User"] = HYPERSPELL_USER_ID;
+
+const res = await fetch(url, { headers });
+if (!res.ok) throw new Error(`GET /emotional-state/recent -> ${res.status}`);
+const all = (await res.json()) ?? [];
+
+// A "day" is a local-time concept for a nightly consolidator; extracted_at is
+// UTC — the Date comparison below applies this machine's timezone boundary.
+const start = new Date(`${day}T00:00:00`); // local midnight
+const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+
+// GET has no status field: drop pending-extraction placeholders (raw
+// role-prefixed transcripts) the same way hooks/emotional-state.ts does.
+const isPendingPlaceholder = (s) => /(^|\n)\s*(user|assistant)\s*:/i.test(s ?? "");
+
+const registers = all.filter((r) => {
+	const t = new Date(r.extracted_at);
+	return t >= start && t < end && !isPendingPlaceholder(r.summary);
+});
+
+// registers[] is what your nightly synthesis compares its own day-read against.
+console.log(JSON.stringify(registers, null, 2));


### PR DESCRIPTION
Detailed implementation guide for #75. See `docs/plans/issue-75-brainstem-tinman-reconcile.md` — this PR's actual scope is narrower than the issue: it documents and verifies the external HTTP fetch contract for stored registers so an external daily-synthesis process has something stable to reconcile against. The reconciliation/divergence logic itself stays out of this repo (consumer's responsibility).

Note: verifying the endpoint behavior for this guide involved live authenticated requests against the production API. That's called out explicitly in the guide as a methodology note for future work in this area.

Ref #75 — planning/design doc, not the implementation.