### PR TITLE
feat(client): map emotional-state metadata echo through on GETs (plugin half of #116)

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -44,3 +44,71 @@ test("sendMessages — omits the metadata key entirely when none is given", asyn
 		restore();
 	}
 });
+
+// GET-shaped stub: emotional-state GETs carry no request body, so the
+// body-parsing stubFetch above would throw — this one just serves a payload.
+function stubFetchJson(payload: unknown) {
+	const orig = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		({ ok: true, status: 200, json: async () => payload }) as unknown as Response) as typeof fetch;
+	return { restore: () => (globalThis.fetch = orig) };
+}
+
+const stateRow = {
+	resource_id: "es-1",
+	summary: "warm, unhurried",
+	extracted_at: "2026-07-12T00:00:00Z",
+	session_id: "s1",
+	relationship_id: null,
+};
+
+test("getRecentEmotionalStates — maps metadata through when the backend echoes it (#116)", async () => {
+	const metadata = { source: "openclaw_agent_end", channelId: "telegram:123", depth_score: 0.7 };
+	const { restore } = stubFetchJson([{ ...stateRow, metadata }]);
+	try {
+		const list = await client.getRecentEmotionalStates(undefined, 3);
+		assert.deepEqual(list?.[0].metadata, metadata);
+	} finally {
+		restore();
+	}
+});
+
+test("getEmotionalState — maps metadata through when the backend echoes it (#116)", async () => {
+	const metadata = { source: "openclaw_agent_end" };
+	const { restore } = stubFetchJson({ ...stateRow, metadata });
+	try {
+		const state = await client.getEmotionalState();
+		assert.deepEqual(state?.metadata, metadata);
+	} finally {
+		restore();
+	}
+});
+
+test("emotional-state GETs — metadata key cleanly absent when the backend doesn't echo it (today's reality)", async () => {
+	const { restore } = stubFetchJson([stateRow]);
+	try {
+		const list = await client.getRecentEmotionalStates();
+		assert.ok(list && !("metadata" in list[0]), "recent: no metadata key invented");
+	} finally {
+		restore();
+	}
+	const { restore: restore2 } = stubFetchJson(stateRow);
+	try {
+		const state = await client.getEmotionalState();
+		assert.ok(state && !("metadata" in state), "latest: no metadata key invented");
+	} finally {
+		restore2();
+	}
+});
+
+test("emotional-state GETs — non-object metadata is ignored, not mapped", async () => {
+	for (const bad of ["oops", 7, null, ["a"]]) {
+		const { restore } = stubFetchJson([{ ...stateRow, metadata: bad }]);
+		try {
+			const list = await client.getRecentEmotionalStates();
+			assert.ok(list && !("metadata" in list[0]), `metadata=${JSON.stringify(bad)} dropped`);
+		} finally {
+			restore();
+		}
+	}
+});

--- a/client.ts
+++ b/client.ts
@@ -57,9 +57,24 @@ export type EmotionalStateLatest = {
   extractedAt: string
   sessionId: string | null
   relationshipId: string | null
+  /**
+   * Echo of store-time metadata — Postmark's `channelId` (#74), future depth
+   * signals (#68). Absent until the backend echoes stored metadata on
+   * emotional-state GETs (issue #116), and on legacy rows stored without it.
+   */
+  metadata?: Record<string, unknown>
 }
 
 const API_BASE_URL = "https://api.hyperspell.com"
+
+/**
+ * The backend metadata echo must be a plain object to map onto
+ * `EmotionalStateLatest.metadata`; anything else (absent, null, array,
+ * scalar) is dropped so a malformed echo can't poison callers.
+ */
+function isMetadataObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 export class HyperspellClient {
 	private client: Hyperspell;
@@ -637,6 +652,10 @@ export class HyperspellClient {
 			extractedAt: data.extracted_at,
 			sessionId: data.session_id ?? null,
 			relationshipId: data.relationship_id ?? null,
+			// Metadata echo maps through only when present and object-shaped —
+			// absent today (backend #116) and on legacy rows, so this is invisible
+			// until the backend ships the echo.
+			...(isMetadataObject(data.metadata) ? { metadata: data.metadata } : {}),
 		};
 
 		log.debugResponse("emotional-state.get", { found: true, resourceId: result.resourceId });
@@ -682,6 +701,8 @@ export class HyperspellClient {
 			extractedAt: (d.extracted_at as string) ?? "",
 			sessionId: (d.session_id as string | null) ?? null,
 			relationshipId: (d.relationship_id as string | null) ?? null,
+			// Same conditional echo as getEmotionalState — see the note there.
+			...(isMetadataObject(d.metadata) ? { metadata: d.metadata } : {}),
 		}));
 		log.debugResponse("emotional-state.recent", { count: list.length });
 		return list;

--- a/docs/hyperspell-backend-followups.md
+++ b/docs/hyperspell-backend-followups.md
@@ -49,3 +49,11 @@ endpoints also drop stored `metadata` entirely — the highest-leverage combined
 fix is a single backend change that echoes both `status` and `metadata` on
 reads, unblocking external channel attribution (#74) and Ballast's depth
 signals (#68) at the same time.
+
+## 6. Echo stored `metadata` on emotional-state GET responses (issue #116)
+
+Proven live 2026-07-12: `GET /emotional-state[/recent]` drops stored
+`metadata` entirely. The client side is now ready and waiting — the plugin
+maps `metadata` through on both GETs when present (`client.ts`), so
+Postmark read-back verification and Ballast (#68) unblock the day the
+backend ships the echo. No plugin change needed then.


### PR DESCRIPTION
## What

The plugin's receiving half for the emotional-state metadata echo:

- `client.ts`: `EmotionalStateLatest` gains `metadata?: Record<string, unknown>` (echo of store-time metadata — Postmark's `channelId` (#74), future depth signals (#68); absent until the backend echoes it, and on legacy rows). Both `getEmotionalState` and `getRecentEmotionalStates` map it through **conditionally** — only when present and object-shaped (shared `isMetadataObject` guard; null/array/scalar echoes are dropped), per the pattern anticipated in the #68 implementation guide (`docs/plans/issue-68-arc-depth-weighting.md` §2 on branch `issue-68-arc-depth-weighting`).
- `docs/hyperspell-backend-followups.md`: one appended section noting the client side is ready and waiting on the backend echo.

## Why

Proven live 2026-07-12 (issue #116): `GET /emotional-state[/recent]` drops stored `metadata` entirely — the root fix is backend-side and is NOT this PR. Landing the mapping now means Postmark read-back verification and Ballast (#68) unblock the day the backend ships the echo, with zero plugin release needed then.

**No behavior change today**: with no `metadata` in the response (current reality) the mapped objects carry no `metadata` key at all — locked by test.

## Evidence

- `npm test`: 323/323 pass (rebased onto current `main` incl. #94/#105/#114), including four new `client.test.ts` cases: metadata mapped through when echoed (both GETs); key cleanly absent when not echoed (today's reality); non-object metadata (`"oops"`, `7`, `null`, `["a"]`) ignored.
- `npm run check-types`: clean.
- Eval harness (`node --experimental-strip-types eval/run.ts`): 12/12 pass, unchanged.

Ref #116 (plugin half — backend echo still required)
