### PR TITLE
fix(hot-buffer): label speakers on every turn, not just detected group chats

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -32,6 +32,31 @@ test("sendMessages — forwards per-message metadata into the POST /messages bod
 	}
 });
 
+test("sendMessages — merges per-message metadata over shared batch metadata", async () => {
+	const { calls, restore } = stubFetch();
+	try {
+		await client.sendMessages(
+			[
+				{
+					resourceId: "r3",
+					messageId: "m3",
+					content: "c3",
+					metadata: { openclaw_speaker_role: "user", openclaw_speaker_name: "David" },
+				},
+			],
+			{ metadata: { openclaw_source: "hot_buffer" } },
+		);
+		const messages = (calls[0].body.messages as Array<Record<string, unknown>>);
+		assert.deepEqual(messages[0].metadata, {
+			openclaw_source: "hot_buffer",
+			openclaw_speaker_role: "user",
+			openclaw_speaker_name: "David",
+		});
+	} finally {
+		restore();
+	}
+});
+
 test("sendMessages — omits the metadata key entirely when none is given", async () => {
 	const { calls, restore } = stubFetch();
 	try {

--- a/client.ts
+++ b/client.ts
@@ -504,7 +504,14 @@ export class HyperspellClient {
 	 * batch 1..1,000 messages. Callers should pre-enforce these.
 	 */
 	async sendMessages(
-		messages: Array<{ resourceId: string; messageId: string; content: string }>,
+		messages: Array<{
+			resourceId: string;
+			messageId: string;
+			content: string;
+			/** Per-message tags (e.g. speaker attribution) merged over the shared
+			 * options.metadata; per-message keys win on collision. */
+			metadata?: Record<string, string | number | boolean>;
+		}>,
 		options?: {
 			userId?: string;
 			source?: string;
@@ -525,15 +532,20 @@ export class HyperspellClient {
 		const metadata = options?.metadata;
 		const body = {
 			source,
-			messages: messages.map((m) => ({
-				resource_id: m.resourceId,
-				message_id: m.messageId,
-				content: m.content,
+			messages: messages.map((m) => {
 				// Per-message metadata (Hyperspell #1921): tags hot-buffer rows so
 				// retrieval can identify/filter them like /memories/add rows. Persists
 				// on the live hot row and is unioned onto the consolidated Resource.
-				...(metadata ? { metadata } : {}),
-			})),
+				// Row-specific tags (speaker attribution) merge over the shared batch
+				// tags, row keys winning on collision.
+				const md = { ...(metadata ?? {}), ...(m.metadata ?? {}) };
+				return {
+					resource_id: m.resourceId,
+					message_id: m.messageId,
+					content: m.content,
+					...(Object.keys(md).length > 0 ? { metadata: md } : {}),
+				};
+			}),
 		};
 
 		log.debugRequest("messages.create", {

--- a/config.test.ts
+++ b/config.test.ts
@@ -352,6 +352,23 @@ test("parseConfig — hotBuffer honors explicit settings", () => {
   assert.equal(cfg.hotBuffer.writeAssistant, false)
 })
 
+test("parseConfig — hotBuffer speaker labels parse, trim, and default to undefined", () => {
+  const cfg = parseConfig({
+    ...base,
+    hotBuffer: { enabled: true, userLabel: " David ", assistantLabel: "Alinea" },
+  })
+  assert.equal(cfg.hotBuffer.userLabel, "David")
+  assert.equal(cfg.hotBuffer.assistantLabel, "Alinea")
+
+  const bare = parseConfig({ ...base, hotBuffer: { enabled: true } })
+  assert.equal(bare.hotBuffer.userLabel, undefined)
+  assert.equal(bare.hotBuffer.assistantLabel, undefined)
+
+  // Whitespace-only labels are treated as absent, not as an empty prefix.
+  const blank = parseConfig({ ...base, hotBuffer: { enabled: true, userLabel: "  " } })
+  assert.equal(blank.hotBuffer.userLabel, undefined)
+})
+
 test("parseConfig — hotBuffer with an unknown key throws", () => {
   assert.throws(
     () => parseConfig({ ...base, hotBuffer: { enbaled: true } }),

--- a/config.ts
+++ b/config.ts
@@ -53,6 +53,14 @@ export type HotBufferConfig = {
 	writeUser: boolean;
 	/** Write the assistant side of each turn. */
 	writeAssistant: boolean;
+	/**
+	 * Fallback speaker label for user turns when the envelope carries no sender
+	 * name. An envelope-derived name always wins — it's the only correct answer
+	 * once a second human appears in the session. Default "User".
+	 */
+	userLabel?: string;
+	/** Speaker label for assistant turns. Default "Assistant". */
+	assistantLabel?: string;
 };
 
 export type StartupOrientationConfig = {
@@ -616,7 +624,7 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 	if (cfg.hotBuffer && typeof cfg.hotBuffer === "object" && !Array.isArray(cfg.hotBuffer)) {
 		assertAllowedKeys(
 			hbRaw,
-			["enabled", "source", "writeUser", "writeAssistant"],
+			["enabled", "source", "writeUser", "writeAssistant", "userLabel", "assistantLabel"],
 			"hyperspell.hotBuffer",
 		);
 	}
@@ -673,6 +681,15 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			source: hbSource,
 			writeUser: (hbRaw.writeUser as boolean) ?? true,
 			writeAssistant: (hbRaw.writeAssistant as boolean) ?? true,
+			userLabel:
+				typeof hbRaw.userLabel === "string" && hbRaw.userLabel.trim().length > 0
+					? hbRaw.userLabel.trim()
+					: undefined,
+			assistantLabel:
+				typeof hbRaw.assistantLabel === "string" &&
+				hbRaw.assistantLabel.trim().length > 0
+					? hbRaw.assistantLabel.trim()
+					: undefined,
 		},
 		emotionalContext: (cfg.emotionalContext as boolean) ?? false,
 		// Default 0 (off) so shipping never changes existing installs' behavior.

--- a/docs/backfill-attribution.mjs
+++ b/docs/backfill-attribution.mjs
@@ -1,0 +1,178 @@
+// Backfill speaker labels onto historical hot-buffer rows (attribution v3 follow-up).
+//
+// Why: rows written before 2026-08-10 carry no speaker label, and the backend
+// stamps every message's sender with the vault user — so the consolidator
+// summarized David's words as A Linea's (and vice versa). The forward fix
+// labels every new row; this script relabels the old ones.
+//
+// How it can be deterministic: hot-buffer message_ids are our own FNV ids,
+// `u-<hash>` for user rows and `a-<hash>` for assistant rows — the role
+// survives in the vault as each message's external_id. POST /messages upserts
+// on (app, user, resource_id, message_id) and updates content in place, so
+// re-posting `[David]: <original>` under the same message_id relabels the row
+// without duplicating it.
+//
+// Safety:
+//   - Rows whose text already starts with "[" are SKIPPED — covers rows the
+//     forward fix already labeled, PR #60 group-chat prefixes, and cron
+//     prompts ("[cron:...] ..."), which are not David speaking.
+//   - Rows whose external_id isn't u-/a- prefixed are SKIPPED and counted
+//     (can't recover the role — never guess).
+//   - Every original row is appended to a JSONL backup BEFORE any write.
+//
+// Usage:
+//   node docs/backfill-attribution.mjs                       # dry-run scan: counts + samples, no writes
+//   node docs/backfill-attribution.mjs --pilot <resource_id> # relabel ONE resource (writes!)
+//   node docs/backfill-attribution.mjs --execute             # relabel the whole vault (writes!)
+//
+// Labels match Alinea's live config (hotBuffer.userLabel / assistantLabel).
+// Backup: ~/.openclaw/attribution-backfill/originals-<runstamp>.jsonl
+
+import fs from "node:fs"
+import path from "node:path"
+import Hyperspell from "hyperspell"
+
+const API_BASE_URL = "https://api.hyperspell.com"
+
+const cfg = JSON.parse(fs.readFileSync(process.env.HOME + "/.openclaw/openclaw.json", "utf8"))
+	.plugins.entries["openclaw-hyperspell"].config
+const apiKey = cfg.apiKey
+const userId = cfg.userId
+const USER_LABEL = cfg.hotBuffer?.userLabel ?? "User"
+const ASSISTANT_LABEL = cfg.hotBuffer?.assistantLabel ?? "Assistant"
+
+if (!apiKey || !userId) {
+	console.error("apiKey/userId missing from config — aborting.")
+	process.exit(1)
+}
+
+const client = new Hyperspell({ apiKey, userID: userId })
+const ro = { headers: { "X-As-User": userId } }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const args = process.argv.slice(2)
+const EXECUTE = args.includes("--execute")
+const pilotIdx = args.indexOf("--pilot")
+const PILOT = pilotIdx >= 0 ? args[pilotIdx + 1] : undefined
+const WRITE = EXECUTE || !!PILOT
+
+const backupDir = path.join(process.env.HOME, ".openclaw", "attribution-backfill")
+const runstamp = new Date().toISOString().replace(/[:.]/g, "-")
+const backupFile = path.join(backupDir, `originals-${runstamp}.jsonl`)
+
+function classify(msg) {
+	const text = msg.children?.map((c) => c.text ?? "").join("\n") ?? ""
+	const extId = msg.external_id ?? ""
+	if (text.trim().length === 0) return { kind: "empty", text }
+	if (text.startsWith("[")) return { kind: "already-labeled-or-special", text }
+	if (extId.startsWith("u-")) return { kind: "relabel", role: "user", label: USER_LABEL, text }
+	if (extId.startsWith("a-")) return { kind: "relabel", role: "assistant", label: ASSISTANT_LABEL, text }
+	return { kind: "unknown-id", text }
+}
+
+async function listConversations() {
+	const out = []
+	let cursor = undefined
+	do {
+		const page = await client.memories.list(
+			{ source: "vault", limit: 100, ...(cursor ? { cursor } : {}) },
+			ro,
+		)
+		for (const it of page.items ?? []) {
+			if ((it.type ?? "") === "conversation") out.push(it.resource_id ?? it.id)
+		}
+		cursor = page.next_cursor ?? undefined
+	} while (cursor)
+	return out
+}
+
+async function relabelBatch(resourceId, rows) {
+	// Same wire shape as the plugin's sendMessages: upsert by message_id.
+	const body = {
+		source: "vault",
+		messages: rows.map((r) => ({
+			resource_id: resourceId,
+			message_id: r.messageId,
+			content: r.newContent,
+			metadata: {
+				openclaw_speaker_role: r.role,
+				openclaw_speaker_name: r.label,
+				openclaw_backfilled: "attribution-2026-08-10",
+			},
+		})),
+	}
+	const res = await fetch(`${API_BASE_URL}/messages`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+			"X-As-User": userId,
+		},
+		body: JSON.stringify(body),
+	})
+	if (!res.ok) throw new Error(`POST /messages ${res.status}: ${await res.text().catch(() => "")}`)
+	return rows.length
+}
+
+const totals = { resources: 0, relabelUser: 0, relabelAssistant: 0, skippedLabeled: 0, skippedUnknownId: 0, empty: 0 }
+const samples = []
+let written = 0
+
+const resourceIds = PILOT ? [PILOT] : await listConversations()
+console.log(`${resourceIds.length} conversation resource(s) to scan${WRITE ? (PILOT ? " [PILOT WRITE]" : " [EXECUTE]") : " [dry-run]"}`)
+
+if (WRITE) fs.mkdirSync(backupDir, { recursive: true })
+
+for (const rid of resourceIds) {
+	let doc
+	try {
+		doc = await client.memories.get(rid, { source: "vault" }, ro)
+	} catch (e) {
+		console.log(`  skip ${rid}: get failed (${String(e).slice(0, 80)})`)
+		continue
+	}
+	totals.resources++
+	const pending = []
+	for (const msg of doc?.document?.children ?? []) {
+		const c = classify(msg)
+		if (c.kind === "relabel") {
+			totals[c.role === "user" ? "relabelUser" : "relabelAssistant"]++
+			if (samples.length < 6) samples.push(`${rid} ${msg.external_id} -> [${c.label}]: ${c.text.slice(0, 60)}`)
+			pending.push({
+				messageId: msg.external_id,
+				role: c.role,
+				label: c.label,
+				original: c.text,
+				newContent: `[${c.label}]: ${c.text}`,
+			})
+		} else if (c.kind === "already-labeled-or-special") totals.skippedLabeled++
+		else if (c.kind === "unknown-id") totals.skippedUnknownId++
+		else totals.empty++
+	}
+
+	if (WRITE && pending.length > 0) {
+		for (const r of pending) {
+			fs.appendFileSync(
+				backupFile,
+				JSON.stringify({ resource_id: rid, message_id: r.messageId, original: r.original }) + "\n",
+			)
+		}
+		// Chunk to stay far under the 1000-message / 5MB batch limits.
+		for (let i = 0; i < pending.length; i += 200) {
+			written += await relabelBatch(rid, pending.slice(i, i + 200))
+		}
+		console.log(`  relabeled ${pending.length} row(s) in ${rid}`)
+		await sleep(150)
+	}
+}
+
+console.log("\n--- summary ---")
+console.log(totals)
+if (!WRITE) {
+	console.log("\nsamples:")
+	for (const s of samples) console.log(" ", s)
+	console.log("\nDry run only — nothing written. Use --pilot <resource_id> or --execute.")
+} else {
+	console.log(`rows written: ${written}`)
+	console.log(`backup of originals: ${backupFile}`)
+}

--- a/hooks/hot-buffer.test.ts
+++ b/hooks/hot-buffer.test.ts
@@ -19,6 +19,7 @@ type SentBatch = Array<{
 	resourceId: string;
 	messageId: string;
 	content: string;
+	metadata?: Record<string, string>;
 }>;
 
 function makeClient() {
@@ -65,7 +66,11 @@ test("hot-buffer — writes user and assistant turns with stable ids", async () 
 	assert.equal(calls.length, 1);
 	assert.equal(calls[0].length, 2);
 	assert.equal(calls[0][0].resourceId, "s1");
-	assert.equal(calls[0][0].content, "hello violet-anchor-123");
+	// No envelope sender and no configured labels → generic role labels. The
+	// label is never omitted: the POST /messages payload has no role field, so
+	// in-content labels are the only speaker signal the consolidator gets.
+	assert.equal(calls[0][0].content, "[User]: hello violet-anchor-123");
+	assert.equal(calls[0][1].content, "[Assistant]: hi there");
 	// distinct ids per role
 	assert.notEqual(calls[0][0].messageId, calls[0][1].messageId);
 });
@@ -179,7 +184,7 @@ test("hot-buffer — stable ctx.sessionId dedups across turns (no whole-transcri
 	assert.equal(calls[1].length, 2);
 	assert.deepEqual(
 		calls[1].map((m) => m.content),
-		["reply-1", "turn-2"],
+		["[Assistant]: reply-1", "[User]: turn-2"],
 	);
 	// All rows share the stable resourceId.
 	for (const batch of calls)
@@ -215,7 +220,7 @@ test("hot-buffer — idempotent: re-firing the same turn sends nothing new", asy
 	assert.equal(calls[1].length, 2); // only the new pair
 	assert.deepEqual(
 		calls[1].map((m) => m.content),
-		["second", "reply two"],
+		["[User]: second", "[Assistant]: reply two"],
 	);
 });
 
@@ -239,7 +244,7 @@ test("hot-buffer — writeAssistant=false skips assistant lines", async () => {
 		{},
 	);
 	assert.equal(calls[0].length, 1);
-	assert.equal(calls[0][0].content, "u");
+	assert.equal(calls[0][0].content, "[User]: u");
 });
 
 test("hot-buffer — skips when agent ended with error", async () => {
@@ -291,7 +296,7 @@ test("hot-buffer — strips injected context wrappers before writing", async () 
 		},
 		{},
 	);
-	assert.equal(calls[0][0].content, "real question");
+	assert.equal(calls[0][0].content, "[User]: real question");
 });
 
 test("hot-buffer — session cleanup lets ids be re-sent in a fresh run", async () => {
@@ -352,7 +357,7 @@ test("hot-buffer — survives a bare process restart without resending the whole
 	assert.equal(calls2[0].length, 2);
 	assert.deepEqual(
 		calls2[0].map((m) => m.content),
-		["reply-1", "turn-2"],
+		["[Assistant]: reply-1", "[User]: turn-2"],
 	);
 });
 
@@ -380,4 +385,159 @@ test("hot-buffer — session cleanup also removes persisted disk state", async (
 	} finally {
 		fs.rmSync(stateRoot, { recursive: true, force: true });
 	}
+});
+
+test("hot-buffer — envelope sender name labels user turns, beating configured userLabel", async () => {
+	const { client, calls } = makeClient();
+	const labeled = parseConfig({
+		apiKey: "k",
+		userId: "u1",
+		hotBuffer: { enabled: true, userLabel: "David", assistantLabel: "Alinea" },
+	});
+	const handler = buildHotBufferHandler(client, labeled, { stateRoot: testStateRoot });
+	await handler(
+		{
+			success: true,
+			messages: [
+				{ role: "user", content: "morning" },
+				{ role: "assistant", content: "morning yourself" },
+			],
+		},
+		{ sessionId: "s-env-label", sender: "David S" },
+	);
+	assert.deepEqual(
+		calls[0].map((m) => m.content),
+		["[David S]: morning", "[Alinea]: morning yourself"],
+	);
+});
+
+test("hot-buffer — configured labels fill in when the envelope has no sender", async () => {
+	const { client, calls } = makeClient();
+	const labeled = parseConfig({
+		apiKey: "k",
+		userId: "u1",
+		hotBuffer: { enabled: true, userLabel: "David", assistantLabel: "Alinea" },
+	});
+	const handler = buildHotBufferHandler(client, labeled, { stateRoot: testStateRoot });
+	await handler(
+		{
+			success: true,
+			messages: [
+				{ role: "user", content: "no envelope here" },
+				{ role: "assistant", content: "still know who's who" },
+			],
+		},
+		{ sessionId: "s-cfg-label" },
+	);
+	assert.deepEqual(
+		calls[0].map((m) => m.content),
+		["[David]: no envelope here", "[Alinea]: still know who's who"],
+	);
+});
+
+test("hot-buffer — escapes ] out of sender names to keep [Name]: parseable", async () => {
+	const { client, calls } = makeClient();
+	const handler = buildHotBufferHandler(client, cfg, { stateRoot: testStateRoot });
+	await handler(
+		{ success: true, messages: [{ role: "user", content: "hi" }] },
+		{ sessionId: "s-escape", sender: "Weird] Name" },
+	);
+	assert.equal(calls[0][0].content, "[Weird Name]: hi");
+});
+
+test("hot-buffer — tags each row with speaker role and name metadata", async () => {
+	const { client, calls } = makeClient();
+	const handler = buildHotBufferHandler(client, cfg, { stateRoot: testStateRoot });
+	await handler(
+		{
+			success: true,
+			messages: [
+				{ role: "user", content: "who said this" },
+				{ role: "assistant", content: "i did" },
+			],
+		},
+		{ sessionId: "s-speaker-md", sender: "David S" },
+	);
+	assert.deepEqual(calls[0][0].metadata, {
+		openclaw_speaker_role: "user",
+		openclaw_speaker_name: "David S",
+	});
+	assert.deepEqual(calls[0][1].metadata, {
+		openclaw_speaker_role: "assistant",
+		openclaw_speaker_name: "Assistant",
+	});
+});
+
+/** Replica of hot-buffer.ts's FNV-1a messageId — the pre-speaker-label id
+ * shape (hashed from unlabeled text). Kept in sync by the migration test
+ * below: if the hash ever drifts, the test fails loudly. */
+function legacyMessageId(role: string, text: string): string {
+	let h = 0x811c9dc5;
+	const s = `${role} ${text}`;
+	for (let i = 0; i < s.length; i++) {
+		h ^= s.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return `${role[0] ?? "x"}-${(h >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+test("hot-buffer — rows sent before speaker labels existed are not re-posted (migration shim)", async () => {
+	// A session open across the upgrade has persisted ids hashed from the
+	// UNLABELED text. agent_end replays the full history every turn; without
+	// the legacy-id check the whole transcript would re-post under new
+	// (labeled) ids, duplicating every row in the resource.
+	const sessionId = "s-legacy-migration";
+	const legacy = [
+		legacyMessageId("user", "old line"),
+		legacyMessageId("assistant", "old reply"),
+	];
+	const dir = path.join(testStateRoot, "hot-buffer-sent");
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, `${sessionId}.json`), JSON.stringify(legacy));
+
+	const { client, calls } = makeClient();
+	const handler = buildHotBufferHandler(client, cfg, { stateRoot: testStateRoot });
+	await handler(
+		{
+			success: true,
+			messages: [
+				{ role: "user", content: "old line" },
+				{ role: "assistant", content: "old reply" },
+				{ role: "user", content: "new line" },
+			],
+		},
+		{ sessionId },
+	);
+
+	// Only the genuinely new message goes out — labeled.
+	assert.equal(calls.length, 1);
+	assert.deepEqual(
+		calls[0].map((m) => m.content),
+		["[User]: new line"],
+	);
+});
+
+test("hot-buffer — cron prompts keep their own prefix instead of the user label", async () => {
+	const { client, calls } = makeClient();
+	const labeled = parseConfig({
+		apiKey: "k",
+		userId: "u1",
+		hotBuffer: { enabled: true, userLabel: "David", assistantLabel: "Alinea" },
+	});
+	const handler = buildHotBufferHandler(client, labeled, { stateRoot: testStateRoot });
+	await handler(
+		{
+			success: true,
+			messages: [
+				{ role: "user", content: "[cron:abc123 daily-review] Do the daily review." },
+				{ role: "assistant", content: "On it." },
+			],
+		},
+		{ sessionId: "s-cron-label" },
+	);
+	assert.deepEqual(
+		calls[0].map((m) => m.content),
+		["[cron:abc123 daily-review] Do the daily review.", "[Alinea]: On it."],
+	);
+	assert.equal(calls[0][0].metadata?.openclaw_speaker_name, "cron");
 });

--- a/hooks/hot-buffer.ts
+++ b/hooks/hot-buffer.ts
@@ -195,28 +195,46 @@ export function buildHotBufferHandler(
 		if (groupChat && !cfg.multiUser && !warnedGroupSessions.has(sessionId)) {
 			warnedGroupSessions.add(sessionId);
 			log.warn(
-				"hot-buffer: multi-speaker session detected but multiUser is not configured — all turns written under cfg.userId with no speaker attribution (see issues #58/#59)",
+				"hot-buffer: multi-speaker session detected but multiUser is not configured — all turns written under cfg.userId; attribution is in-content [Name]: labels only (see issues #58/#59)",
 			);
 		}
 
-		// In multi-speaker single-user mode, prefix each human turn with the sender
-		// name so attribution survives in stored text. Metadata on hot-buffer
-		// writes suppresses indexing (Hyperspell #1921), so the text content is
-		// the only place attribution can land. Only prefix when we have an
-		// envelope-derived name — if it equals cfg.userId the sender field was
-		// absent and prefixing "alinea:" onto someone else's message would mislead.
-		// Escape ] to keep the [Name]: format parseable (issue #59 follow-up).
-		const envName =
-			resolved?.name && resolved.name !== (cfg.userId ?? "")
-				? resolved.name.replace(/\]/g, "").trim()
+		// Speaker labels on EVERY conversational turn, in all sessions — not just
+		// detected group chats. POST /messages carries no role or speaker field
+		// (the payload is {resource_id, message_id, content}), so an in-content
+		// label is the only speaker signal the server-side consolidator ever
+		// sees. Unlabeled 1:1 turns were summarized with speakers guessed from a
+		// wall of merged first-person text under one vault user — the human's
+		// words came back attributed to the agent and vice versa. The
+		// attribution-v2 guards (issues #58/#59) gated labeling on multi-speaker
+		// detection, which treated 1:1 sessions as the safe case; they were the
+		// worst case. For user turns an envelope-derived sender name wins (the
+		// only correct answer once a second human appears), then
+		// hotBuffer.userLabel, then a generic role label. Only trust
+		// resolved.name when it's envelope-derived — if it equals cfg.userId the
+		// sender field was absent, and in multiUser mode an unresolved fallback
+		// carries sharedUserId, not a person. Escape ] to keep [Name]: parseable.
+		const escapeLabel = (s: string | undefined): string | undefined => {
+			const v = (s ?? "").replace(/\]/g, "").trim();
+			return v.length > 0 ? v : undefined;
+		};
+		const envName = cfg.multiUser
+			? resolved?.resolved
+				? resolved.name
+				: undefined
+			: resolved?.name && resolved.name !== (cfg.userId ?? "")
+				? resolved.name
 				: undefined;
-		const speakerPrefix =
-			groupChat && !cfg.multiUser && envName ? `[${envName}]: ` : undefined;
+		const userLabel =
+			escapeLabel(envName) ?? escapeLabel(cfg.hotBuffer.userLabel) ?? "User";
+		const assistantLabel =
+			escapeLabel(cfg.hotBuffer.assistantLabel) ?? "Assistant";
 
 		const pending: Array<{
 			resourceId: string;
 			messageId: string;
 			content: string;
+			metadata: Record<string, string>;
 		}> = [];
 		const pendingIds: string[] = [];
 
@@ -231,10 +249,21 @@ export function buildHotBufferHandler(
 				continue;
 			}
 
-			let text = extractText(m.content);
-			if (role === "user" && speakerPrefix) text = speakerPrefix + text;
-			if (text.length === 0) continue;
+			const raw = extractText(m.content);
+			if (raw.length === 0) continue;
 
+			// Cron prompts arrive as user-role turns but aren't the human
+			// speaking — OpenClaw injects its own "[cron:<id> <name>]" prefix.
+			// Stamping the user label on top would attribute automation to the
+			// human; leave those rows as-is (the attribution backfill applies
+			// the same skip rule).
+			const isCronPrompt = role === "user" && raw.startsWith("[cron:");
+			const label = isCronPrompt
+				? "cron"
+				: role === "user"
+					? userLabel
+					: assistantLabel;
+			let text = isCronPrompt ? raw : `[${label}]: ${raw}`;
 			if (text.length > MAX_CONTENT_CHARS) {
 				log.warn(
 					`hot-buffer: truncating ${role} message ${text.length} -> ${MAX_CONTENT_CHARS} chars`,
@@ -243,9 +272,29 @@ export function buildHotBufferHandler(
 			}
 
 			const id = messageId(role, text);
-			if (sent.has(id)) continue;
+			// Migration shim: rows written before speaker labels existed (or before
+			// an envelope name was known) were hashed from the unlabeled text.
+			// agent_end replays the full session history every turn, so without
+			// this check the first post-upgrade turn of any open session re-posts
+			// its entire transcript under new ids — duplicating every row in the
+			// resource instead of upserting.
+			const legacyId = messageId(role, raw);
+			if (sent.has(id) || sent.has(legacyId)) continue;
 
-			pending.push({ resourceId, messageId: id, content: text });
+			pending.push({
+				resourceId,
+				messageId: id,
+				content: text,
+				// Per-row speaker tags ride alongside the in-content label so
+				// retrieval can filter live hot rows by speaker without parsing
+				// content. Row-level only: consolidation unions metadata across a
+				// resource's rows, so at resource level these keys may collapse to
+				// one arbitrary speaker — never filter consolidated results on them.
+				metadata: {
+					openclaw_speaker_role: role,
+					openclaw_speaker_name: label,
+				},
+			});
 			pendingIds.push(id);
 		}
 


### PR DESCRIPTION
## The bug

`POST /messages` carries no role or speaker field, so hot-buffer rows from 1:1 sessions were stored as unlabeled text under a single vault user. The server-side consolidator then guessed speakers — and stamped every message's `sender` with the vault owner. Result, observed live: the human's words came back summarized as the agent's ("Alinea expresses feeling shaky after drinking…") and the agent's work came back as "the user".

The attribution-v2 guards (#58/#59) only fired on multi-speaker detection — 1:1 sessions were treated as the safe case. They were the worst case.

## The fix

- **Label every conversational turn** in all sessions: envelope sender name → `hotBuffer.userLabel` → `"User"` for user turns; `hotBuffer.assistantLabel` → `"Assistant"` for assistant turns. In-content labels are the only speaker signal the consolidator sees, and they outrank the owner stamp at summarization time (verified live: relabeled resources re-consolidate with correct attribution in ~40s).
- **Cron prompts keep their own `[cron:…]` prefix** — automation is not the human speaking.
- **Per-row speaker metadata** (`openclaw_speaker_role`/`openclaw_speaker_name`), merged over the shared batch tags. Row-level only: consolidation unions metadata across a resource, so these keys collapse at resource level — documented as never-filter-consolidated-on-these.
- **Dedup migration shim**: ids hash from the labeled text, with a legacy (unlabeled-text) id check so sessions open across the upgrade don't re-post their entire transcript.
- **`docs/backfill-attribution.mjs`**: deterministic relabel of historical rows — the role survives in the vault as each message's `u-`/`a-` external_id prefix, so no guessing. Dry-run by default, JSONL backup before any write, skips rows already starting with `[` and rows with unrecognizable ids. Live state: dry-run scoped 347 conversations / 10,290 rows; one-resource pilot verified.

## Verification

- 425 tests pass; clean build.
- Deployed to a live install: two real gateway turns stored and consolidated as `[David]: …` / `[A Linea]: …`, titles and summaries regenerated with correct attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788985072&installation_model_id=8852&pr_number=123&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F123&signature=441e34019f9a52a74ec49333ed7e45bf3d06af56adce5f7f988c0d9d9493c201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->