### PR TITLE
fix: migrate off plugin hooks removed in OpenClaw 2026.7.2 (restores all context injection)

### DIFF
--- a/commands/preview.ts
+++ b/commands/preview.ts
@@ -10,7 +10,7 @@ import { isExcludedChannel } from "../lib/exclude-channels.ts"
 import { log } from "../logger.ts"
 
 /**
- * Assemble a read-only report of what before_agent_start WOULD inject at the
+ * Assemble a read-only report of what the injection hook WOULD inject at the
  * start of the next session. Calls only the pure fetch/format functions the
  * real hooks are composed from — never the hook handlers themselves — so it
  * cannot touch the inject-once session caches, and it never calls rollMood
@@ -23,7 +23,7 @@ export async function buildPreviewReport(
   ctx: { senderId?: string; channel?: string },
 ): Promise<string> {
   // Quarantined channels get no injected memory of any kind (index.ts guards
-  // before_agent_start with the same check) — report that instead of a bundle.
+  // the injection hook with the same check) — report that instead of a bundle.
   if (isExcludedChannel({ channelId: ctx.channel }, cfg)) {
     return "This channel is quarantined (excludeChannels): no context would be injected here and no memory would be written."
   }

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -77,7 +77,7 @@ const sessionMoods = new Map<string, MoodSpec>();
  * hundred tokens of repeated wrapper per turn.
  *
  * Lifecycle:
- *  - first before_agent_start in a session: fetch, inject, mark.
+ *  - first injection-hook fire in a session: fetch, inject, mark.
  *  - subsequent turns in same session: skip (return undefined).
  *  - after_compaction: clear the mark so the next turn re-injects (the
  *    initial injection may have been compacted out of history).
@@ -206,7 +206,7 @@ export function buildEmotionalContext(states: EmotionalStateLatest[]): string {
  * context. On later turns of the same session, return undefined — the
  * injection from the first turn is already in the conversation history.
  *
- * Runs on `before_agent_start` (which fires every turn).
+ * Runs on the session injection hook (fires every turn).
  */
 export function buildEmotionalStateFetchHandler(
 	client: HyperspellClient,

--- a/hooks/memory-sync.ts
+++ b/hooks/memory-sync.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs"
 import * as path from "node:path"
 import type { HyperspellClient } from "../client.ts"
 import type { HyperspellConfig, WatchPathEntry } from "../config.ts"
@@ -150,6 +151,68 @@ export function buildFileSyncHandler(client: HyperspellClient, cfg: HyperspellCo
       await doSync(filePath)
     }
   }
+}
+
+/**
+ * Plugin-owned file watcher feeding the file-sync handler.
+ *
+ * OpenClaw 2026.7.2 removed the host `file_changed` hook with no replacement,
+ * so live sync must come from the plugin itself. Used on EVERY host version
+ * (old hosts still expose `file_changed`, but registering both would
+ * double-sync) — one canonical path. Events are forwarded in the old hook's
+ * `{ file_path }` shape; the handler already owns syncability filtering and
+ * debounce, so the watcher stays dumb.
+ */
+export function buildMemorySyncWatcher(
+  cfg: HyperspellConfig,
+  onFileChanged: (event: { file_path: string }) => void,
+): { start: () => void; stop: () => void } {
+  const workspaceDir = getWorkspaceDir()
+  const roots = [
+    path.join(workspaceDir, "memory"),
+    ...(cfg.syncMemoriesConfig.watchPaths ?? []).map((wp) =>
+      resolveWatchPath(workspaceDir, wp.path),
+    ),
+  ]
+  const watchers: fs.FSWatcher[] = []
+
+  const start = () => {
+    let watched = 0
+    for (const root of roots) {
+      let isDirectory: boolean
+      try {
+        isDirectory = fs.statSync(root).isDirectory()
+      } catch {
+        log.debug(`memory-sync watcher: root missing, skipping: ${root}`)
+        continue
+      }
+      // Watching a file directly breaks on editor rename-replace cycles;
+      // watch the parent and filter to the file's own events instead.
+      const dir = isDirectory ? root : path.dirname(root)
+      try {
+        const watcher = fs.watch(dir, { recursive: isDirectory }, (_type, filename) => {
+          if (!filename) return
+          const filePath = path.join(dir, filename.toString())
+          if (!isDirectory && filePath !== root) return
+          onFileChanged({ file_path: filePath })
+        })
+        watchers.push(watcher)
+        watched += 1
+      } catch (err) {
+        log.error(`memory-sync watcher failed for ${dir}`, err)
+      }
+    }
+    if (watched > 0) {
+      log.info(`memory-sync: watching ${watched} root(s) with plugin-owned watchers`)
+    }
+  }
+
+  const stop = () => {
+    for (const watcher of watchers) watcher.close()
+    watchers.length = 0
+  }
+
+  return { start, stop }
 }
 
 /**

--- a/hooks/memory-sync.watcher.test.ts
+++ b/hooks/memory-sync.watcher.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { afterEach, beforeEach, test } from "node:test"
+import { buildMemorySyncWatcher } from "./memory-sync.ts"
+import { parseConfig } from "../config.ts"
+
+// buildMemorySyncWatcher resolves roots via getWorkspaceDir(), which reads the
+// workspace out of an OpenClaw config file; point OPENCLAW_CONFIG_PATH at a
+// temp config so the watcher runs against a scratch workspace.
+
+let tmpDir: string
+let workspaceDir: string
+let prevConfigPath: string | undefined
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return parseConfig({ apiKey: "hs-test", syncMemories: true, ...overrides })
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!check()) {
+    if (Date.now() > deadline) throw new Error("waitFor timed out")
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hs-watch-"))
+  workspaceDir = path.join(tmpDir, "workspace")
+  fs.mkdirSync(path.join(workspaceDir, "memory"), { recursive: true })
+  const configPath = path.join(tmpDir, "openclaw.json")
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ agents: { defaults: { workspace: workspaceDir } } }),
+  )
+  prevConfigPath = process.env.OPENCLAW_CONFIG_PATH
+  process.env.OPENCLAW_CONFIG_PATH = configPath
+})
+
+afterEach(() => {
+  if (prevConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH
+  else process.env.OPENCLAW_CONFIG_PATH = prevConfigPath
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test("watcher fires for files created under memory/", async () => {
+  const seen: string[] = []
+  const watcher = buildMemorySyncWatcher(makeConfig(), (event) => {
+    seen.push(event.file_path)
+  })
+  watcher.start()
+  try {
+    const target = path.join(workspaceDir, "memory", "note.md")
+    fs.writeFileSync(target, "# hello")
+    await waitFor(() => seen.includes(target))
+  } finally {
+    watcher.stop()
+  }
+})
+
+test("watcher covers configured watchPaths roots", async () => {
+  const extraDir = path.join(tmpDir, "notes")
+  fs.mkdirSync(extraDir, { recursive: true })
+  const seen: string[] = []
+  const watcher = buildMemorySyncWatcher(
+    makeConfig({ syncMemories: { watchPaths: [extraDir] } }),
+    (event) => {
+      seen.push(event.file_path)
+    },
+  )
+  watcher.start()
+  try {
+    const target = path.join(extraDir, "extra.md")
+    fs.writeFileSync(target, "# extra")
+    await waitFor(() => seen.includes(target))
+  } finally {
+    watcher.stop()
+  }
+})
+
+test("stop() ends delivery and missing roots are skipped without throwing", async () => {
+  const seen: string[] = []
+  const watcher = buildMemorySyncWatcher(
+    makeConfig({
+      syncMemories: { watchPaths: [path.join(tmpDir, "does-not-exist")] },
+    }),
+    (event) => {
+      seen.push(event.file_path)
+    },
+  )
+  watcher.start()
+  watcher.stop()
+  fs.writeFileSync(path.join(workspaceDir, "memory", "after-stop.md"), "# late")
+  await new Promise((resolve) => setTimeout(resolve, 200))
+  assert.equal(seen.length, 0)
+})

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -221,7 +221,7 @@ export type OrientationGather = {
 
 /**
  * The fetch+format core of startup orientation, shared by the real
- * before_agent_start handler and the read-only /previewcontext command.
+ * session-start injection handler and the read-only /previewcontext command.
  * Pure with respect to session lifecycle: no inject-once cache, no retry
  * counting — callers own that policy. Keeping one formatter here keeps the
  * preview byte-identical to real injection.
@@ -238,7 +238,7 @@ export async function gatherOrientation(
 	// off agents). Fall back to agent_end traces only when there's no hot
 	// buffer but auto-trace is on. Otherwise skip: there's nothing to fetch,
 	// and the trace-source list is expensive (observed ~12s + failing/turn),
-	// blocking before_agent_start and slowing the reply.
+	// blocking the injection hook and slowing the reply.
 	const recentSource = cfg.hotBuffer.enabled
 		? ("hotBuffer" as const)
 		: cfg.autoTrace.enabled

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,11 @@ import {
 	buildEmotionalStateSessionCleanupHandler,
 	buildEmotionalStateStoreHandler,
 } from "./hooks/emotional-state.ts"
-import { buildFileSyncHandler, syncMemoriesOnStartup } from "./hooks/memory-sync.ts"
+import {
+	buildFileSyncHandler,
+	buildMemorySyncWatcher,
+	syncMemoriesOnStartup,
+} from "./hooks/memory-sync.ts"
 import {
 	buildHotBufferHandler,
 	buildHotBufferSessionCleanupHandler,
@@ -121,7 +125,7 @@ export default {
 
 		// Channel quarantine (cfg.excludeChannels): excluded conversations get no
 		// memory surface in either direction. Guard the shared choke points here —
-		// before_agent_start (all injection), agent_end (all writes), and the tool
+		// the injection hook (all injection), agent_end (all writes), and the tool
 		// factories — so individual hooks stay quarantine-unaware.
 		const quarantined = (ctx?: Record<string, unknown>): boolean => {
 			if (!isExcludedChannel(ctx, cfg)) return false;
@@ -146,8 +150,8 @@ export default {
 		});
 
 		// Session-start context injectors (emotional fetch, auto-context,
-		// startup-orientation) all run on `before_agent_start`. The host awaits
-		// before_agent_start hooks SEQUENTIALLY, so registering them separately
+		// startup-orientation) all run on the injection hook. The host awaits
+		// same-name hooks SEQUENTIALLY, so registering them separately
 		// stacked their backend searches — making the first message of a session
 		// roughly 2x slower than necessary. Instead we collect them and run them
 		// in PARALLEL under a single hook, merging prependContext in registration
@@ -209,8 +213,21 @@ export default {
 			api.on("session_end", buildStartupOrientationSessionCleanupHandler());
 		}
 
+		// Injection hook selection: OpenClaw 2026.7.2 removed the plugin-facing
+		// `before_agent_start`; its replacement `agent_turn_prepare` shipped in the
+		// same core commit as `enqueueNextTurnInjection` (openclaw#72287, 2026-04),
+		// so probing that api member tells us exactly which hook this host knows.
+		// Register exactly ONE of the two: cores between 2026-04 and 2026-07
+		// accept both and would double-inject. Both hooks share the same
+		// { prependContext } result contract and provide event.prompt.
+		const injectionHook =
+			typeof (api as { enqueueNextTurnInjection?: unknown })
+				.enqueueNextTurnInjection === "function"
+				? "agent_turn_prepare"
+				: "before_agent_start";
+
 		if (startHandlers.length > 0) {
-			api.on("before_agent_start", async (event, ctx) => {
+			api.on(injectionHook, async (event, ctx) => {
 				// Quarantined channels get no injected memory of any kind.
 				if (quarantined(ctx as Record<string, unknown> | undefined)) return undefined;
 				const results = await Promise.all(
@@ -251,10 +268,16 @@ export default {
 			api.on("session_end", buildHotBufferSessionCleanupHandler());
 		}
 
-		// Register memory sync hook
+		// Memory sync live watcher. Plugin-owned on every host version:
+		// 2026.7.2 removed the host `file_changed` hook, and on older hosts
+		// registering both paths would double-sync each edit. Started/stopped
+		// by the lifecycle service below.
+		let memorySyncWatcher: { start: () => void; stop: () => void } | undefined;
 		if (cfg.syncMemories) {
 			const fileSyncHandler = buildFileSyncHandler(client, cfg);
-			api.on("file_changed", fileSyncHandler);
+			memorySyncWatcher = buildMemorySyncWatcher(cfg, (event) => {
+				void fileSyncHandler(event);
+			});
 			api.logger.info(
 				`hyperspell: memory sync enabled (sectionize=${cfg.syncMemoriesConfig.sectionize}, watchPaths=${cfg.syncMemoriesConfig.watchPaths.length})`,
 			);
@@ -311,8 +334,10 @@ export default {
 						api.logger.error("hyperspell: background memory sync failed", err);
 					});
 				}
+				memorySyncWatcher?.start();
 			},
 			stop: () => {
+				memorySyncWatcher?.stop();
 				api.logger.info("hyperspell: stopped");
 			},
 		});

--- a/lib/speaker-tracker.ts
+++ b/lib/speaker-tracker.ts
@@ -10,7 +10,7 @@
  *
  * Lifecycle:
  *   - record() on every turn that has a resolvable senderId (hot-buffer agent_end,
- *     auto-context before_agent_start)
+ *     auto-context injection hook)
  *   - isMultiSpeaker() checked by any hook or tool that needs to guard behaviour
  *   - cleanup() on session_end, called from the hot-buffer cleanup handler
  */

--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "@hyperspell/openclaw-hyperspell",
-  "version": "0.21.0",
-  "type": "module",
-  "description": "OpenClaw Hyperspell memory plugin",
-  "license": "MIT",
-  "main": "./dist/index.js",
-  "files": [
-    "dist/",
-    "openclaw.plugin.json",
-    "README.md"
-  ],
-  "author": "Hyperspell <hello@hyperspell.com> (https://hyperspell.com)",
-  "homepage": "https://hyperspell.com",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hyperspell/hyperspell-openclaw.git"
-  },
-  "keywords": [
-    "openclaw",
-    "hyperspell",
-    "memory",
-    "rag",
-    "ai",
-    "plugin"
-  ],
-  "dependencies": {
-    "@clack/prompts": "^1.0.0",
-    "@sinclair/typebox": "^0.34.0",
-    "hyperspell": "^0.35.1"
-  },
-  "peerDependencies": {
-    "openclaw": ">=2026.1.29"
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "npm run build",
-    "check-types": "tsc --noEmit",
-    "lint": "bunx @biomejs/biome ci .",
-    "lint:fix": "bunx @biomejs/biome check --write .",
-    "test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
-  },
-  "openclaw": {
-    "extensions": [
-      "./dist/index.js"
-    ],
-    "hooks": [],
-    "compat": {
-      "pluginApi": ">=2026.1.29",
-      "minGatewayVersion": "2026.1.29"
-    },
-    "build": {
-      "openclawVersion": "2026.3.24-beta.2",
-      "pluginSdkVersion": "2026.3.24-beta.2"
-    }
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3"
-  }
+	"name": "@hyperspell/openclaw-hyperspell",
+	"version": "0.21.0",
+	"type": "module",
+	"description": "OpenClaw Hyperspell memory plugin",
+	"license": "MIT",
+	"main": "./dist/index.js",
+	"files": [
+		"dist/",
+		"openclaw.plugin.json",
+		"README.md"
+	],
+	"author": "Hyperspell <hello@hyperspell.com> (https://hyperspell.com)",
+	"homepage": "https://hyperspell.com",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/hyperspell/hyperspell-openclaw.git"
+	},
+	"keywords": [
+		"openclaw",
+		"hyperspell",
+		"memory",
+		"rag",
+		"ai",
+		"plugin"
+	],
+	"dependencies": {
+		"@clack/prompts": "^1.0.0",
+		"@sinclair/typebox": "^0.34.0",
+		"hyperspell": "^0.35.1"
+	},
+	"peerDependencies": {
+		"openclaw": ">=2026.1.29"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "npm run build",
+		"check-types": "tsc --noEmit",
+		"lint": "bunx @biomejs/biome ci .",
+		"lint:fix": "bunx @biomejs/biome check --write .",
+		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
+	},
+	"openclaw": {
+		"extensions": [
+			"./dist/index.js"
+		],
+		"hooks": [],
+		"compat": {
+			"pluginApi": ">=2026.1.29",
+			"minGatewayVersion": "2026.1.29"
+		},
+		"build": {
+			"openclawVersion": "2026.3.24-beta.2",
+			"pluginSdkVersion": "2026.3.24-beta.2"
+		}
+	},
+	"devDependencies": {
+		"typescript": "^5.9.3"
+	}
 }

--- a/sync/markdown.ts
+++ b/sync/markdown.ts
@@ -289,7 +289,7 @@ export function saveManifest(workspaceDir: string, manifest: SyncManifest): void
 
 /**
  * Serializes manifest read-modify-write across the whole process. Startup bulk
- * sync and the live file_changed handler (plus independent per-file debounce
+ * sync and the live file-watch handler (plus independent per-file debounce
  * timers) would otherwise interleave load → await addMemory → save and lose
  * resourceId entries, causing the next sync to re-upload sections as brand-new
  * memories. Every load→sync→save runs inside this critical section.
@@ -745,7 +745,7 @@ export async function syncAllFilesSectionized(
   // not changing — re-parsing/hashing/diffing it every startup is pure churn.
   // Files NOT yet in the manifest are always processed regardless of age, so
   // a genuinely cold start (or a never-synced old file) still ingests once.
-  // The live file_changed handler is unaffected: an edit bumps mtime, so
+  // The live file-watch handler is unaffected: an edit bumps mtime, so
   // edited-but-old files re-enter the window naturally.
   const maxAgeDays = options?.maxAgeDays ?? 0
   let candidates = files


### PR DESCRIPTION
## What broke

OpenClaw **2026.7.2** removed the plugin-facing `before_agent_start` and `file_changed` typed hooks (openclaw#111451, "remove expired plugin compatibility surfaces"). The gateway discards unknown hook registrations with a warn-level log and continues startup, so on 2026.7.2+ hosts the plugin *looks* healthy — client connects, hot-buffer and emotional-state writes keep working (`agent_end`/`session_end` are still valid) — while **every context-injection path is silently dead**: auto-context, startup-orientation, emotional-context all hung off the single `before_agent_start` registration, and live memory-file sync hung off `file_changed`.

Observed live: 1,877 lifetime `auto-context: injecting` log lines → **0** after the host updated to 2026.7.2. Sessions wake with no memory, no arc, no orientation.

## The fix

**Injection hook — capability-probed, back-compatible.** `agent_turn_prepare` (the replacement) shipped in the same core commit as `api.enqueueNextTurnInjection` (openclaw#72287, 2026-04), so probing that member is an exact host-capability test:

- hosts with `enqueueNextTurnInjection` → register `agent_turn_prepare` only
- older hosts → register `before_agent_start` only

Exactly one hook per host. That matters because cores between 2026-04 and 2026-07 accept **both** names and would double-inject. Both hooks share the `{ prependContext }` result contract and provide `event.prompt`, so handler bodies are unchanged. Peer dep stays `openclaw >=2026.1.29` — one published version serves every supported host.

**File sync — plugin-owned watcher on every host.** `file_changed` is gone from core with no replacement. `buildMemorySyncWatcher()` now watches `memory/` plus configured `watchPaths` roots with `fs.watch` (recursive for dirs; file roots watch their parent and filter, so editor rename-replace cycles don't kill the watcher). It forwards events in the old `{ file_path }` shape — filtering and debounce stay in `buildFileSyncHandler`, the watcher stays dumb. Used on old hosts too: registering both the host hook and our watcher there would double-sync every edit, so one canonical path. Started/stopped by the existing lifecycle service.

## Evidence

- Before fix (2026.7.2 host): `[gateway] unknown typed hook "before_agent_start" ignored (plugin=openclaw-hyperspell)` + `unknown typed hook "file_changed" ignored`; zero injection lines after host update.
- After fix, deployed live on a 2026.7.2 gateway: warnings gone; `memory-sync: watching 1 root(s) with plugin-owned watchers`; test turn logs `auto-context: injecting (ranked)`, `startup-orientation: injecting recent=0 loops=3`, emotional arc injected.
- `npm test`: 415/415 pass (adds `hooks/memory-sync.watcher.test.ts`: fires for memory/ files, covers extra watchPaths roots, stop() ends delivery, missing roots skipped without throwing). `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787603780&installation_model_id=8852&pr_number=121&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F121&signature=e36bda637829e0b53c7dd9f511efc5d6f62c1f5ab0b81cf651b0358e50a6028e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->