### PR TITLE
Implementation guide: observable mood-weather rolls via recall-excluded records

### DIFF
--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -2,6 +2,8 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { HyperspellClient } from "../client.ts"
 import type { CanReadScope, HyperspellConfig } from "../config.ts"
 import { getWorkspaceDir } from "../config.ts"
+import { MOOD_WEATHER_COLLECTION } from "../hooks/mood-weather.ts"
+import { MOOD_WEATHER_SOURCE } from "../lib/filters.ts"
 import {
   buildScopeFilter,
   getCanReadScopes,
@@ -193,6 +195,44 @@ export function registerCommands(
       } catch (err) {
         log.error("/sync failed", err)
         return { text: "Failed to sync memory files. Check logs for details." }
+      }
+    },
+  })
+
+  // /moodweather — private roll history (operator retrospection only; these rows
+  // are excluded from all agent recall, so this command is the ONLY reader).
+  api.registerCommand({
+    name: "moodweather",
+    description: "Show recent mood-weather rolls (never fed back into tone)",
+    acceptsArgs: false,
+    requireAuth: true,
+    handler: async () => {
+      log.debug("/moodweather command")
+      try {
+        const rows: Array<{ mood: string; rolledAt: string }> = []
+        for await (const mem of client.listMemories({
+          collection: MOOD_WEATHER_COLLECTION,
+          pageSize: 50,
+        })) {
+          if (mem.metadata?.openclaw_source !== MOOD_WEATHER_SOURCE) continue
+          rows.push({
+            mood: String(mem.metadata.mood ?? "?"),
+            rolledAt: String(mem.metadata.rolled_at ?? ""),
+          })
+          if (rows.length >= 20) break
+        }
+        if (rows.length === 0) {
+          return { text: "No mood-weather rolls recorded." }
+        }
+        const lines = rows.map(
+          (r) => `• ${r.rolledAt.slice(0, 16).replace("T", " ")} — ${r.mood}`,
+        )
+        return {
+          text: `Recent mood-weather rolls (newest first):\n${lines.join("\n")}`,
+        }
+      } catch (err) {
+        log.error("/moodweather failed", err)
+        return { text: "Failed to fetch mood-weather history. Check logs for details." }
       }
     },
   })

--- a/docs/filter-dialect-test.mjs
+++ b/docs/filter-dialect-test.mjs
@@ -11,8 +11,13 @@
 //   H  — tagged openclaw_source="hot_buffer"  via memories.add (Option 2 sim)
 //   Um — UNTAGGED-but-with-metadata via POST /messages (tests whether /messages
 //        even accepts metadata — i.e. whether Option 2 is possible for hot rows)
+//   M  — tagged openclaw_source="mood_weather" via memories.add (issue #71 roll
+//        record; the second value the multi-value exclude must drop)
 //
 // Goal filter: returns U=yes, A=no, status 200. Everything is deleted at the end.
+// Issue #71 (multi-value exclude, post-#1921 re-verification): the
+// $nin[agent_end,mood_weather] row must show U=Y, A=N, M=N; $and[$ne,$ne] is
+// the fallback shape if $nin fails.
 //
 // Run:  node docs/filter-dialect-test.mjs
 
@@ -30,7 +35,7 @@ if (!userId) { console.error("no userId; aborting"); process.exit(1) }
 
 const run = Date.now().toString(36)
 const SHARED = `dialecttest-${run}` // common term in every canary
-const tok = { U: `tokU-${run}`, A: `tokA-${run}`, H: `tokH-${run}`, Um: `tokUm-${run}` }
+const tok = { U: `tokU-${run}`, A: `tokA-${run}`, H: `tokH-${run}`, Um: `tokUm-${run}`, M: `tokM-${run}` }
 const Uid = `fdt-U-${run}`
 const Umid = `fdt-Um-${run}`
 
@@ -56,7 +61,7 @@ const rUm = await postMessage(Umid, tok.Um, { metadata: { openclaw_source: "hot_
 console.log(`Um (/messages + metadata)      -> ${rUm.status} ${rUm.body ? "("+rUm.body.slice(0,60)+")" : ""}`)
 if (rUm.status < 300) created.push({ label: "Um", resource_id: Umid, via: "messages" })
 
-let A, H
+let A, H, M
 try {
   A = await client.memories.add({ text: `${SHARED} ${tok.A}. Safe to delete.`, title: `FDT A ${run}`, collection: "openclaw", metadata: { openclaw_source: "agent_end" } }, ro)
   console.log(`A  (memories.add agent_end)    -> ${A.resource_id}`)
@@ -67,6 +72,11 @@ try {
   console.log(`H  (memories.add hot_buffer)   -> ${H.resource_id}`)
   created.push({ label: "H", resource_id: H.resource_id, via: "memories" })
 } catch (e) { console.log("H add failed:", e?.status, e?.message) }
+try {
+  M = await client.memories.add({ text: `${SHARED} ${tok.M}. Safe to delete.`, title: `FDT M ${run}`, collection: "mood-weather", metadata: { openclaw_source: "mood_weather" } }, ro)
+  console.log(`M  (memories.add mood_weather) -> ${M.resource_id}`)
+  created.push({ label: "M", resource_id: M.resource_id, via: "memories" })
+} catch (e) { console.log("M add failed:", e?.status, e?.message) }
 
 console.log("\nindexing… (4s)")
 await sleep(4000)
@@ -78,7 +88,7 @@ async function probe(filter) {
     const r = await client.memories.search({ query: SHARED, options: opts }, ro)
     const hay = r.documents.map((d) => `${d.resource_id} ${d.title ?? ""} ${(d.highlights ?? []).map((h) => h.text).join(" ")}`).join(" || ")
     const has = (t, id) => hay.includes(t) || hay.includes(id)
-    return { status: 200, n: r.documents.length, U: has(tok.U, Uid), Um: has(tok.Um, Umid), A: has(tok.A, A?.resource_id ?? "A?"), H: has(tok.H, H?.resource_id ?? "H?") }
+    return { status: 200, n: r.documents.length, U: has(tok.U, Uid), Um: has(tok.Um, Umid), A: has(tok.A, A?.resource_id ?? "A?"), H: has(tok.H, H?.resource_id ?? "H?"), M: has(tok.M, M?.resource_id ?? "M?") }
   } catch (e) { return { status: e?.status ?? "ERR", err: e?.message } }
 }
 
@@ -95,15 +105,19 @@ const FILTERS = [
   ["$eq hot_buffer", { openclaw_source: { $eq: "hot_buffer" } }],
   ["$in[hot_buffer]", { openclaw_source: { $in: ["hot_buffer"] } }],
   ["$and[$ne]", { $and: [{ openclaw_source: { $ne: "agent_end" } }] }],
+  // issue #71 — multi-value exclude candidates (post-#1921 re-verification).
+  // Success criterion: U=Y, A=N, M=N, status 200. Prefer $nin; $and-of-$ne is the fallback.
+  ["$nin[agent_end,mood_weather]", { openclaw_source: { $nin: ["agent_end", "mood_weather"] } }],
+  ["$and[$ne,$ne]", { $and: [{ openclaw_source: { $ne: "agent_end" } }, { openclaw_source: { $ne: "mood_weather" } }] }],
 ]
 
-console.log("\n=== truth table (want: U=Y, A=N, status 200) ===")
-console.log("filter".padEnd(26), "stat", " U ", "Um ", " A ", " H ", " n")
+console.log("\n=== truth table (want: U=Y, A=N, status 200; #71 rows also want M=N) ===")
+console.log("filter".padEnd(30), "stat", " U ", "Um ", " A ", " H ", " M ", " n")
 for (const [label, f] of FILTERS) {
   const r = await probe(f)
-  if (r.status !== 200) { console.log(label.padEnd(26), String(r.status).padEnd(4), " — err:", r.err); continue }
+  if (r.status !== 200) { console.log(label.padEnd(30), String(r.status).padEnd(4), " — err:", r.err); continue }
   const y = (b) => (b ? " Y " : " . ")
-  console.log(label.padEnd(26), "200 ", y(r.U), y(r.Um), y(r.A), y(r.H), String(r.n).padStart(2))
+  console.log(label.padEnd(30), "200 ", y(r.U), y(r.Um), y(r.A), y(r.H), y(r.M), String(r.n).padStart(2))
 }
 
 // --- cleanup everything ---
@@ -119,4 +133,4 @@ for (const c of created) {
     } catch { console.log("COULD NOT DELETE", c.label, c.resource_id, "— token", tok[c.label]) }
   }
 }
-console.log("\nKey: U=untagged hot row (KEEP), A=agent_end (DROP), Um=/messages+metadata (does tagging stick?), H=tagged hot_buffer (Option 2)")
+console.log("\nKey: U=untagged hot row (KEEP), A=agent_end (DROP), Um=/messages+metadata (does tagging stick?), H=tagged hot_buffer (Option 2), M=mood_weather roll record (DROP — issue #71)")

--- a/docs/plans/issue-71-mood-weather-observability.md
+++ b/docs/plans/issue-71-mood-weather-observability.md
@@ -4,6 +4,8 @@
 
 Each time a mood actually lands (i.e. is injected into a session), fire-and-forget a small memory row tagged `openclaw_source: "mood_weather"` via the existing `memories.add` write path, and extend the existing exclude-filter mechanism in `lib/filters.ts` so that tag is dropped from every recall path the same way `agent_end` traces already are. The "never writes forward" guarantee stays enforced by construction: the emotional-state **store** handler (`POST /emotional-state`) is untouched, the record goes to a completely separate store (vault memories), and the arc **fetch** (`GET /emotional-state[/recent]`) can never return it because it reads a different endpoint keyed by `relationship_id`. The only new leak surface is generic memory recall — which is exactly what the exclude filter closes.
 
+**⚠️ Coordination with issue #77 (mood-weather cross-session cooldown) — read before implementing either.** Both this guide and #77's restructure the same two return sites inside `buildEmotionalStateFetchHandler`. #77 introduces a `priorMood`/cooldown mechanism so a post-compaction re-injection *replays* the same mood instead of rolling fresh dice, and its natural landing spot for "a roll genuinely happened" is a guard shaped `if (mood && !priorMood)`. **`recordMoodRoll` must be called inside that guard, not on a bare `if (mood)`** — otherwise, once #77 lands, a post-compaction replay of an already-rolled mood would call `recordMoodRoll` a second time for the same roll, producing a duplicate observability record for one real event. If #71 lands first (without #77's `priorMood` concept yet), use `if (mood)` as written below, but whoever implements #77 afterward must move the call into its `if (mood && !priorMood)` block rather than leaving a duplicate. If #77 lands first, skip straight to the reconciled version and call `recordMoodRoll` from its guard. Either PR's author should check whether the other has already merged and adjust accordingly — this note exists so neither implementer is surprised by the other's shape.
+
 **No backend change is needed.** This is purely client-side:
 
 - `memories.add` metadata is **proven** to persist and be filterable — canary `A` in `docs/filter-dialect-test.mjs` was tagged via `memories.add` and both matched `{$eq}` and was dropped by `{$ne}` (see truth table in `docs/hyperspell-backend-followups.md`).
@@ -140,7 +142,9 @@ Also update the `DOES NOT WRITE FORWARD` bullet in the file header (`hooks/mood-
 
 ### Call sites in `hooks/emotional-state.ts` (`buildEmotionalStateFetchHandler`)
 
-Critical placement detail: the handler can roll a mood and then **discard** it — the "still extracting" branch (`hooks/emotional-state.ts:202-212`) returns without injecting `moodBlock`, and the next turn re-rolls. Record **only when the mood block is actually returned**, or the log will show weather that never happened. Two injection sites:
+Critical placement detail: the handler can roll a mood and then **discard** it — the "still extracting" branch returns without injecting `moodBlock`, and the next turn re-rolls. Record **only when the mood block is actually returned**, or the log will show weather that never happened.
+
+**If #77 has not landed yet** (no `priorMood`/cooldown concept exists), two injection sites, gated on bare `if (mood)`:
 
 ```ts
 // blank-slate return
@@ -157,7 +161,9 @@ if (mood) recordMoodRoll(client, mood, { sessionKey, relationshipId: cfg.relatio
 return { prependContext: context };
 ```
 
-Because the inject-once cache (`injectedSessions`) gates the whole path, this is at most **one record per injected session** — matching the roll semantics exactly.
+Because the inject-once cache (`injectedSessions`) gates the whole path, this is at most **one record per injected session** — matching the roll semantics exactly, *as long as #77 hasn't also landed introducing mid-session mood replay across compaction*.
+
+**If #77 has already landed** (its `priorMood`/`sessionMoods` replay mechanism exists), the gate must be `if (mood && !priorMood)` instead of `if (mood)` at both sites — see #77's guide for the exact surrounding code. Calling `recordMoodRoll` on a `priorMood` replay (post-compaction re-injection of an already-rolled mood) would log the same roll twice, which is exactly the kind of noise this feature exists to avoid.
 
 **Quarantine is inherited for free:** the merged start-handler wrapper in `index.ts` skips the fetch handler entirely for `excludeChannels` conversations, so no roll and no write happen there — consistent with the "no memory writes" quarantine contract.
 

--- a/docs/plans/issue-71-mood-weather-observability.md
+++ b/docs/plans/issue-71-mood-weather-observability.md
@@ -1,0 +1,255 @@
+# Implementation guide — issue #71: make mood-weather rolls observable without ever feeding them back
+
+## Design summary
+
+Each time a mood actually lands (i.e. is injected into a session), fire-and-forget a small memory row tagged `openclaw_source: "mood_weather"` via the existing `memories.add` write path, and extend the existing exclude-filter mechanism in `lib/filters.ts` so that tag is dropped from every recall path the same way `agent_end` traces already are. The "never writes forward" guarantee stays enforced by construction: the emotional-state **store** handler (`POST /emotional-state`) is untouched, the record goes to a completely separate store (vault memories), and the arc **fetch** (`GET /emotional-state[/recent]`) can never return it because it reads a different endpoint keyed by `relationship_id`. The only new leak surface is generic memory recall — which is exactly what the exclude filter closes.
+
+**No backend change is needed.** This is purely client-side:
+
+- `memories.add` metadata is **proven** to persist and be filterable — canary `A` in `docs/filter-dialect-test.mjs` was tagged via `memories.add` and both matched `{$eq}` and was dropped by `{$ne}` (see truth table in `docs/hyperspell-backend-followups.md`).
+- Do **not** use `POST /messages` (`sendMessages`) for this — per the warning in `lib/filters.ts:30-33`, a `/messages` write carrying metadata renders the row non-retrievable.
+- No new `HyperspellClient` method is needed. `client.ts`'s `addMemory` already accepts arbitrary metadata and its default `openclaw_source: "command"` is overridden by the spread (`client.ts:290-297`: `openclaw_source: "command", ...options?.metadata`), so passing `metadata: { openclaw_source: "mood_weather", ... }` wins. Reuse it.
+
+The one open backend question is the **multi-value filter shape** (step 0 below).
+
+## Step 0 (blocking): verify the multi-value filter shape live
+
+Today's shipped filter is exactly:
+
+```ts
+// lib/filters.ts:39-41
+export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
+  openclaw_source: { $ne: "agent_end" },
+}
+```
+
+We now need to exclude **two** values when both auto-trace and mood-weather are enabled. The pre-#1921 truth table (`docs/hyperspell-backend-followups.md:39-49`) shows `$nin` behaved *differently* from `$ne` (returned 4 rows vs `$ne`'s 7) and `$and:[{$ne}]` returned **0 rows**. Backend #1921 changed `$ne` to MongoDB absent-field semantics (per the header comment in `lib/filters.ts:19-23`), but `$nin` and `$and`-of-`$ne` have **not been re-verified post-#1921**.
+
+Before writing the filter code, extend `docs/filter-dialect-test.mjs`:
+
+1. Add a canary `M` — `memories.add` with `metadata: { openclaw_source: "mood_weather" }` (copy the `A` canary block).
+2. Add to `FILTERS`:
+   - `["$nin[agent_end,mood_weather]", { openclaw_source: { $nin: ["agent_end", "mood_weather"] } }]`
+   - `["$and[$ne,$ne]", { $and: [{ openclaw_source: { $ne: "agent_end" } }, { openclaw_source: { $ne: "mood_weather" } }] }]`
+3. Run it. Success criterion: `U=Y, A=N, M=N, status 200`.
+
+Pick whichever shape passes (prefer `$nin` — one predicate, likely same ~1s cost as the current single `$ne`; `$and`-of-`$ne` is the fallback). **Contingency:** if neither passes, single-value `$ne` still covers the two common configs (only one feature on at a time — see gating below); file a backend follow-up in the style of `docs/hyperspell-backend-followups.md` for the both-on combo and log a warning when both features are enabled. The rest of this guide assumes `$nin` verifies.
+
+## 1. Filter change — `lib/filters.ts`
+
+Replace the single-value constant with a config-driven list. Keep the per-feature gating pattern (it exists for the ~1s/search latency of any `openclaw_source` predicate):
+
+```ts
+/** Metadata tag values excluded from all generic recall. */
+export const AGENT_END_SOURCE = "agent_end"
+export const MOOD_WEATHER_SOURCE = "mood_weather"
+
+/** Minimal slice of config the exclude logic needs (avoids a config-module cycle). */
+type ExcludeCfg = {
+  autoTrace: { enabled: boolean }
+  emotionalContext: boolean
+  moodWeatherChance: number
+}
+
+export function excludeFilterFor(
+  cfg: ExcludeCfg,
+): Record<string, unknown> | undefined {
+  const excluded: string[] = []
+  if (cfg.autoTrace.enabled) excluded.push(AGENT_END_SOURCE)
+  // Mood rolls are recorded only when the emotional-context handler is
+  // registered AND the dice are live — same "no rows to hide → skip the
+  // ~1s predicate" gate as auto-trace.
+  if (cfg.emotionalContext && cfg.moodWeatherChance > 0) {
+    excluded.push(MOOD_WEATHER_SOURCE)
+  }
+  if (excluded.length === 0) return undefined
+  // Single value: keep the proven plain-$ne shape. Two values: $nin
+  // (verified live post-#1921 — see docs/filter-dialect-test.mjs).
+  if (excluded.length === 1) return { openclaw_source: { $ne: excluded[0] } }
+  return { openclaw_source: { $nin: excluded } }
+}
+```
+
+- **Delete** `EXCLUDE_SESSION_END_FILTER` — its only consumers are `lib/filters.ts` and `lib/filters.test.ts` (verified by grep); update the tests rather than keeping the stale export.
+- `mergeWithExclude` needs **no change** — it delegates to `excludeFilterFor`.
+- All production call sites pick this up automatically with zero edits, because they pass the full `HyperspellConfig` (which structurally satisfies the widened `ExcludeCfg`): `hooks/auto-context.ts:193`, `hooks/auto-context.ts:278`, `hooks/auto-context.ts:291`, `tools/search.ts:90`.
+
+### Closing the remaining recall paths
+
+- **Emotional-state arc fetch** — nothing to do; excluded by construction. `getEmotionalState` / `getRecentEmotionalStates` (`client.ts:612-688`) read `GET /emotional-state[/recent]`, a separate store that only `storeEmotionalState` writes to. A vault memory row cannot appear there. State this in a comment on the write helper.
+- **Startup-orientation loops search** — `hooks/startup-orientation.ts:271-274` calls `client.search(so.loopsQuery, { limit, userId })` with **no filter**. This is a context-injection path; add `filter: excludeFilterFor(cfg)`. (Note in the PR: this also closes a pre-existing gap where `agent_end` traces could surface in the loops block.) The recent-interactions paths are already safe: `fetchRecentConversations` skips any row with a truthy `metadata.openclaw_source` (`hooks/startup-orientation.ts:185`), and `fetchRecentTraces` requires `openclaw_source === "agent_end"` (`hooks/startup-orientation.ts:130`).
+- **Knowledge graph** — `graph/ops.ts:94-107` `scanMemories` iterates all memories and would ingest mood rows into the graph (which feeds context). Add after line 106: `if (mem.metadata?.openclaw_source === MOOD_WEATHER_SOURCE) continue` (import from `lib/filters.ts`).
+- **`/getcontext`** (`commands/slash.ts:75`) does not apply the exclude filter today (for `agent_end` either). That's an operator-facing command reply, not agent context, so leaving it is consistent — and it doubles as an ad-hoc retrieval path. Leave as-is; note in the PR.
+
+## 2. Write path — record the roll
+
+### Helper in `hooks/mood-weather.ts`
+
+Put the recorder next to the mood table it describes (it imports `MOOD_WEATHER_SOURCE` from `lib/filters.ts` — hooks→lib is the normal direction, no cycle):
+
+```ts
+import type { HyperspellClient } from "../client.ts";
+import { MOOD_WEATHER_SOURCE } from "../lib/filters.ts";
+import { log } from "../logger.ts";
+
+/** Collection the roll records live in, so /moodweather can list them without a search. */
+export const MOOD_WEATHER_COLLECTION = "mood-weather";
+
+/**
+ * Fire-and-forget observability record for a mood roll (issue #71).
+ *
+ * This does NOT weaken the "does not write forward" contract above: the record
+ * goes to the generic vault store tagged openclaw_source="mood_weather", which
+ * excludeFilterFor() drops from every recall path (auto-context, the
+ * hyperspell_search tool, startup-orientation loops, knowledge graph). The
+ * emotional-state arc fetch reads a different endpoint entirely, so it can
+ * never surface there. Queryable only via the dedicated /moodweather command.
+ *
+ * Deliberately not awaited: this sits on the first-turn injection hot path, and
+ * a logging write must never delay or break the session.
+ */
+export function recordMoodRoll(
+  client: HyperspellClient,
+  mood: MoodSpec,
+  opts: { sessionKey?: string; relationshipId?: string },
+): void {
+  const rolledAt = new Date().toISOString();
+  void client
+    .addMemory(
+      `Mood weather roll: woke up "${mood.id}" (${rolledAt}). Exogenous session mood — uncaused, session-only, never part of the relational register.`,
+      {
+        title: `Mood weather — ${mood.id} (${rolledAt.slice(0, 10)})`,
+        collection: MOOD_WEATHER_COLLECTION,
+        metadata: {
+          openclaw_source: MOOD_WEATHER_SOURCE,
+          mood: mood.id,
+          rolled_at: rolledAt,
+          ...(opts.sessionKey ? { session: opts.sessionKey } : {}),
+          ...(opts.relationshipId ? { relationship_id: opts.relationshipId } : {}),
+        },
+      },
+    )
+    .catch((err) => {
+      // Fire-and-forget — observability must never break the session.
+      log.warn("mood-weather: roll record write failed (non-fatal)", err);
+    });
+}
+```
+
+Also update the `DOES NOT WRITE FORWARD` bullet in the file header (`hooks/mood-weather.ts:21-24`) to say: *"…A private, recall-excluded observability record IS written per roll (issue #71) — see recordMoodRoll; it is invisible to every injection/recall path, so the guarantee holds."*
+
+### Call sites in `hooks/emotional-state.ts` (`buildEmotionalStateFetchHandler`)
+
+Critical placement detail: the handler can roll a mood and then **discard** it — the "still extracting" branch (`hooks/emotional-state.ts:202-212`) returns without injecting `moodBlock`, and the next turn re-rolls. Record **only when the mood block is actually returned**, or the log will show weather that never happened. Two injection sites:
+
+```ts
+// blank-slate return
+if (sessionKey) injectedSessions.add(sessionKey);
+if (mood) recordMoodRoll(client, mood, { sessionKey, relationshipId: cfg.relationshipId });
+return moodBlock ? { prependContext: moodBlock } : undefined;
+```
+
+In the arc branch:
+
+```ts
+if (sessionKey) injectedSessions.add(sessionKey);
+if (mood) recordMoodRoll(client, mood, { sessionKey, relationshipId: cfg.relationshipId });
+return { prependContext: context };
+```
+
+Because the inject-once cache (`injectedSessions`) gates the whole path, this is at most **one record per injected session** — matching the roll semantics exactly.
+
+**Quarantine is inherited for free:** the merged start-handler wrapper in `index.ts` skips the fetch handler entirely for `excludeChannels` conversations, so no roll and no write happen there — consistent with the "no memory writes" quarantine contract.
+
+## 3. Retrieval path — `/moodweather` command (in scope, small)
+
+Include it in this PR: it's ~30 lines, it's the only way to satisfy the issue's third test ("CAN be retrieved via a dedicated path"), and it follows the existing pattern in `commands/slash.ts`. Register alongside `/getcontext`:
+
+```ts
+// /moodweather — private roll history (operator retrospection only; these rows
+// are excluded from all agent recall, so this command is the ONLY reader).
+api.registerCommand({
+  name: "moodweather",
+  description: "Show recent mood-weather rolls (never fed back into tone)",
+  acceptsArgs: false,
+  requireAuth: true,
+  handler: async () => {
+    try {
+      const rows: Array<{ mood: string; rolledAt: string }> = []
+      for await (const mem of client.listMemories({
+        collection: MOOD_WEATHER_COLLECTION,
+        pageSize: 50,
+      })) {
+        if (mem.metadata?.openclaw_source !== MOOD_WEATHER_SOURCE) continue
+        rows.push({
+          mood: String(mem.metadata.mood ?? "?"),
+          rolledAt: String(mem.metadata.rolled_at ?? ""),
+        })
+        if (rows.length >= 20) break
+      }
+      if (rows.length === 0) return { text: "No mood-weather rolls recorded." }
+      const lines = rows.map((r) => `• ${r.rolledAt.slice(0, 16).replace("T", " ")} — ${r.mood}`)
+      return { text: `Recent mood-weather rolls (newest first):\n${lines.join("\n")}` }
+    } catch (err) {
+      log.error("/moodweather failed", err)
+      return { text: "Failed to fetch mood-weather history. Check logs for details." }
+    }
+  },
+})
+```
+
+`listMemories` returns newest-first, and the mood + timestamp live in metadata, so no content parsing is needed. A `/moodweather clear` (bulk `deleteMemory`) is a reasonable **follow-up**, not this PR.
+
+## 4. Tests
+
+### `lib/filters.test.ts` (rewrite the fixtures)
+
+```ts
+const BOTH_OFF = { autoTrace: { enabled: false }, emotionalContext: false, moodWeatherChance: 0 }
+const TRACE_ON = { autoTrace: { enabled: true },  emotionalContext: false, moodWeatherChance: 0 }
+const MOOD_ON  = { autoTrace: { enabled: false }, emotionalContext: true,  moodWeatherChance: 0.1 }
+const BOTH_ON  = { autoTrace: { enabled: true },  emotionalContext: true,  moodWeatherChance: 0.1 }
+```
+
+- `excludeFilterFor(BOTH_OFF)` → `undefined`
+- `excludeFilterFor(TRACE_ON)` → `{ openclaw_source: { $ne: "agent_end" } }` (proves the shipped single-`$ne` shape is byte-identical to today's — no regression for existing users)
+- `excludeFilterFor(MOOD_ON)` → `{ openclaw_source: { $ne: "mood_weather" } }`
+- `excludeFilterFor(BOTH_ON)` → `{ openclaw_source: { $nin: ["agent_end", "mood_weather"] } }`
+- mood gate requires **both** flags: `{ ...MOOD_ON, emotionalContext: false }` → `undefined`; `{ ...MOOD_ON, moodWeatherChance: 0 }` → `undefined`
+- `mergeWithExclude(base, BOTH_ON)` → `{ $and: [base, <nin filter>] }`; `mergeWithExclude(base, BOTH_OFF)` → `base`
+
+### `hooks/emotional-state.test.ts` (roll → write)
+
+Extend `FakeClient` with a recorder. Use `cfg = { relationshipId: "rel-x", emotionalContext: true, moodWeatherChance: 1 }` — chance 1 makes `rollMood` deterministic. Since the write is un-awaited, flush microtasks with `await new Promise((r) => setImmediate(r))` before asserting.
+
+1. **Roll triggers exactly one tagged write:** first turn with a usable arc → `prependContext` contains `<hyperspell-mood-weather>`; after flush, `client.added.length === 1`, tagged `mood_weather`, valid mood id, valid timestamp, correct collection. Second turn same session → no new write (inject-once cache).
+2. **Write failure never breaks the session:** `addMemory` rejects → handler still resolves with the injection; no throw, no unhandled rejection.
+3. **Discarded roll is not recorded:** arc client returning only raw-transcript-placeholder states with `moodWeatherChance: 1` → handler returns `undefined` and `client.added.length === 0`.
+4. **Chance 0 → no write.**
+
+### Live proof (before landing)
+
+1. Run the extended `docs/filter-dialect-test.mjs` — the `$nin` row must show `U=Y, A=N, M=N`.
+2. On a dev agent set `moodWeatherChance: 1`, start a fresh session; confirm the log line and that `/moodweather` shows the entry.
+3. Negative recall check: send a prompt that is a strong semantic match for the record text and confirm auto-context/hyperspell_search return no `mood_weather` row.
+
+## 5. Edge cases and decisions to state in the PR
+
+- **Fire-and-forget contract:** never `await` because the write sits on the first-turn injection path; matches the store handler's "never let this break the session" pattern.
+- **Filter gating tradeoff (pre-existing, now shared):** if `moodWeatherChance` later goes back to 0, old rows lose their filter gate — same accepted tradeoff the `agent_end` gate has. Document it; a cleanup command is follow-up material.
+- **Multi-user:** the record is written as the primary configured user (no `userId` passed), same as the emotional register itself.
+- **`/messages` is off-limits** for this write; `memories.add` is the proven path.
+- **Backend coordination:** none required for the core feature. Only the both-features-on `$nin` shape needs live confirmation (step 0); if it fails, ship the single-`$ne` gating and file a backend dialect follow-up.
+
+## Files touched
+
+- `lib/filters.ts` — `AGENT_END_SOURCE`/`MOOD_WEATHER_SOURCE` constants, list-driven `excludeFilterFor` (`$ne`/`$nin`), widened `ExcludeCfg`, delete `EXCLUDE_SESSION_END_FILTER`
+- `lib/filters.test.ts` — new gating/shape truth-table tests
+- `hooks/mood-weather.ts` — `recordMoodRoll`, `MOOD_WEATHER_COLLECTION`, header-contract comment update
+- `hooks/emotional-state.ts` — call `recordMoodRoll` at the two injection return sites in `buildEmotionalStateFetchHandler`
+- `hooks/emotional-state.test.ts` — roll-writes-record, write-failure, discarded-roll, chance-0 tests
+- `hooks/startup-orientation.ts` — add `filter: excludeFilterFor(cfg)` to the loops search
+- `graph/ops.ts` — skip `mood_weather`-tagged rows in `scanMemories`
+- `commands/slash.ts` — `/moodweather` history command
+- `docs/filter-dialect-test.mjs` — `M` canary + `$nin`/`$and` probe rows
+- `hooks/auto-context.test.ts`, `tools/search.test.ts` — fixture config fields only, if the compiler asks

--- a/graph/ops.ts
+++ b/graph/ops.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
+import { MOOD_WEATHER_SOURCE } from "../lib/filters.ts"
 import { getAllUserIds } from "../lib/sender.ts"
 import { log } from "../logger.ts"
 import { NetworkStateManager } from "./state.ts"
@@ -105,6 +106,9 @@ export async function scanMemories(
       if (stateManager.isProcessed(mem.resourceId)) continue
       if (mem.metadata?.graph_entity === "true" || mem.metadata?.graph_entity === true) continue
       if ((mem.metadata?.status as string) !== "completed") continue
+      // Mood-weather roll records are observability-only (issue #71): the graph
+      // feeds context, so ingesting them would leak the rolls back into recall.
+      if (mem.metadata?.openclaw_source === MOOD_WEATHER_SOURCE) continue
 
       let summary = ""
       try {

--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -17,9 +17,19 @@ type State = {
 	sessionId: string | null;
 	relationshipId: string | null;
 };
+type AddedMemory = {
+	text: string;
+	options?: {
+		title?: string;
+		collection?: string;
+		metadata?: Record<string, string | number | boolean>;
+	};
+};
 type FakeClient = {
 	getEmotionalState: (relId?: string) => Promise<State | null>;
 	getRecentEmotionalStates: (relId?: string, limit?: number) => Promise<State[] | null>;
+	addMemory: (text: string, options?: AddedMemory["options"]) => Promise<{ resourceId: string }>;
+	added: AddedMemory[];
 	callCount: number;
 };
 
@@ -36,6 +46,7 @@ function makeClient(
 ): { client: FakeClient } {
 	const client: FakeClient = {
 		callCount: 0,
+		added: [],
 		// Default mock: /recent unavailable (null) → handler falls back to getEmotionalState.
 		async getRecentEmotionalStates() {
 			return null;
@@ -43,6 +54,11 @@ function makeClient(
 		async getEmotionalState() {
 			client.callCount++;
 			return summary === null ? null : st(summary);
+		},
+		// Records recordMoodRoll's fire-and-forget observability write (#71).
+		async addMemory(text, options) {
+			client.added.push({ text, options });
+			return { resourceId: `mem-${client.added.length}` };
 		},
 	};
 	return { client };
@@ -52,9 +68,10 @@ function makeClient(
 function makeArcClient(states: State[] | null): {
 	client: FakeClient & { recentCalls: number };
 } {
-	const client = {
+	const client: FakeClient & { recentCalls: number } = {
 		callCount: 0,
 		recentCalls: 0,
+		added: [],
 		async getRecentEmotionalStates() {
 			client.recentCalls++;
 			return states;
@@ -62,6 +79,10 @@ function makeArcClient(states: State[] | null): {
 		async getEmotionalState() {
 			client.callCount++;
 			return null;
+		},
+		async addMemory(text, options) {
+			client.added.push({ text, options });
+			return { resourceId: `mem-${client.added.length}` };
 		},
 	};
 	return { client };
@@ -542,6 +563,9 @@ test("mood weather — a still-extracting turn does not consume the roll", async
 				? st("user: hi\nassistant: hey")
 				: st("Settled and warm.");
 		},
+		async addMemory() {
+			return { resourceId: "mem-x" };
+		},
 	};
 	const handler = buildEmotionalStateFetchHandler(
 		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
@@ -559,4 +583,111 @@ test("mood weather — a still-extracting turn does not consume the roll", async
 		String((second as { prependContext?: string })?.prependContext ?? ""),
 		/Settled and warm/,
 	);
+});
+
+// ---- mood weather: roll observability record (issue #71) --------------------
+
+/** recordMoodRoll is fire-and-forget (un-awaited) — flush microtasks/immediates before asserting. */
+const flushAsyncWrites = () => new Promise((r) => setImmediate(r));
+
+const MOOD_IDS = MOOD_TABLE.map((m) => m.id);
+
+test("mood weather observability — a landed roll writes exactly one tagged record", async () => {
+	const { client } = makeClient("Warm and steady.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-obs-write"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+
+	const first = await handler({}, { sessionKey: "obs-s1" });
+	assert.ok(hasMood(first), "chance=1 → weather lands");
+	await flushAsyncWrites();
+
+	assert.equal(client.added.length, 1, "exactly one observability record per roll");
+	const rec = client.added[0];
+	assert.equal(rec.options?.collection, "mood-weather");
+	assert.equal(rec.options?.metadata?.openclaw_source, "mood_weather");
+	assert.ok(
+		MOOD_IDS.includes(String(rec.options?.metadata?.mood)),
+		"metadata.mood is a valid mood id",
+	);
+	const rolledAt = String(rec.options?.metadata?.rolled_at);
+	assert.ok(!Number.isNaN(new Date(rolledAt).getTime()), "rolled_at is a valid timestamp");
+	assert.equal(rec.options?.metadata?.session, "obs-s1");
+	assert.equal(rec.options?.metadata?.relationship_id, "rel-obs-write");
+
+	const second = await handler({}, { sessionKey: "obs-s1" });
+	assert.equal(second, undefined, "inject-once cache holds");
+	await flushAsyncWrites();
+	assert.equal(client.added.length, 1, "no second record for the same session");
+});
+
+test("mood weather observability — post-compaction replay does NOT record a second roll", async () => {
+	// The recordMoodRoll call lives inside the !priorMood guard: a replay of an
+	// already-rolled mood is not a new roll and must not double-log.
+	const { client } = makeClient("Warm and steady.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-obs-replay"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+	const onCompaction = buildEmotionalStateCompactionHandler();
+	const ctx = { sessionKey: "obs-replay" };
+
+	const first = await handler({}, ctx);
+	assert.ok(hasMood(first));
+	await onCompaction({}, ctx);
+	const replay = await handler({}, ctx);
+	assert.ok(hasMood(replay), "replay re-injects the same mood");
+	await flushAsyncWrites();
+	assert.equal(client.added.length, 1, "one roll, one record — replay does not double-log");
+});
+
+test("mood weather observability — a failing record write never breaks the session", async () => {
+	const { client } = makeClient("Warm and steady.");
+	client.addMemory = async () => {
+		throw new Error("backend down");
+	};
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-obs-fail"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+
+	const out = await handler({}, { sessionKey: "obs-fail" });
+	assert.ok(hasMood(out), "injection succeeds even though the record write rejects");
+	// Flush the rejected write — recordMoodRoll's .catch must swallow it (an
+	// unhandled rejection would fail the test run).
+	await flushAsyncWrites();
+});
+
+test("mood weather observability — a discarded roll is not recorded", async () => {
+	// Only raw-transcript placeholders → the still-extracting early return fires
+	// BEFORE the roll, so nothing lands and nothing may be written.
+	const { client } = makeArcClient([st("user: hi\nassistant: hey")]);
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-obs-discard"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+
+	const out = await handler({}, { sessionKey: "obs-discard" });
+	assert.equal(out, undefined, "still extracting — no injection");
+	await flushAsyncWrites();
+	assert.equal(client.added.length, 0, "no record for weather that never happened");
+});
+
+test("mood weather observability — chance 0 writes nothing", async () => {
+	const { client } = makeClient("Warm and steady.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-obs-zero", 0),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+
+	const out = await handler({}, { sessionKey: "obs-zero" });
+	assert.ok(!hasMood(out), "no dice → no weather");
+	await flushAsyncWrites();
+	assert.equal(client.added.length, 0);
 });

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -5,7 +5,12 @@ import { resolveCurrentSessionId } from "../lib/session.ts";
 import { isMultiSpeaker } from "../lib/speaker-tracker.ts";
 import { log } from "../logger.ts";
 import { sanitizeTraceText } from "./auto-trace.ts";
-import { buildMoodWeatherContext, type MoodSpec, rollMood } from "./mood-weather.ts";
+import {
+	buildMoodWeatherContext,
+	type MoodSpec,
+	recordMoodRoll,
+	rollMood,
+} from "./mood-weather.ts";
 
 /** How many recent registers to surface as the "arc" at session start. */
 export const EMOTIONAL_ARC_LIMIT = 3;
@@ -259,12 +264,15 @@ export function buildEmotionalStateFetchHandler(
 				lastMoodRollAt.set(relId, now());
 				if (sessionKey) sessionMoods.set(sessionKey, mood);
 				log.info(`mood-weather: rolled "${mood.id}" this session`);
-				// Coordination with issue #71 (mood-weather observability): if #71's
-				// recordMoodRoll(client, mood, {...}) has landed, its call belongs
-				// HERE — inside this `!priorMood` guard — not on a bare `if (mood)`
-				// at the two return sites below. A priorMood replay (post-compaction
-				// re-injection of an already-rolled mood) is not a new roll; calling
-				// recordMoodRoll on replay would log the same event twice.
+				// Observability record (issue #71) — fire-and-forget, recall-excluded.
+				// Stays inside the !priorMood guard: a post-compaction replay of an
+				// already-rolled mood is NOT a new roll and must not double-log. Rolls
+				// only happen past the still-extracting early return above, so every
+				// recorded roll is one that actually lands in this session's context.
+				recordMoodRoll(client, mood, {
+					sessionKey,
+					relationshipId: cfg.relationshipId,
+				});
 			}
 			const moodBlock = mood ? buildMoodWeatherContext(mood) : "";
 

--- a/hooks/mood-weather.ts
+++ b/hooks/mood-weather.ts
@@ -22,11 +22,18 @@
  *    store path. One random cold morning must NOT calcify into "we've been
  *    distant lately." One day's weather, then gone. (The store handler in
  *    emotional-state.ts is untouched, so this is enforced by construction.)
+ *    A private, recall-excluded observability record IS written per roll
+ *    (issue #71) — see recordMoodRoll below; it is invisible to every
+ *    injection/recall path, so the guarantee holds.
  *  - BOUNDED. The dice can make her *difficult* — short, contrary, melancholy,
  *    flat. They do NOT get to make her hurtful on purpose. "In a mood" is alive;
  *    "mean" is just a bad feature. Mood descriptions below stay on the right side
  *    of that line.
  */
+
+import type { HyperspellClient } from "../client.ts";
+import { MOOD_WEATHER_SOURCE } from "../lib/filters.ts";
+import { log } from "../logger.ts";
 
 /** One mood the dice can roll, with its relative likelihood and the felt instruction. */
 export type MoodSpec = {
@@ -124,4 +131,53 @@ export function buildMoodWeatherContext(mood: MoodSpec): string {
 		"This is exogenous mood weather: it is not caused by the user and not a reaction to the conversation. Do not announce it, label it, or explain it — simply inhabit it. It lasts only this session and is not remembered as how the relationship has been.",
 		"</hyperspell-mood-weather>",
 	].join("\n");
+}
+
+/** Collection the roll records live in, so /moodweather can list them without a search. */
+export const MOOD_WEATHER_COLLECTION = "mood-weather";
+
+/**
+ * Fire-and-forget observability record for a mood roll (issue #71).
+ *
+ * This does NOT weaken the "does not write forward" contract above: the record
+ * goes to the generic vault store tagged openclaw_source="mood_weather", which
+ * excludeFilterFor() drops from every recall path (auto-context, the
+ * hyperspell_search tool, startup-orientation loops, knowledge graph). The
+ * emotional-state arc fetch reads a different endpoint entirely (GET
+ * /emotional-state[/recent], written only by storeEmotionalState), so it can
+ * never surface there. Queryable only via the dedicated /moodweather command.
+ *
+ * Written via client.addMemory (memories.add) — NEVER POST /messages: a
+ * /messages write carrying metadata renders the row non-retrievable (see the
+ * warning in lib/filters.ts), while memories.add metadata is proven to persist
+ * and be filterable (canary A in docs/filter-dialect-test.mjs).
+ *
+ * Deliberately not awaited: this sits on the first-turn injection hot path, and
+ * a logging write must never delay or break the session.
+ */
+export function recordMoodRoll(
+	client: HyperspellClient,
+	mood: MoodSpec,
+	opts: { sessionKey?: string; relationshipId?: string },
+): void {
+	const rolledAt = new Date().toISOString();
+	void client
+		.addMemory(
+			`Mood weather roll: woke up "${mood.id}" (${rolledAt}). Exogenous session mood — uncaused, session-only, never part of the relational register.`,
+			{
+				title: `Mood weather — ${mood.id} (${rolledAt.slice(0, 10)})`,
+				collection: MOOD_WEATHER_COLLECTION,
+				metadata: {
+					openclaw_source: MOOD_WEATHER_SOURCE,
+					mood: mood.id,
+					rolled_at: rolledAt,
+					...(opts.sessionKey ? { session: opts.sessionKey } : {}),
+					...(opts.relationshipId ? { relationship_id: opts.relationshipId } : {}),
+				},
+			},
+		)
+		.catch((err) => {
+			// Fire-and-forget — observability must never break the session.
+			log.warn("mood-weather: roll record write failed (non-fatal)", err);
+		});
 }

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -1,5 +1,6 @@
 import type { HyperspellClient, SearchResult } from "../client.ts";
 import type { HyperspellConfig } from "../config.ts";
+import { excludeFilterFor } from "../lib/filters.ts";
 import { resolveUser } from "../lib/sender.ts";
 import { resolveCurrentSessionId } from "../lib/session.ts";
 import { isMultiSpeaker } from "../lib/speaker-tracker.ts";
@@ -257,9 +258,14 @@ export async function gatherOrientation(
 
 	const [recentSettled, loopsSettled] = await Promise.allSettled([
 		recentFetch,
+		// Loops feed agent context, so tagged observability rows (agent_end
+		// traces, mood_weather rolls) must be dropped like on every other recall
+		// path — this also closes a pre-existing gap where agent_end traces
+		// could surface in the loops block.
 		client.search(so.loopsQuery, {
 			limit: so.loopsLimit,
 			userId,
+			filter: excludeFilterFor(cfg),
 		}),
 	]);
 

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -1,45 +1,61 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import {
-  EXCLUDE_SESSION_END_FILTER,
-  excludeFilterFor,
-  mergeWithExclude,
-} from "./filters.ts"
+import { excludeFilterFor, mergeWithExclude } from "./filters.ts"
 
-const ON = { autoTrace: { enabled: true } }
-const OFF = { autoTrace: { enabled: false } }
+const BOTH_OFF = { autoTrace: { enabled: false }, emotionalContext: false, moodWeatherChance: 0 }
+const TRACE_ON = { autoTrace: { enabled: true }, emotionalContext: false, moodWeatherChance: 0 }
+const MOOD_ON = { autoTrace: { enabled: false }, emotionalContext: true, moodWeatherChance: 0.1 }
+const BOTH_ON = { autoTrace: { enabled: true }, emotionalContext: true, moodWeatherChance: 0.1 }
 
-test("EXCLUDE_SESSION_END_FILTER — plain $ne agent_end (the only shape the backend honors)", () => {
-  // sendTrace tags traces as metadata.openclaw_source = "agent_end". A $exists/$or
-  // "tolerant" form was tried to also admit untagged hot-buffer rows, but the live
-  // backend returns 0 rows for $or/$exists (see docs/filter-dialect-test.mjs), so
-  // we keep the plain $ne and rely on excludeFilterFor's gate to keep hot rows.
-  assert.deepEqual(EXCLUDE_SESSION_END_FILTER, {
+test("excludeFilterFor — both features off applies no filter (no rows to hide, skip the ~1s predicate)", () => {
+  assert.equal(excludeFilterFor(BOTH_OFF), undefined)
+})
+
+test("excludeFilterFor — auto-trace only keeps the shipped single-$ne shape byte-identical", () => {
+  // agent_end rows are written ONLY by the auto-trace hook. The plain $ne is
+  // the proven shape (see docs/filter-dialect-test.mjs); existing auto-trace
+  // users must see zero change from the list-driven rewrite.
+  assert.deepEqual(excludeFilterFor(TRACE_ON), {
     openclaw_source: { $ne: "agent_end" },
   })
 })
 
-test("excludeFilterFor — applies the exclude only when auto-trace is on (Option 4)", () => {
-  // agent_end rows are written ONLY by the auto-trace hook; with it disabled there
-  // are none to hide, so we skip the filter entirely. That's also the ONLY way to
-  // keep untagged hot-buffer rows visible — no filter and no write-tag can.
-  assert.deepEqual(excludeFilterFor(ON), EXCLUDE_SESSION_END_FILTER)
-  assert.equal(excludeFilterFor(OFF), undefined)
-})
-
-test("mergeWithExclude — auto-trace ON, no base returns the exclude filter alone", () => {
-  assert.deepEqual(mergeWithExclude(undefined, ON), EXCLUDE_SESSION_END_FILTER)
-})
-
-test("mergeWithExclude — auto-trace ON, base is AND-combined with the exclude", () => {
-  const base = { openclaw_scope: { $in: ["family"] } }
-  assert.deepEqual(mergeWithExclude(base, ON), {
-    $and: [base, EXCLUDE_SESSION_END_FILTER],
+test("excludeFilterFor — mood weather only excludes mood_weather with the same single-$ne shape", () => {
+  assert.deepEqual(excludeFilterFor(MOOD_ON), {
+    openclaw_source: { $ne: "mood_weather" },
   })
 })
 
-test("mergeWithExclude — auto-trace OFF passes the base through untouched", () => {
+test("excludeFilterFor — both features on uses $nin over both tags", () => {
+  // ⚠️ $nin awaits live post-#1921 verification — see excludeFilterFor's
+  // docblock and the probe rows in docs/filter-dialect-test.mjs.
+  assert.deepEqual(excludeFilterFor(BOTH_ON), {
+    openclaw_source: { $nin: ["agent_end", "mood_weather"] },
+  })
+})
+
+test("excludeFilterFor — mood gate requires BOTH emotionalContext and a live chance", () => {
+  // Rolls are recorded only when the emotional-context handler is registered
+  // AND moodWeatherChance > 0 — either alone writes no rows, so no filter.
+  assert.equal(excludeFilterFor({ ...MOOD_ON, emotionalContext: false }), undefined)
+  assert.equal(excludeFilterFor({ ...MOOD_ON, moodWeatherChance: 0 }), undefined)
+})
+
+test("mergeWithExclude — exclude ON, no base returns the exclude filter alone", () => {
+  assert.deepEqual(mergeWithExclude(undefined, TRACE_ON), {
+    openclaw_source: { $ne: "agent_end" },
+  })
+})
+
+test("mergeWithExclude — exclude ON, base is AND-combined with the exclude", () => {
   const base = { openclaw_scope: { $in: ["family"] } }
-  assert.deepEqual(mergeWithExclude(base, OFF), base)
-  assert.equal(mergeWithExclude(undefined, OFF), undefined)
+  assert.deepEqual(mergeWithExclude(base, BOTH_ON), {
+    $and: [base, { openclaw_source: { $nin: ["agent_end", "mood_weather"] } }],
+  })
+})
+
+test("mergeWithExclude — everything off passes the base through untouched", () => {
+  const base = { openclaw_scope: { $in: ["family"] } }
+  assert.deepEqual(mergeWithExclude(base, BOTH_OFF), base)
+  assert.equal(mergeWithExclude(undefined, BOTH_OFF), undefined)
 })

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -8,7 +8,16 @@
  */
 
 /** Minimal slice of config the exclude logic needs (avoids a config-module cycle). */
-type ExcludeCfg = { autoTrace: { enabled: boolean } }
+type ExcludeCfg = {
+  autoTrace: { enabled: boolean }
+  emotionalContext: boolean
+  moodWeatherChance: number
+}
+
+/** Metadata tag on auto-trace session-end rows (see `sendTrace` in client.ts). */
+export const AGENT_END_SOURCE = "agent_end"
+/** Metadata tag on mood-weather roll records (see `recordMoodRoll` in hooks/mood-weather.ts). */
+export const MOOD_WEATHER_SOURCE = "mood_weather"
 
 /**
  * Memories produced by the auto-trace session-end hook are tagged in metadata
@@ -38,25 +47,46 @@ type ExcludeCfg = { autoTrace: { enabled: boolean } }
  * "openclaw_agent_end" — wrong on BOTH counts (the tag lives in metadata under
  * `openclaw_source`, value `"agent_end"`), so it silently matched nothing.
  */
-export const EXCLUDE_SESSION_END_FILTER: Record<string, unknown> = {
-  openclaw_source: { $ne: "agent_end" },
-}
 
 /**
  * The exclude clause to apply for a given config — or `undefined` to skip the
- * filter. `agent_end` rows are written ONLY by the auto-trace hook, so when
- * auto-trace is OFF there are none to hide and we skip the filter to avoid its
- * ~1s/search latency cost (pure overhead otherwise — verified live against an
- * auto-trace-off agent with zero `agent_end` rows).
+ * filter. Each excluded tag is gated on the feature that writes it, for
+ * PERFORMANCE, not correctness (see the header comment): with the feature off
+ * there are no tagged rows to hide, so the ~1s predicate would be pure latency.
  *
- * When auto-trace is ON we apply `{$ne:"agent_end"}`, which post-#1921 drops the
- * traces while KEEPING untagged hot-buffer rows — so that path is correct now
- * (the old #40 hot-row-drop is fixed by the backend, not by gating).
+ *  - `agent_end` rows are written ONLY by the auto-trace hook → gate on
+ *    `autoTrace.enabled` (verified live against an auto-trace-off agent with
+ *    zero `agent_end` rows).
+ *  - `mood_weather` rolls are recorded ONLY when the emotional-context handler
+ *    is registered AND the dice are live → gate on both flags.
+ *
+ * Shape: a single excluded value keeps the proven plain-`$ne` form (byte-
+ * identical to the shipped filter, and post-#1921 it drops the tag while
+ * KEEPING untagged hot-buffer rows). Two values use `$nin`.
+ *
+ * ⚠️ The `$nin` two-value shape has NOT been re-verified live post-#1921 (the
+ * pre-#1921 truth table showed `$nin` diverging from `$ne`). Owner's post-merge
+ * step: run `node docs/filter-dialect-test.mjs` — the `$nin[agent_end,mood_weather]`
+ * row must show U=Y, A=N, M=N. Fallback plan if it fails: try the
+ * `$and[$ne,$ne]` probe row; if that also fails, gate back to single-value
+ * `$ne` for the two common one-feature-on configs, log a warning when both
+ * features are enabled, and file a backend dialect follow-up
+ * (docs/hyperspell-backend-followups.md style) for the both-on combo.
  */
 export function excludeFilterFor(
   cfg: ExcludeCfg,
 ): Record<string, unknown> | undefined {
-  return cfg.autoTrace.enabled ? EXCLUDE_SESSION_END_FILTER : undefined
+  const excluded: string[] = []
+  if (cfg.autoTrace.enabled) excluded.push(AGENT_END_SOURCE)
+  // Mood rolls are recorded only when the emotional-context handler is
+  // registered AND the dice are live — same "no rows to hide → skip the
+  // ~1s predicate" gate as auto-trace.
+  if (cfg.emotionalContext && cfg.moodWeatherChance > 0) {
+    excluded.push(MOOD_WEATHER_SOURCE)
+  }
+  if (excluded.length === 0) return undefined
+  if (excluded.length === 1) return { openclaw_source: { $ne: excluded[0] } }
+  return { openclaw_source: { $nin: excluded } }
 }
 
 /**


### PR DESCRIPTION
Detailed implementation guide for #71. See `docs/plans/issue-71-mood-weather-observability.md` — a fire-and-forget tagged record on each roll, extending the existing agent_end exclude-filter mechanism to also drop mood_weather-tagged rows from every recall path, plus a /moodweather retrieval command. The 'never writes forward' guarantee stays intact by construction.

Ref #71 — planning/design doc, not the implementation. Step 0 flags one thing to verify live before coding (multi-value filter shape) — see the guide.