### PR TITLE
fix(logging): operator diagnostics visible in gateway.log via info-level log.diag (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ files back to Hyperspell.
 | `knowledgeGraph.enabled` | boolean | `false` | Memory Network: extract entities (people, projects, organizations, topics) from memories into `memory/` markdown files. See [Memory Network](#memory-network). |
 | `knowledgeGraph.scanIntervalMinutes` | number | `60` | Extraction cadence the setup wizard bakes into the cron job it creates. The cron job is the runtime source of truth — to change cadence after setup, edit the cron job (and keep this field in sync). |
 | `knowledgeGraph.batchSize` | number | `20` | Memories per extraction scan batch |
-| `debug` | boolean | `false` | Enable verbose logging |
+| `debug` | boolean | `false` | Enable diagnostic logging. One-line diagnostics (auto-context ranked/cut/injection summaries, orientation and emotional-context injection counts) are emitted at **info** level, so they appear in `gateway.log` at default host log levels — no host `logging.level` change needed. Verbose output (per-request/response dumps, per-candidate score lines) stays at debug level. |
 | `dreaming.enabled` | boolean | `false` | Allow `memory-core` to sidecar-load so Dreaming can consolidate local session transcripts into `workspace/MEMORY.md`. See [Running alongside Dreaming](#running-alongside-dreaming). |
 
 Stored emotional-state registers (`emotionalContext`) are fetchable by external processes (e.g. a nightly consolidator reconciling its own day-read) — the verified fetch contract lives in [docs/emotional-state-external-reconciliation.md](docs/emotional-state-external-reconciliation.md).
@@ -312,10 +312,12 @@ Tips:
 - Ranking (including `storyTerms`) applies only to **auto-context** injection.
   The `hyperspell_search` tool and `/getcontext` return raw relevance order —
   don't test `storyTerms` there and conclude it's broken.
-- To verify it's working, enable `debug: true` and watch for the per-search
-  tally (`auto-context: ranked {...} candidates → selected {...}`) and the
-  per-candidate lines (`[story] 0.47→0.82 The Lighthouse Keeper — Chapter 3`),
-  which show story matches even when they lose to the threshold.
+- To verify it's working, enable `debug: true` and watch `gateway.log` for the
+  per-search tally (`auto-context: ranked {...} candidates → selected {...}`) —
+  it appears at default host log levels. The per-candidate lines
+  (`[story] 0.47→0.82 The Lighthouse Keeper — Chapter 3`), which show story
+  matches even when they lose to the threshold, are debug-level and also need
+  host debug logging.
 
 Full knobs and defaults:
 
@@ -470,7 +472,8 @@ the scanner skip memories synced from the entity directories.
 
 ### Auto-context not injecting
 - Verify `autoContext: true` in your config
-- Enable `debug: true` to see what queries are being made
+- Enable `debug: true` — the ranked/cut/injection summary lines land in
+  `gateway.log` at default host log levels
 - Check that you have memories matching your conversation topics
 
 ### Enabling `memory-core` disabled Hyperspell

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -246,12 +246,16 @@ test("auto-context — score log failure is isolated: unwritable path still inje
 })
 
 test("auto-context — debug lines carry cut reasons and the injected composite range", async () => {
-  const seen: string[] = []
+  // Summary lines (ranked/cut/injecting) must arrive on the INFO channel: the
+  // host drops plugin debug output from gateway.log (issue #118), so log.diag
+  // routes them via info when debug: true. Per-candidate lines stay debug.
+  const seenInfo: string[] = []
+  const seenDebug: string[] = []
   const capture = {
-    info: () => {},
+    info: (msg: string) => seenInfo.push(msg),
     warn: () => {},
     error: () => {},
-    debug: (msg: string) => seen.push(msg),
+    debug: (msg: string) => seenDebug.push(msg),
   }
   initLogger(capture, true)
   try {
@@ -261,21 +265,21 @@ test("auto-context — debug lines carry cut reasons and the injected composite 
     initLogger(console, false)
   }
 
-  const rankedLine = seen.find((m) => m.includes("auto-context: ranked"))
+  const rankedLine = seenInfo.find((m) => m.includes("auto-context: ranked"))
   assert.ok(rankedLine, "unconditional candidates → selected tally logged")
   assert.ok(
     rankedLine.includes(`ranked {"curated":2,"chatter":3} candidates → selected {"curated":1,"chatter":2}`),
     `candidate-pool tally shows kinds that lost, not just survivors: ${rankedLine}`,
   )
-  const perResultLines = seen.filter((m) => /^ {2}\[(story|curated|chatter|other)\] /.test(m.replace(/^hyperspell: /, "")))
-  assert.equal(perResultLines.length, 5, "one per-candidate line for each of the 5 ranked results")
+  const perResultLines = seenDebug.filter((m) => /^ {2}\[(story|curated|chatter|other)\] /.test(m.replace(/^hyperspell: /, "")))
+  assert.equal(perResultLines.length, 5, "one per-candidate line for each of the 5 ranked results (verbose — stays debug)")
   assert.ok(
     perResultLines[0].includes("[curated]"),
     `top candidate line carries kind + base→composite: ${perResultLines[0]}`,
   )
 
-  const cutLine = seen.find((m) => m.includes("auto-context: cut"))
-  assert.ok(cutLine, "cut-reason line logged")
+  const cutLine = seenInfo.find((m) => m.includes("auto-context: cut"))
+  assert.ok(cutLine, "cut-reason line logged via the info-emitting path (issue #118)")
   assert.ok(
     cutLine.includes(`cut 2 of 5 candidates {"chatter-quota":1,"threshold":1}`),
     `cut tally names each binding reason: ${cutLine}`,
@@ -285,8 +289,8 @@ test("auto-context — debug lines carry cut reasons and the injected composite 
     "quota-bound drops report the top dropped composite (proposal 03)",
   )
 
-  const injectLine = seen.find((m) => m.includes("injecting (ranked)"))
-  assert.ok(injectLine, "tally line logged")
+  const injectLine = seenInfo.find((m) => m.includes("injecting (ranked)"))
+  assert.ok(injectLine, "tally line logged via the info-emitting path (issue #118)")
   assert.ok(
     injectLine.includes(`{"curated":1,"chatter":2} from 5 candidates (chatter cap 2, composite 0.65–0.90)`),
     `tally line extended with the injected composite range: ${injectLine}`,

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -267,7 +267,7 @@ export function buildAutoContextHandler(
         // "injecting" line below): a story/curated match that loses to the
         // threshold is exactly the case an operator tuning storyTerms needs to
         // see, and it never reaches the formatted branch (proposal 01 §3.4).
-        log.debug(
+        log.diag(
           `auto-context: ranked ${JSON.stringify(kindTally(ranked))} candidates → selected ${JSON.stringify(kindTally(selected))} (chatter cap ${ranking.chatterQuota})`,
         )
         for (const r of ranked.slice(0, 10)) {
@@ -291,14 +291,14 @@ export function buildAutoContextHandler(
           const quotaNote = topQuotaDrop
             ? `, top quota-dropped composite ${topQuotaDrop.result._composite.toFixed(2)}`
             : ""
-          log.debug(
+          log.diag(
             `auto-context: cut ${cuts.length} of ${ranked.length} candidates ${JSON.stringify(cutTally)}${quotaNote}`,
           )
         }
 
         formatted = formatSelected(selected, cfg.relevanceThreshold)
         if (formatted) {
-          log.debug(
+          log.diag(
             `auto-context: injecting (ranked) ${JSON.stringify(kindTally(selected))} from ${results.length} candidates (chatter cap ${ranking.chatterQuota}, composite ${selected.at(-1)?._composite.toFixed(2)}–${selected[0]?._composite.toFixed(2)})`,
           )
         }

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -283,7 +283,9 @@ export function buildEmotionalStateFetchHandler(
 				return moodBlock ? { prependContext: moodBlock } : undefined;
 			}
 
-			log.debug(
+			// log.diag, not debug: the exact line issue #118's live audit proved
+			// invisible — one line per injection, operator-meaningful.
+			log.diag(
 				`emotional-context: injecting ${usable.length} recent register(s)`,
 			);
 			// Mood block comes AFTER the arc so it reads as today's override on top

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -381,7 +381,10 @@ export function buildStartupOrientationHandler(
 		const blocks = [gathered.recentBlock, gathered.loopsBlock].filter(
 			(b): b is string => b !== null,
 		);
-		log.debug(
+		// log.diag, not debug: this one-line injection summary is the operator's
+		// only live signal that orientation fired (issue #118 — host drops plugin
+		// debug output from gateway.log).
+		log.diag(
 			`startup-orientation: injecting recent=${gathered.recentCount} loops=${gathered.loopsCount}`,
 		);
 		return { prependContext: blocks.join("\n\n") };

--- a/logger.test.ts
+++ b/logger.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { initLogger, log } from "./logger.ts"
+
+type Captured = { info: string[]; debug: string[] }
+
+function capture(): { logger: Parameters<typeof initLogger>[0]; seen: Captured } {
+  const seen: Captured = { info: [], debug: [] }
+  return {
+    logger: {
+      info: (msg: string) => seen.info.push(msg),
+      warn: () => {},
+      error: () => {},
+      debug: (msg: string) => seen.debug.push(msg),
+    },
+    seen,
+  }
+}
+
+// log.diag exists so operator-meaningful one-line diagnostics survive the host
+// dropping the plugin debug channel from gateway.log (issue #118): with the
+// plugin's own debug flag on, they must go out via INFO — never debug.
+test("log.diag — emits via the info channel when debug is enabled", () => {
+  const { logger, seen } = capture()
+  initLogger(logger, true)
+  try {
+    log.diag("auto-context: cut 2 of 5 candidates")
+  } finally {
+    initLogger(console, false)
+  }
+  assert.deepEqual(seen.info, ["hyperspell: auto-context: cut 2 of 5 candidates"])
+  assert.deepEqual(seen.debug, [], "diag never touches the debug channel")
+})
+
+test("log.diag — fully silent when debug is disabled", () => {
+  const { logger, seen } = capture()
+  initLogger(logger, false)
+  try {
+    log.diag("auto-context: cut 2 of 5 candidates")
+  } finally {
+    initLogger(console, false)
+  }
+  assert.deepEqual(seen.info, [])
+  assert.deepEqual(seen.debug, [])
+})

--- a/logger.ts
+++ b/logger.ts
@@ -28,6 +28,22 @@ export const log = {
       _logger.debug(`hyperspell: ${message}`, ...args)
     }
   },
+  /**
+   * Operator-meaningful diagnostics (one line per event: injection summaries,
+   * cut attribution, ranked tallies). Emits via the host's INFO channel when the
+   * plugin's own `debug: true` is set, and stays silent otherwise.
+   *
+   * Why not `debug`: the host drops plugin debug-channel output from gateway.log
+   * even at `logging.level: "debug"` (issue #118 — 2,026 info lines vs zero debug
+   * lines, live). The plugin's `debug` flag is explicit operator intent, so these
+   * diagnostics must not depend on host debug-channel plumbing. Truly-verbose
+   * output (per-request dumps, per-candidate lines) stays on `debug`.
+   */
+  diag: (message: string, ...args: unknown[]) => {
+    if (_debug) {
+      _logger.info(`hyperspell: ${message}`, ...args)
+    }
+  },
   debugRequest: (method: string, params: unknown) => {
     if (_debug) {
       _logger.debug(`hyperspell: [${method}] request`, params)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types client.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
+    "test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## What

Adds `log.diag(...)` to the plugin logger: emits via the host's **info** channel when the plugin's own `debug: true` is set, silent otherwise. Switches the operator-meaningful one-line diagnostics to it:

- `hooks/auto-context.ts` — ranked-tally line, cut-attribution summary (Cutting Room's primary output), and the injection summary
- `hooks/startup-orientation.ts` — injection summary (`injecting recent=N loops=M`)
- `hooks/emotional-state.ts` — `emotional-context: injecting N recent register(s)` (the exact line the live audit proved invisible)

Per-request/response dumps, the search echo, and per-candidate score lines stay at `log.debug`. README's `debug` config row, storyTerms verification tip, and troubleshooting section updated to state that these one-line diagnostics now appear in `gateway.log` at default host log levels.

## Why

Live evidence (0.19.0, Run 2, 2026-07-12): plugin `api.logger.debug` output **never** reaches `gateway.log`, even with host `logging.level: "debug"` — 2,026 info-level hyperspell lines vs zero debug-level lines from any hook ever. Cutting Room is an observability feature whose primary output was therefore invisible in live operation. The plugin's `debug: true` flag is explicit operator intent and must not depend on host debug-channel plumbing (issue option 1, plugin-side mitigation; the core-side sink investigation remains OpenClaw future work).

## Evidence

- `npm test`: 321/321 pass (rebased onto current `main` incl. #94/#105/#114), including new `logger.test.ts` (diag emits via info when debug true, fully silent when false) and the updated `hooks/auto-context.test.ts` asserting ranked/cut/injection summaries arrive on the info channel while per-candidate lines stay on debug.
- `npm run check-types`: clean.
- Eval harness (`node --experimental-strip-types eval/run.ts`): 12/12 pass, unchanged — no ranking behavior touched, only the log channel of the summary lines.
- Live verification path (issue's test): with `debug: true`, a normal message triggering auto-context now writes e.g. `hyperspell: auto-context: cut 2 of 5 candidates {"chatter-quota":1,"threshold":1}` at info level, greppable in gateway.log at a default operator setup.

Fixes #118
