### PR TITLE
fix(mood-weather): skip the dice on unattended sessions (#122)

### DIFF
--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -723,3 +723,66 @@ test("mood weather observability — chance 0 writes nothing", async () => {
 	await flushAsyncWrites();
 	assert.equal(client.added.length, 0);
 });
+
+// ---- mood weather: unattended sessions don't roll (issue #122) --------------
+
+test("mood weather — cron/heartbeat/memory triggers never roll, user does", async () => {
+	for (const trigger of ["cron", "heartbeat", "memory"]) {
+		const { client } = makeClient("Warm and steady.");
+		const handler = buildEmotionalStateFetchHandler(
+			client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+			moodCfg(`rel-unattended-${trigger}`),
+			{ now: () => 1_000_000, rng: () => 0 },
+		);
+		const out = await handler({}, { sessionKey: `unatt-${trigger}`, trigger });
+		assert.ok(
+			!hasMood(out),
+			`trigger=${trigger} must not roll even with chance=1 and a hitting rng`,
+		);
+		assert.match(
+			String((out as { prependContext?: string })?.prependContext ?? ""),
+			/Warm and steady/,
+			"arc injection itself is unaffected — only the dice are skipped",
+		);
+	}
+
+	const { client } = makeClient("Warm and steady.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-attended-user"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+	const out = await handler({}, { sessionKey: "att-user", trigger: "user" });
+	assert.ok(hasMood(out), "trigger=user rolls normally");
+});
+
+test("mood weather — missing trigger stays eligible (fail-open to prior behavior)", async () => {
+	const { client } = makeClient("Warm and steady.");
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-no-trigger"),
+		{ now: () => 1_000_000, rng: () => 0 },
+	);
+	const out = await handler({}, { sessionKey: "no-trigger-s1" });
+	assert.ok(hasMood(out), "no trigger in ctx → rolls as before");
+});
+
+test("mood weather — a skipped cron roll does not burn the cross-session cooldown", async () => {
+	const { client } = makeClient("Warm and steady.");
+	let t = 1_000_000;
+	const handler = buildEmotionalStateFetchHandler(
+		client as unknown as Parameters<typeof buildEmotionalStateFetchHandler>[0],
+		moodCfg("rel-cron-no-burn"),
+		{ now: () => t, rng: () => 0 },
+	);
+
+	const cronOut = await handler({}, { sessionKey: "burn-cron", trigger: "cron" });
+	assert.ok(!hasMood(cronOut), "cron session skipped the dice");
+
+	t += 60 * 1000; // one minute later — far inside what a cooldown would cover
+	const userOut = await handler({}, { sessionKey: "burn-user", trigger: "user" });
+	assert.ok(
+		hasMood(userOut),
+		"the skipped cron roll left the window untouched — the next real conversation can land weather",
+	);
+});

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -269,11 +269,26 @@ export function buildEmotionalStateFetchHandler(
 			const lastLanded = lastMoodRollAt.get(relId);
 			const cooledDown =
 				lastLanded === undefined || now() - lastLanded >= MOOD_WEATHER_COOLDOWN_MS;
+			// The dice only roll where somebody can perceive the weather (issue
+			// #122): on a live install ~half of all rolls were landing on cron/
+			// heartbeat runs, halving the effective rate on real conversations.
+			// Same trigger gate as the store path (NON_CONVERSATIONAL_TRIGGERS);
+			// a missing trigger stays eligible (fail-open to prior behavior). A
+			// skipped roll is a non-event: it neither burns the cooldown nor logs
+			// a roll, so the next attended session's odds are untouched.
+			const unattended = NON_CONVERSATIONAL_TRIGGERS.has(ctx?.trigger ?? "");
 			const mood =
 				priorMood ??
-				(cfg.moodWeatherChance > 0 && cooledDown
+				(!unattended && cfg.moodWeatherChance > 0 && cooledDown
 					? rollMood(cfg.moodWeatherChance, deps.rng)
 					: null);
+			// diag, not debug (issue #118): this line is the live evidence the
+			// cron fix works — at most one per unattended session, ~2/day.
+			if (!mood && unattended && cfg.moodWeatherChance > 0) {
+				log.diag(
+					`mood-weather: unattended session (trigger=${ctx?.trigger}) — dice not rolled`,
+				);
+			}
 			if (mood && !priorMood) {
 				lastMoodRollAt.set(relId, now());
 				if (sessionKey) sessionMoods.set(sessionKey, mood);


### PR DESCRIPTION
Rolls no longer fire on cron/heartbeat/memory-triggered sessions — same trigger gate as the store path. Skipped rolls don't burn the cooldown. Live-deployed and verified on the reference install.

Closes #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789014240&installation_model_id=8852&pr_number=126&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F126&signature=201de58d75b8ce91eb430c8cc776d26ccaf7da564b392c2816cbd650822f942b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->