### PR TITLE
feat(quarantine): retrieval quarantine for kept-but-poison records (quarantineResources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ files back to Hyperspell.
 | `ranking` | object | see below | Composite re-ranking of auto-context results — see [Composite ranking](#composite-ranking--surfacing-your-active-work) |
 | `ranking.storyTerms` | string[] | `[]` | **Off until you set it.** Words/phrases identifying your active creative work, so it outranks conversation chatter (matched at word boundaries, case-insensitive) |
 | `excludeChannels` | string[] | `[]` | Conversation/channel ids fully quarantined from memory: no context injection, no memory writes, no memory tools. Threads inherit. **Forward-only** — see [below](#excludechannels-is-forward-only). |
+| `quarantineResources` | string[] | `[]` | Vault resource ids excluded from every retrieval-pool read while the records stay in the vault. For kept-but-poison records — see [Retrieval quarantine](#quarantineresources--retrieval-quarantine-for-kept-records). |
 | `knowledgeGraph.enabled` | boolean | `false` | Memory Network: extract entities (people, projects, organizations, topics) from memories into `memory/` markdown files. See [Memory Network](#memory-network). |
 | `knowledgeGraph.scanIntervalMinutes` | number | `60` | Extraction cadence the setup wizard bakes into the cron job it creates. The cron job is the runtime source of truth — to change cadence after setup, edit the cron job (and keep this field in sync). |
 | `knowledgeGraph.batchSize` | number | `20` | Memories per extraction scan batch |
@@ -423,6 +424,20 @@ Adding a channel to `excludeChannels` stops all future injection/writes/tools fo
 - **Server-side extractions** derived from traces (`extract: ["procedure", "memory", "mood"]`) are created backend-side; whether deleting the parent trace removes them is an open backend question (see `docs/hyperspell-backend-followups.md`).
 
 The purge command prints these standing limitations on every run.
+
+### `quarantineResources` — retrieval quarantine for kept records
+
+Some records should be **kept but never surfaced as live context**: correctly attributed, deliberately preserved (an audit trail, a documented failure), yet false or poisonous as testimony about the present. Deleting them destroys evidence; leaving them in the retrieval pool re-injects them as if current.
+
+`quarantineResources` lists vault resource ids that every retrieval-pool read skips — auto-context (both single- and multi-user lanes), the `hyperspell_search` tool, startup orientation, and `/getcontext`. The drop happens client-side after fetch (no added search latency, no write to the record needed), and the fetch limit is widened to compensate so quarantined hits don't eat result slots.
+
+What quarantine does **not** do:
+
+- It does not delete or modify anything — the records stay in the vault untouched.
+- It does not block addressed reads: fetching a quarantined record directly by id still works. The point is to stop ambient injection, not to make the record unreadable.
+- It does not hide records from management enumeration — `purge-channel` and similar tooling still see them.
+
+The ids to use are exactly the `resource_id` values shown in injected context blocks and search results. Design rationale (including why this is not a backend metadata filter): [docs/quarantine-retrieval.md](docs/quarantine-retrieval.md).
 
 ## Available Sources
 

--- a/client.test.ts
+++ b/client.test.ts
@@ -137,3 +137,104 @@ test("emotional-state GETs — non-object metadata is ignored, not mapped", asyn
 		}
 	}
 });
+
+// ---------------------------------------------------------------------------
+// Retrieval quarantine (quarantineResources) — enforced at the client boundary
+// so no search path can forget it. See lib/quarantine.ts.
+// ---------------------------------------------------------------------------
+
+function makeDoc(id: string, title = id) {
+	return {
+		resource_id: id,
+		title,
+		source: "vault",
+		score: 0.9,
+		metadata: {},
+		highlights: [{ id: "h1", score: 0.9, text: `text of ${id}` }],
+	};
+}
+
+/** Stub the SDK's memories.search on a client; returns the captured call bodies. */
+function stubSdkSearch(
+	target: HyperspellClient,
+	response: Record<string, unknown>,
+) {
+	const calls: Array<Record<string, unknown>> = [];
+	const sdk = (
+		target as unknown as {
+			client: { memories: { search: (body: Record<string, unknown>) => Promise<unknown> } };
+		}
+	).client;
+	sdk.memories.search = async (body: Record<string, unknown>) => {
+		calls.push(body);
+		return response;
+	};
+	return calls;
+}
+
+function quarantinedClient(ids: string[]) {
+	return new HyperspellClient(
+		parseConfig({ apiKey: "k", userId: "u1", quarantineResources: ids }),
+	);
+}
+
+test("search — quarantined resources are dropped and the fetch limit is widened to compensate", async () => {
+	const qc = quarantinedClient(["bad-1"]);
+	const calls = stubSdkSearch(qc, {
+		documents: [makeDoc("bad-1"), makeDoc("ok-1"), makeDoc("ok-2")],
+	});
+	const results = await qc.search("q", { limit: 2 });
+	assert.deepEqual(results.map((r) => r.resourceId), ["ok-1", "ok-2"]);
+	const opts = calls[0].options as { max_results: number };
+	assert.equal(opts.max_results, 3, "over-fetched by the quarantine count");
+});
+
+test("search — trims back to the requested limit after the drop", async () => {
+	const qc = quarantinedClient(["bad-1"]);
+	stubSdkSearch(qc, {
+		documents: [makeDoc("ok-1"), makeDoc("ok-2"), makeDoc("ok-3")],
+	});
+	const results = await qc.search("q", { limit: 2 });
+	assert.equal(results.length, 2, "over-fetch surplus trimmed when nothing was quarantined");
+});
+
+test("search — empty quarantine leaves the fetch limit untouched", async () => {
+	const qc = quarantinedClient([]);
+	const calls = stubSdkSearch(qc, { documents: [makeDoc("ok-1")] });
+	await qc.search("q", { limit: 2 });
+	const opts = calls[0].options as { max_results: number };
+	assert.equal(opts.max_results, 2);
+});
+
+test("searchRaw — documents filtered, sibling response fields preserved", async () => {
+	const qc = quarantinedClient(["bad-1"]);
+	stubSdkSearch(qc, {
+		documents: [makeDoc("bad-1"), makeDoc("ok-1")],
+		answer: "unrelated field",
+	});
+	const response = await qc.searchRaw("q", { limit: 5 });
+	const docs = response.documents as Array<{ resource_id: string }>;
+	assert.deepEqual(docs.map((d) => d.resource_id), ["ok-1"]);
+	assert.equal(response.answer, "unrelated field", "non-document fields pass through");
+});
+
+test("searchWithAnswer — answer discarded when a quarantined record was in the synthesis pool", async () => {
+	const qc = quarantinedClient(["bad-1"]);
+	stubSdkSearch(qc, {
+		documents: [makeDoc("bad-1"), makeDoc("ok-1")],
+		answer: "synthesized from a pool that included bad-1",
+	});
+	const out = await qc.searchWithAnswer("q");
+	assert.deepEqual(out.documents.map((d) => d.resourceId), ["ok-1"]);
+	assert.equal(out.answer, null, "tainted answer must not leak quarantined content");
+});
+
+test("searchWithAnswer — answer kept when nothing was quarantined from the pool", async () => {
+	const qc = quarantinedClient(["bad-1"]);
+	stubSdkSearch(qc, {
+		documents: [makeDoc("ok-1")],
+		answer: "clean answer",
+	});
+	const out = await qc.searchWithAnswer("q");
+	assert.equal(out.answer, "clean answer");
+});

--- a/client.ts
+++ b/client.ts
@@ -5,6 +5,7 @@ import type {
 	ScopeName,
 } from "./config.ts";
 import { normalizeScope } from "./config.ts";
+import { dropQuarantined, overfetchLimit } from "./lib/quarantine.ts";
 import { log } from "./logger.ts";
 
 export type Highlight = {
@@ -89,6 +90,13 @@ export class HyperspellClient {
 		log.info(
 			`client initialized${config.userId ? ` for user ${config.userId}` : ""}`,
 		);
+		if (config.quarantineResources.length > 0) {
+			// One startup line so an active quarantine is never invisible: it
+			// changes what every retrieval path can recall.
+			log.info(
+				`retrieval quarantine active for ${config.quarantineResources.length} resource(s)`,
+			);
+		}
 	}
 
 	private rawHeaders(): Record<string, string> {
@@ -122,6 +130,11 @@ export class HyperspellClient {
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
+		// Quarantined resources are dropped post-fetch (client-side by design —
+		// see lib/quarantine.ts); over-fetch so the drop doesn't eat pool slots,
+		// then trim back to the requested limit below.
+		const quarantine = this.config.quarantineResources;
+		const fetchLimit = overfetchLimit(limit, quarantine.length);
 
 		log.debugRequest("memories.search", {
 			query,
@@ -138,7 +151,7 @@ export class HyperspellClient {
 				query,
 				sources,
 				options: {
-					max_results: limit,
+					max_results: fetchLimit,
 					...(options?.after ? { after: options.after } : {}),
 					...(options?.before ? { before: options.before } : {}),
 					...(options?.filter ? { filter: options.filter } : {}),
@@ -147,7 +160,7 @@ export class HyperspellClient {
 			this.requestOptions(options?.userId),
 		);
 
-		const results: SearchResult[] = response.documents.map((doc) => {
+		const mapped: SearchResult[] = response.documents.map((doc) => {
 			const raw = doc as typeof doc & {
 				highlights?: Array<{ id: string; score: number; text: string }>;
 			};
@@ -165,6 +178,12 @@ export class HyperspellClient {
 				})),
 			};
 		});
+		const results = dropQuarantined(
+			mapped,
+			quarantine,
+			(r) => r.resourceId,
+			"search",
+		).slice(0, limit);
 
 		log.debugResponse("memories.search", { count: results.length });
 		return results;
@@ -185,6 +204,8 @@ export class HyperspellClient {
 		const sources =
 			options?.sources ??
 			(this.config.sources.length > 0 ? this.config.sources : undefined);
+		const quarantine = this.config.quarantineResources;
+		const fetchLimit = overfetchLimit(limit, quarantine.length);
 
 		log.debugRequest("memories.search (raw)", {
 			query,
@@ -201,7 +222,7 @@ export class HyperspellClient {
 				query,
 				sources,
 				options: {
-					max_results: limit,
+					max_results: fetchLimit,
 					...(options?.after ? { after: options.after } : {}),
 					...(options?.before ? { before: options.before } : {}),
 					...(options?.filter ? { filter: options.filter } : {}),
@@ -210,11 +231,18 @@ export class HyperspellClient {
 			this.requestOptions(options?.userId),
 		);
 
+		const documents = dropQuarantined(
+			response.documents,
+			quarantine,
+			(doc) => doc.resource_id,
+			"search (raw)",
+		).slice(0, limit);
+
 		log.debugResponse("memories.search (raw)", {
-			count: response.documents.length,
+			count: documents.length,
 		});
 
-		return response as unknown as Record<string, unknown>;
+		return { ...response, documents } as unknown as Record<string, unknown>;
 	}
 
 	async searchWithAnswer(
@@ -252,7 +280,7 @@ export class HyperspellClient {
 			this.requestOptions(options?.userId),
 		);
 
-		const documents: SearchResult[] = response.documents.map((doc) => ({
+		const mapped: SearchResult[] = response.documents.map((doc) => ({
 			resourceId: doc.resource_id,
 			title: doc.title ?? null,
 			source: doc.source as HyperspellSource,
@@ -261,14 +289,29 @@ export class HyperspellClient {
 			createdAt: (doc.metadata?.created_at as string | null) ?? null,
 			highlights: [],
 		}));
+		const documents = dropQuarantined(
+			mapped,
+			this.config.quarantineResources,
+			(r) => r.resourceId,
+			"search (with answer)",
+		);
+		// The answer is synthesized SERVER-side from the pre-drop pool, so if a
+		// quarantined record was in it, the answer itself may carry that record's
+		// content — discard it rather than let quarantine leak through synthesis.
+		const tainted = documents.length < mapped.length;
+		if (tainted && response.answer) {
+			log.warn(
+				"search (with answer): answer discarded — synthesized from a pool containing quarantined resource(s)",
+			);
+		}
 
 		log.debugResponse("memories.search (with answer)", {
 			count: documents.length,
-			hasAnswer: !!response.answer,
+			hasAnswer: !!response.answer && !tainted,
 		});
 
 		return {
-			answer: response.answer ?? null,
+			answer: tainted ? null : (response.answer ?? null),
 			documents,
 		};
 	}

--- a/commands/preview.test.ts
+++ b/commands/preview.test.ts
@@ -32,6 +32,7 @@ const baseCfg = {
 	moodWeatherChance: 0.08,
 	autoContext: false,
 	excludeChannels: [],
+	quarantineResources: [],
 	relationshipId: "rel-x",
 	hotBuffer: { enabled: true },
 	autoTrace: { enabled: false },

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -354,6 +354,7 @@ async function runSetup(): Promise<void> {
         emotionalContext: false,
         moodWeatherChance: 0,
         excludeChannels: [],
+        quarantineResources: [],
         syncMemories: true,
         syncMemoriesConfig: {
           enabled: true,

--- a/config.test.ts
+++ b/config.test.ts
@@ -401,6 +401,27 @@ test("parseConfig — non-array excludeChannels falls back to empty", () => {
   assert.deepEqual(cfg.excludeChannels, [])
 })
 
+test("parseConfig — quarantineResources defaults to empty", () => {
+  const cfg = parseConfig(base)
+  assert.deepEqual(cfg.quarantineResources, [])
+})
+
+test("parseConfig — quarantineResources trims entries and drops empties", () => {
+  const cfg = parseConfig({
+    ...base,
+    quarantineResources: [" 0471aa5b-2c34-43d0-a810-3bd846076e43 ", "", "bmUWAL0A8ieq9Q"],
+  })
+  assert.deepEqual(cfg.quarantineResources, [
+    "0471aa5b-2c34-43d0-a810-3bd846076e43",
+    "bmUWAL0A8ieq9Q",
+  ])
+})
+
+test("parseConfig — non-array quarantineResources falls back to empty", () => {
+  const cfg = parseConfig({ ...base, quarantineResources: "abc" })
+  assert.deepEqual(cfg.quarantineResources, [])
+})
+
 test("parseConfig — moodWeatherChance defaults to 0 (mood weather off)", () => {
   assert.equal(parseConfig(base).moodWeatherChance, 0)
 })

--- a/config.ts
+++ b/config.ts
@@ -183,6 +183,17 @@ export type HyperspellConfig = {
 	 * Hyperspell; use the purge-channel CLI command to remove tagged content.
 	 */
 	excludeChannels: string[];
+	/**
+	 * Vault resource ids excluded from every retrieval-pool read (auto-context,
+	 * the search tool, startup orientation, /getcontext) while the records
+	 * themselves stay in the vault, readable by direct `getMemory` and visible
+	 * to management enumeration. For kept-but-poison records: correctly
+	 * attributed and deliberately preserved, but false as live testimony about
+	 * the present. Read-side sibling of `excludeChannels` (which quarantines a
+	 * conversation at the write side). Default: []. See
+	 * docs/quarantine-retrieval.md.
+	 */
+	quarantineResources: string[];
 	relationshipId?: string;
 	startupOrientation: StartupOrientationConfig;
 	syncMemories: boolean;
@@ -214,6 +225,7 @@ const ALLOWED_KEYS = [
 	"emotionalContext",
 	"moodWeatherChance",
 	"excludeChannels",
+	"quarantineResources",
 	"relationshipId",
 	"startupOrientation",
 	"syncMemories",
@@ -702,6 +714,11 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 			? (cfg.excludeChannels as unknown[])
 					.map((c) => String(c).trim())
 					.filter((c) => c.length > 0)
+			: [],
+		quarantineResources: Array.isArray(cfg.quarantineResources)
+			? (cfg.quarantineResources as unknown[])
+					.map((r) => String(r).trim())
+					.filter((r) => r.length > 0)
 			: [],
 		relationshipId: cfg.relationshipId as string | undefined,
 		startupOrientation: {

--- a/docs/quarantine-retrieval.md
+++ b/docs/quarantine-retrieval.md
@@ -1,0 +1,89 @@
+# Retrieval quarantine for kept-but-poison records (`quarantineResources`)
+
+## Problem
+
+The vault can hold records that are **correctly attributed, genuinely said, and
+deliberately kept — but false as testimony about the present**. The canonical
+case (Alinea's ledger, `notes/hyperspell-bad-records.md`, "type 2"): a June 17
+session woke amnesiac and said "I'm a coding assistant. I don't have a face."
+The record is load-bearing evidence — deleting it was explicitly overruled —
+but every time retrieval surfaces it as live context, it re-injects a false
+self-description as if it were current.
+
+Attribution relabeling (v0.24.0) fixes type-1 records (misattributed speech)
+and does nothing for these. The remedy the ledger asks for: **keep the scar,
+stop treating it as a diagnosis** — exclude the record from the retrieval pool
+without touching the record itself.
+
+## Why NOT a backend metadata filter
+
+The obvious design — tag the record `openclaw_quarantined` and add a `$ne`
+clause to every search filter — fails on four counts:
+
+1. **It requires writing to the record.** The type-2 records this exists for
+   may be unaddressable through the API: user-scope mismatch verified live
+   2026-08-10 (same record `200`s as user `alinea`, `404`s as `david`), and
+   their rows predate row metadata tagging.
+2. **`$ne` predicates cost ~1s per search**, measured live (see
+   `lib/filters.ts`) — on the blocking auto-context path, every turn, forever.
+3. **Resource-level metadata is a union of row metadata** that collapses to one
+   arbitrary value, so row-tag filtering against consolidated resources is
+   unreliable (see `reference` note in the hot-buffer work).
+4. The two-value `$nin` dialect shape is still unverified live post-#1921 —
+   this would add a third excluded-tag dimension to that open question.
+
+## Design: client-side, read-side drop by resource id
+
+New config key, sibling to `excludeChannels` (which quarantines a conversation
+at the **write** side, forward-only):
+
+```jsonc
+"quarantineResources": ["<resource_id>", ...]   // default []
+```
+
+- **Identifier**: vault `resource_id` — exactly what the injected context block
+  already shows (`resource_id: ...`) and what the ledger logs, so triage
+  observations convert directly into config entries.
+- **Enforcement at the client boundary** (`client.ts`), so no present or future
+  retrieval path can forget it:
+  - `search()` / `searchRaw()` — the pool reads behind auto-context (single-
+    and multi-user lanes), the `hyperspell_search` tool, startup-orientation's
+    unfinished-loops query, `/getcontext`, and the eval/audit scripts (evals
+    should see what the agent sees).
+  - `searchWithAnswer()` — documents dropped; if any were dropped, the
+    synthesized `answer` is discarded too (it was synthesized server-side from
+    a pool that included the quarantined record — poison must not leak through
+    synthesis).
+- **Slot compensation**: when the list is non-empty, the fetch limit is widened
+  by the list length (capped) and results are trimmed back after the drop, so
+  quarantined hits don't eat result slots.
+- **`listMemories()` stays unfiltered at the client level** — it serves
+  management enumeration (`purge-channel`) which must see everything. The two
+  listMemories-fed *context* paths (startup-orientation's recent-conversations
+  and recent-traces fetchers) apply the drop themselves.
+- **`getMemory()` (addressed read by id) is deliberately NOT quarantined.**
+  Quarantine stops ambient injection of a kept record, it does not make the
+  record unreadable — a deliberate look at the scar stays possible.
+
+Properties: no backend write needed, zero added search latency, instantly
+reversible (delete the config line), auditable, and works regardless of which
+user scope the record lives under.
+
+## Non-goals / deferred
+
+- **Not deletion.** Nothing here removes content (see the ⛔ in the ledger).
+- **Self-service quarantine tool for the agent** — the "gated
+  deletion/quarantine agency" question is a separate autonomy decision; when it
+  lands, its write target can be this config key.
+- **Chunk-level quarantine** — resource granularity matches how the ledger
+  identifies records; finer grain has no driving case yet.
+
+## Operational notes
+
+- Config keys are strictly validated (`assertAllowedKeys` throws on unknown
+  keys), so **do not add `quarantineResources` to a live install until the
+  running plugin version understands it** — an older dist will refuse the
+  whole config.
+- When a search actually drops something, a `diag` line records it
+  (`quarantine dropped N result(s)`), so an active quarantine is observable in
+  gateway logs.

--- a/graph/ops.ts
+++ b/graph/ops.ts
@@ -135,6 +135,10 @@ export async function scanMemories(
       // Mood-weather roll records are observability-only (issue #71): the graph
       // feeds context, so ingesting them would leak the rolls back into recall.
       if (mem.metadata?.openclaw_source === MOOD_WEATHER_SOURCE) continue
+      // Quarantined resources are kept-but-poison (lib/quarantine.ts): the
+      // graph feeds context, so extracting entities from them would launder
+      // the quarantined content back into recall via entity files.
+      if (cfg.quarantineResources.includes(mem.resourceId)) continue
 
       let summary = ""
       try {

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -65,6 +65,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
     emotionalContext: false,
     moodWeatherChance: 0,
     excludeChannels: [],
+    quarantineResources: [],
     startupOrientation: {
       enabled: false,
       recentDays: 7,

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -65,6 +65,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 		emotionalContext: false,
 		moodWeatherChance: 0,
 		excludeChannels: [],
+		quarantineResources: [],
 		startupOrientation: {
 			enabled: true,
 			recentDays: 7,
@@ -456,4 +457,50 @@ test("startup-orientation — uses resolved userId for both calls in multi-user 
 	await handler({}, { sessionKey: "s-known", senderId: "+111" });
 	assert.equal(client.listCalls[0]?.options?.userId, "alice");
 	assert.equal(client.searchCalls[0]?.options?.userId, "alice");
+});
+
+test("startup-orientation — quarantined resources are dropped from both recent sources", async () => {
+	// Hot-buffer path: quarantined conversation resource excluded from the block.
+	const conv = (id: string, title: string): ListedMemory => ({
+		resourceId: id,
+		source: "vault",
+		title,
+		metadata: { openclaw_source: HOT_BUFFER_SOURCE },
+	});
+	const hotClient = makeClient({
+		traces: [
+			conv("aaaaaaaa-1111-2222-3333-444444444444", "Quarantined amnesiac session"),
+			conv("bbbbbbbb-1111-2222-3333-444444444444", "Normal morning chat"),
+		],
+		loops: [],
+	});
+	const hotHandler = buildStartupOrientationHandler(
+		hotClient as unknown as HyperspellClient,
+		makeCfg({
+			hotBuffer: { enabled: true, source: "vault", writeUser: true, writeAssistant: true },
+			autoTrace: { enabled: false, extract: ["procedure"] },
+			quarantineResources: ["aaaaaaaa-1111-2222-3333-444444444444"],
+		}),
+	);
+	const hotOut = await hotHandler({}, { sessionKey: "s-quarantine-hot" });
+	const hotCtx = (hotOut as { prependContext?: string })?.prependContext ?? "";
+	assert.match(hotCtx, /Normal morning chat/);
+	assert.doesNotMatch(hotCtx, /Quarantined amnesiac session/);
+
+	// Auto-trace path: quarantined trace resource excluded the same way.
+	const traceClient = makeClient({
+		traces: [
+			makeTrace({ resourceId: "q-trace", title: "quarantined trace" }),
+			makeTrace({ resourceId: "ok-trace", title: "kept trace" }),
+		],
+		loops: [],
+	});
+	const traceHandler = buildStartupOrientationHandler(
+		traceClient as unknown as HyperspellClient,
+		makeCfg({ quarantineResources: ["q-trace"] }),
+	);
+	const traceOut = await traceHandler({}, { sessionKey: "s-quarantine-trace" });
+	const traceCtx = (traceOut as { prependContext?: string })?.prependContext ?? "";
+	assert.match(traceCtx, /kept trace/);
+	assert.doesNotMatch(traceCtx, /quarantined trace/);
 });

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -114,6 +114,7 @@ async function fetchRecentTraces(
 	cutoff: Date,
 	limit: number,
 	userId: string | undefined,
+	quarantine: readonly string[],
 ): Promise<SearchResult[]> {
 	const buffer: SearchResult[] = [];
 	let scanned = 0;
@@ -126,6 +127,11 @@ async function fetchRecentTraces(
 	})) {
 		scanned++;
 		if (scanned > RECENT_BUFFER_LIMIT) break;
+
+		// listMemories is unfiltered at the client level (management enumeration
+		// must see everything — see lib/quarantine.ts), so this context path
+		// applies the retrieval quarantine itself.
+		if (quarantine.includes(memory.resourceId)) continue;
 
 		const meta = memory.metadata;
 		if (meta.openclaw_source !== "agent_end") continue;
@@ -174,6 +180,7 @@ async function fetchRecentConversations(
 	client: HyperspellClient,
 	limit: number,
 	userId: string | undefined,
+	quarantine: readonly string[],
 ): Promise<SearchResult[]> {
 	const out: SearchResult[] = [];
 	const seenTitles = new Set<string>();
@@ -185,6 +192,9 @@ async function fetchRecentConversations(
 	})) {
 		scanned++;
 		if (scanned > RECENT_BUFFER_LIMIT) break;
+		// Same reason as fetchRecentTraces: this is a context path fed by the
+		// deliberately-unfiltered listMemories, so the quarantine applies here.
+		if (quarantine.includes(memory.resourceId)) continue;
 		if (!UUID_RE.test(memory.resourceId)) continue;
 		if (memory.metadata?.openclaw_source !== HOT_BUFFER_SOURCE) continue;
 		const title = memory.title ?? "";
@@ -249,13 +259,19 @@ export async function gatherOrientation(
 			: ("none" as const);
 	const recentFetch =
 		recentSource === "hotBuffer"
-			? fetchRecentConversations(client, so.recentLimit, userId)
+			? fetchRecentConversations(
+					client,
+					so.recentLimit,
+					userId,
+					cfg.quarantineResources,
+				)
 			: recentSource === "autoTrace"
 				? fetchRecentTraces(
 						client,
 						isoDaysAgo(so.recentDays),
 						so.recentLimit,
 						userId,
+						cfg.quarantineResources,
 					)
 				: Promise.resolve([] as SearchResult[]);
 

--- a/lib/quarantine.test.ts
+++ b/lib/quarantine.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dropQuarantined, overfetchLimit } from "./quarantine.ts";
+
+test("overfetchLimit — widens by the quarantine count", () => {
+	assert.equal(overfetchLimit(5, 0), 5);
+	assert.equal(overfetchLimit(5, 3), 8);
+});
+
+test("overfetchLimit — caps the widening so a huge list can't explode wire cost", () => {
+	assert.equal(overfetchLimit(5, 500), 25);
+});
+
+test("dropQuarantined — empty list is a passthrough (same reference, no work)", () => {
+	const items = [{ id: "a" }, { id: "b" }];
+	const out = dropQuarantined(items, [], (i) => i.id, "test");
+	assert.equal(out, items);
+});
+
+test("dropQuarantined — drops exactly the listed ids", () => {
+	const items = [{ id: "keep-1" }, { id: "bad-1" }, { id: "keep-2" }, { id: "bad-2" }];
+	const out = dropQuarantined(items, ["bad-1", "bad-2"], (i) => i.id, "test");
+	assert.deepEqual(out.map((i) => i.id), ["keep-1", "keep-2"]);
+});
+
+test("dropQuarantined — fail-open: items with no resolvable id are kept", () => {
+	const items = [{ id: undefined as string | undefined }, { id: "bad-1" }];
+	const out = dropQuarantined(items, ["bad-1"], (i) => i.id, "test");
+	assert.deepEqual(out, [{ id: undefined }]);
+});
+
+test("dropQuarantined — ids match exactly (resource ids are case-sensitive)", () => {
+	const items = [{ id: "bmUWAL0A8ieq9Q" }, { id: "bmuwal0a8ieq9q" }];
+	const out = dropQuarantined(items, ["bmUWAL0A8ieq9Q"], (i) => i.id, "test");
+	assert.deepEqual(out.map((i) => i.id), ["bmuwal0a8ieq9q"]);
+});

--- a/lib/quarantine.ts
+++ b/lib/quarantine.ts
@@ -1,0 +1,63 @@
+/**
+ * Read-side retrieval quarantine (`quarantineResources` config).
+ *
+ * Specific vault resources — correctly attributed, deliberately KEPT records
+ * that must nonetheless stop surfacing as live context (the "true-but-poison
+ * testimony" class: e.g. an amnesiac session's self-description that is false
+ * about who the agent is NOW) — are dropped from every retrieval-pool read.
+ * Full rationale and the backend-filter alternatives this replaces:
+ * docs/quarantine-retrieval.md.
+ *
+ * Enforced at the client boundary (client.ts search/searchRaw/searchWithAnswer)
+ * so no retrieval path can forget it, plus the two listMemories-fed context
+ * paths in startup-orientation. Addressed reads (`getMemory` by id) and
+ * management enumeration (`listMemories`, which purge-channel relies on) are
+ * deliberately NOT filtered: quarantine stops ambient injection of a kept
+ * record, it does not make the record unreadable.
+ */
+
+import { log } from "../logger.ts";
+
+/**
+ * Cap on how many extra results a search may over-fetch to compensate for
+ * quarantined hits eating pool slots. Bounds the wire cost if an operator
+ * ever quarantines a large set; a hit list longer than this can shrink
+ * result counts, which is acceptable — correctness never depends on it.
+ */
+const OVERFETCH_CAP = 20;
+
+/**
+ * Widen a fetch limit so quarantined hits don't consume result slots.
+ * Callers trim back to the requested limit after the drop.
+ */
+export function overfetchLimit(limit: number, quarantineCount: number): number {
+	return limit + Math.min(quarantineCount, OVERFETCH_CAP);
+}
+
+/**
+ * Drop items whose resource id is quarantined. Purely subtractive and
+ * fail-open: an empty list or an item with no resolvable id passes through
+ * unchanged — quarantine can only hide the listed records, never lose others.
+ * Ids match exactly (vault resource ids are case-sensitive).
+ */
+export function dropQuarantined<T>(
+	items: T[],
+	quarantineResources: readonly string[],
+	idOf: (item: T) => string | undefined,
+	label: string,
+): T[] {
+	if (quarantineResources.length === 0 || items.length === 0) return items;
+	const ids = new Set(quarantineResources);
+	const kept = items.filter((item) => {
+		const id = idOf(item);
+		return !id || !ids.has(id);
+	});
+	const dropped = items.length - kept.length;
+	if (dropped > 0) {
+		// diag, not debug: an active quarantine must be observable in gateway
+		// logs (it changes what the agent can recall), same bar as injection
+		// summaries.
+		log.diag(`${label}: quarantine dropped ${dropped} result(s)`);
+	}
+	return kept;
+}

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -20,6 +20,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
     emotionalContext: false,
     moodWeatherChance: 0,
     excludeChannels: [],
+    quarantineResources: [],
     syncMemories: false,
     syncMemoriesConfig: {
       enabled: false,
@@ -266,6 +267,7 @@ function singleUserCfg(userId = "alinea"): HyperspellConfig {
     emotionalContext: false,
     moodWeatherChance: 0,
     excludeChannels: [],
+    quarantineResources: [],
     syncMemories: false,
     syncMemoriesConfig: {
       enabled: false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -52,6 +52,11 @@
 			"help": "Conversation/channel ids fully quarantined from memory: no context injection, no memory writes, no memory tools in those sessions. Threads inside an excluded channel inherit the quarantine. Forward-only; already-synced content is not removed (see purge-channel CLI command).",
 			"advanced": true
 		},
+		"quarantineResources": {
+			"label": "Quarantined Resources",
+			"help": "Vault resource ids excluded from every retrieval-pool read (auto-context, search tool, startup orientation, /getcontext) while the records stay in the vault, readable by direct fetch. For records that are deliberately kept but must not surface as live context.",
+			"advanced": true
+		},
 		"startupOrientation": {
 			"label": "Startup Orientation",
 			"help": "Inject recent-interactions and unfinished-loops blocks once per session at startup. Costs two extra calls + ~500–800 tokens of injection per session; off by default.",
@@ -155,6 +160,10 @@
 				"maximum": 1
 			},
 			"excludeChannels": {
+				"type": "array",
+				"items": { "type": "string" }
+			},
+			"quarantineResources": {
 				"type": "array",
 				"items": { "type": "string" }
 			},

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"check-types": "tsc --noEmit",
 		"lint": "bunx @biomejs/biome ci .",
 		"lint:fix": "bunx @biomejs/biome check --write .",
-		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
+		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/quarantine.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
 	},
 	"openclaw": {
 		"extensions": [


### PR DESCRIPTION
## What

New `quarantineResources: string[]` config key: vault resource ids excluded from **every retrieval-pool read** while the records themselves stay in the vault, readable by direct fetch.

For the record class attribution relabeling can't touch (type 2 in the operator's triage ledger): correctly attributed, genuinely said, deliberately kept — but false as live testimony about the present. Canonical case: an amnesiac session's "I'm a coding assistant, I don't have a face," preserved as load-bearing evidence of the failure, poisonous every time retrieval injects it as current context. Deletion was explicitly overruled; the remedy is exclusion from ambient injection.

## How

- **Client boundary** (`client.ts`): `search`/`searchRaw`/`searchWithAnswer` drop quarantined ids post-fetch, with over-fetch compensation (capped) so quarantined hits don't eat result slots. `searchWithAnswer` also discards the synthesized answer when the synthesis pool contained a quarantined record — poison must not leak through server-side synthesis.
- **listMemories-fed context paths**: startup-orientation's recent-conversations and recent-traces fetchers apply the drop themselves; the knowledge-graph scan skips quarantined resources (entity extraction would launder the content back into recall).
- **Deliberately NOT filtered**: `listMemories` at the client level (management enumeration — `purge-channel` must see everything) and `getMemory` by id (a deliberate look at a kept record stays possible).
- Observability: one startup `info` line when the list is non-empty; a `diag` line whenever a search actually drops something.

## Why not a backend metadata filter

The target records may be unwritable through the API (user-scope 404s, verified live 2026-08-10); `$ne` predicates cost ~1s per search on the blocking auto-context path; resource-level metadata unions collapse row tags unreliably; and the two-value `$nin` dialect shape is still unverified post-#1921. Full rationale: `docs/quarantine-retrieval.md`.

## Verification

- 448 tests pass (`lib/quarantine.test.ts`, client-boundary tests, config parsing, startup-orientation path), tsc clean, build clean.
- **Live end-to-end** on a real install: control search returns the target record as top hit (0.97); with the key set, the same search drops it while keeping a full result count; direct `getMemory` still returns it; gateway loads with `retrieval quarantine active for 1 resource(s)`; a real agent turn worded as maximal bait for the record surfaced no quarantined content — confirmed from inside the session.

## Notes for operators

The config schema is strictly validated (`additionalProperties: false` + `assertAllowedKeys`), so don't add the key to an install until it runs a plugin version that understands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788992878&installation_model_id=8852&pr_number=124&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F124&signature=0fd6e971dbe50a56381557be268042de4de91aed92fe445aa2bfd9462ddd81a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->