### PR TITLE
Authorship-aware ranking, write hygiene, and the metadata handshake contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ files back to Hyperspell.
 | `relevanceThreshold` | number | `0.6` | Minimum (composite) score a memory needs to be injected by auto-context |
 | `ranking` | object | see below | Composite re-ranking of auto-context results — see [Composite ranking](#composite-ranking--surfacing-your-active-work) |
 | `ranking.storyTerms` | string[] | `[]` | **Off until you set it.** Words/phrases identifying your active creative work, so it outranks conversation chatter (matched at word boundaries, case-insensitive) |
+| `ranking.processPaths` | string[] | `[]` | Case-insensitive path substrings marking synced files as the **agent's own process output** (thought logs, caches, heartbeat notes). Matches classify as `process` and score neutral — no curation boost, full-speed recency decay — instead of being promoted as curated user truth. |
+| `ranking.perFileCap` | number | `2` | Max injected results per synced source file. Distinct sections of one document pass near-duplicate dedup individually and would otherwise monopolize the pool at near-identical scores. `0` disables. |
 | `excludeChannels` | string[] | `[]` | Conversation/channel ids fully quarantined from memory: no context injection, no memory writes, no memory tools. Threads inherit. **Forward-only** — see [below](#excludechannels-is-forward-only). |
 | `quarantineResources` | string[] | `[]` | Vault resource ids excluded from every retrieval-pool read while the records stay in the vault. For kept-but-poison records — see [Retrieval quarantine](#quarantineresources--retrieval-quarantine-for-kept-records). |
 | `knowledgeGraph.enabled` | boolean | `false` | Memory Network: extract entities (people, projects, organizations, topics) from memories into `memory/` markdown files. See [Memory Network](#memory-network). |
@@ -244,6 +246,7 @@ The plugin registers tools that the AI can use autonomously:
 
 - **hyperspell_search** - Search through connected sources
 - **hyperspell_remember** - Save information to memory
+- **hyperspell_vault_triage** - Read-only audit search that does NOT apply the retrieval quarantine: quarantined hits come back flagged with content suppressed, plus the current quarantine roster. For hunting bad/stale/misattributed records proactively (quarantine is otherwise discovered only by being injected) and for verifying a quarantine took effect — not for normal recall
 - **hyperspell_emotional_arc** - Re-fetch the recent emotional arc mid-conversation (requires `emotionalContext: true`); returns the same block injected at session start, e.g. after compaction removed it
 
 ## Auto-Context
@@ -272,6 +275,23 @@ composite = relevance
 
 Chatter is additionally capped at `chatterQuota` results per injection,
 regardless of score.
+
+Classification is **origin-aware where origin is known**: results carrying the
+plugin's own write-pipeline metadata are classified by that tag first (a
+hot-buffer session the backend consolidator happened to *title* is still a
+conversation echo, not curated memory), and synced files matching
+`ranking.processPaths` classify as `process` — the agent's own operational
+output, scored neutral rather than promoted. Without that knob, a "titled,
+non-UUID" heuristic hands agent thought-logs and caches the same curation
+boost as deliberately kept user notes, and at volume the agent's process noise
+out-competes the user's quiet, durable memory. The title/id-shape heuristic
+remains the fallback for records with no origin metadata.
+
+One more diversity guard: `ranking.perFileCap` (default `2`) bounds how many
+sections of a single synced file can be injected at once. Sectionized sync
+turns a big file into many sibling candidates at near-identical scores; they
+pass near-duplicate dedup individually (different text, same document) and
+would otherwise fill the pool.
 
 Provenance is a signal too: an optional `sourceWeights` map multiplies a
 result's **base relevance** (before the kind boosts/penalties are added) by a
@@ -570,6 +590,13 @@ the scanner skip memories synced from the entity directories.
 - Enable `debug: true` — the ranked/cut/injection summary lines land in
   `gateway.log` at default host log levels
 - Check that you have memories matching your conversation topics
+- **After a gateway update**, grep `gateway.log` for `unknown typed hook` — a
+  host release that renames/removes a hook silently disables the feature
+  behind it (writes can keep working while all injection is dead). The plugin
+  logs its registered hooks at startup (`typed hooks registered: …`) and runs
+  a cross-hook liveness watchdog: if turn traffic proves one of the
+  injection/write hook pair alive while its sibling never fires, it logs an
+  **error** naming the dead hook instead of staying silent.
 
 ### Enabling `memory-core` disabled Hyperspell
 - This means `memory-core` was placed in `plugins.slots.memory`. The slot should stay on `openclaw-hyperspell`; `memory-core` rides alongside as a sidecar.

--- a/client.test.ts
+++ b/client.test.ts
@@ -178,6 +178,29 @@ function quarantinedClient(ids: string[]) {
 	);
 }
 
+test("search — metaWriter: openclaw_writer stamp wins; legacy metadata.source is the retroactive fallback", async () => {
+	const qc = quarantinedClient([]);
+	stubSdkSearch(qc, {
+		documents: [
+			{ ...makeDoc("r1"), metadata: { openclaw_writer: "user", source: "openclaw_tool" } },
+			{ ...makeDoc("r2"), metadata: { source: "openclaw_tool" } },
+			{ ...makeDoc("r3"), metadata: { source: "openclaw_command" } },
+			// Emotional-state registers: bare legacy key only — agent-generated
+			// (their transcripts were text-indexed into vault search until
+			// backend PR #3330; titled chunks read as curated without this).
+			{ ...makeDoc("r4"), metadata: { source: "openclaw_agent_end" } },
+			{ ...makeDoc("r5"), metadata: {} },
+			{ ...makeDoc("r6") },
+		],
+	});
+	const results = await qc.search("q", { limit: 10 });
+	assert.deepEqual(
+		results.map((r) => r.metaWriter),
+		["user", "agent", "user", "agent", null, null],
+		"stamp beats legacy; tool→agent, command→user, agent_end→agent; unknown→null (fail open)",
+	);
+});
+
 test("search — quarantined resources are dropped and the fetch limit is widened to compensate", async () => {
 	const qc = quarantinedClient(["bad-1"]);
 	const calls = stubSdkSearch(qc, {

--- a/client.ts
+++ b/client.ts
@@ -21,12 +21,26 @@ export type SearchResult = {
 	score: number | null;
 	url: string | null;
 	createdAt: string | null;
+	/** metadata.openclaw_source when echoed — the plugin's write-pipeline tag
+	 * (hot_buffer / agent_end / memory_sync / memory_sync_section / …). Origin
+	 * truth for classification: a consolidator-titled session resource still
+	 * reads as a conversation echo through this, not as curated memory. */
+	metaSource: string | null;
+	/** metadata.file_path when echoed — the workspace file a synced section
+	 * came from. Keys ranking's per-file diversity cap and processPaths. */
+	metaFilePath: string | null;
 	highlights: Highlight[];
 };
 
 export type SearchWithAnswerResult = {
 	answer: string | null;
 	documents: SearchResult[];
+};
+
+export type TriageResult = SearchResult & {
+	/** True when the resource is on the quarantineResources list — visible
+	 * here (and only here) so the audit view shows what quarantine covers. */
+	quarantined: boolean;
 };
 
 export type Integration = {
@@ -75,6 +89,16 @@ const API_BASE_URL = "https://api.hyperspell.com"
  */
 function isMetadataObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A string metadata value by key, or null — non-strings are dropped so a
+ * malformed echo can't poison classification. */
+function metaString(
+	metadata: Record<string, unknown> | null | undefined,
+	key: string,
+): string | null {
+	const v = metadata?.[key];
+	return typeof v === "string" && v.length > 0 ? v : null;
 }
 
 export class HyperspellClient {
@@ -171,6 +195,8 @@ export class HyperspellClient {
 				score: doc.score ?? null,
 				url: (doc.metadata?.url as string | null) ?? null,
 				createdAt: (doc.metadata?.created_at as string | null) ?? null,
+				metaSource: metaString(doc.metadata, "openclaw_source"),
+				metaFilePath: metaString(doc.metadata, "file_path"),
 				highlights: (raw.highlights ?? []).map((h) => ({
 					id: h.id,
 					score: h.score,
@@ -287,6 +313,8 @@ export class HyperspellClient {
 			score: doc.score ?? null,
 			url: (doc.metadata?.url as string | null) ?? null,
 			createdAt: (doc.metadata?.created_at as string | null) ?? null,
+			metaSource: metaString(doc.metadata, "openclaw_source"),
+			metaFilePath: metaString(doc.metadata, "file_path"),
 			highlights: [],
 		}));
 		const documents = dropQuarantined(
@@ -314,6 +342,78 @@ export class HyperspellClient {
 			answer: tainted ? null : (response.answer ?? null),
 			documents,
 		};
+	}
+
+	/**
+	 * Audit-view search for the vault-triage tool — the ONLY retrieval path
+	 * that does not drop quarantined resources (lib/quarantine.ts is enforced
+	 * on every other read). Quarantine is reactive by construction: a bad
+	 * record is normally discovered only by being injected. This view exists
+	 * so bad records can be hunted proactively; hits on the quarantine list
+	 * come back FLAGGED, never silently mixed in.
+	 */
+	async searchTriage(
+		query: string,
+		options?: {
+			limit?: number;
+			sources?: HyperspellSource[];
+			after?: string;
+			before?: string;
+			userId?: string;
+		},
+	): Promise<TriageResult[]> {
+		const limit = options?.limit ?? this.config.maxResults;
+		const sources =
+			options?.sources ??
+			(this.config.sources.length > 0 ? this.config.sources : undefined);
+
+		log.debugRequest("memories.search (triage)", {
+			query,
+			limit,
+			sources,
+			after: options?.after,
+			before: options?.before,
+			userId: options?.userId,
+		});
+
+		const response = await this.client.memories.search(
+			{
+				query,
+				sources,
+				options: {
+					max_results: limit,
+					...(options?.after ? { after: options.after } : {}),
+					...(options?.before ? { before: options.before } : {}),
+				},
+			},
+			this.requestOptions(options?.userId),
+		);
+
+		const quarantined = new Set(this.config.quarantineResources);
+		const results: TriageResult[] = response.documents.map((doc) => {
+			const raw = doc as typeof doc & {
+				highlights?: Array<{ id: string; score: number; text: string }>;
+			};
+			return {
+				resourceId: doc.resource_id,
+				title: doc.title ?? null,
+				source: doc.source as HyperspellSource,
+				score: doc.score ?? null,
+				url: (doc.metadata?.url as string | null) ?? null,
+				createdAt: (doc.metadata?.created_at as string | null) ?? null,
+				metaSource: metaString(doc.metadata, "openclaw_source"),
+				metaFilePath: metaString(doc.metadata, "file_path"),
+				highlights: (raw.highlights ?? []).map((h) => ({
+					id: h.id,
+					score: h.score,
+					text: h.text,
+				})),
+				quarantined: quarantined.has(doc.resource_id),
+			};
+		});
+
+		log.debugResponse("memories.search (triage)", { count: results.length });
+		return results;
 	}
 
 	async addMemory(

--- a/client.ts
+++ b/client.ts
@@ -26,6 +26,12 @@ export type SearchResult = {
 	 * truth for classification: a consolidator-titled session resource still
 	 * reads as a conversation echo through this, not as curated memory. */
 	metaSource: string | null;
+	/** metadata.openclaw_speaker_role when echoed. Only hot-buffer writes (and
+	 * the attribution backfill) stamp it, so its mere presence marks a
+	 * conversation row — backfilled rows verified live 2026-08-18 to carry
+	 * speaker tags but NO openclaw_source, and would otherwise dodge the
+	 * origin-based chatter rule. */
+	metaSpeakerRole: string | null;
 	/** metadata.file_path when echoed — the workspace file a synced section
 	 * came from. Keys ranking's per-file diversity cap and processPaths. */
 	metaFilePath: string | null;
@@ -196,6 +202,7 @@ export class HyperspellClient {
 				url: (doc.metadata?.url as string | null) ?? null,
 				createdAt: (doc.metadata?.created_at as string | null) ?? null,
 				metaSource: metaString(doc.metadata, "openclaw_source"),
+				metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 				metaFilePath: metaString(doc.metadata, "file_path"),
 				highlights: (raw.highlights ?? []).map((h) => ({
 					id: h.id,
@@ -314,6 +321,7 @@ export class HyperspellClient {
 			url: (doc.metadata?.url as string | null) ?? null,
 			createdAt: (doc.metadata?.created_at as string | null) ?? null,
 			metaSource: metaString(doc.metadata, "openclaw_source"),
+			metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 			metaFilePath: metaString(doc.metadata, "file_path"),
 			highlights: [],
 		}));
@@ -402,6 +410,7 @@ export class HyperspellClient {
 				url: (doc.metadata?.url as string | null) ?? null,
 				createdAt: (doc.metadata?.created_at as string | null) ?? null,
 				metaSource: metaString(doc.metadata, "openclaw_source"),
+				metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 				metaFilePath: metaString(doc.metadata, "file_path"),
 				highlights: (raw.highlights ?? []).map((h) => ({
 					id: h.id,

--- a/client.ts
+++ b/client.ts
@@ -35,6 +35,17 @@ export type SearchResult = {
 	/** metadata.file_path when echoed — the workspace file a synced section
 	 * came from. Keys ranking's per-file diversity cap and processPaths. */
 	metaFilePath: string | null;
+	/** Who authored the memory's content: "agent" | "user", else null.
+	 * Primary signal is the openclaw_writer stamp (written from 2026-08 on);
+	 * legacy rows fall back to metadata.source, which has distinguished the
+	 * agent's remember TOOL ("openclaw_tool") from the user's /remember
+	 * COMMAND ("openclaw_command") since the initial release — written since
+	 * January, read by nothing until now. Null = unknown, and ranking MUST
+	 * fail open on null (treat as today's behavior, never strip a boost on
+	 * missing data). Note the legacy signal marks the write SURFACE, not
+	 * strictly authorship — good enough for retrieval weighting, not for
+	 * attribution claims. */
+	metaWriter: "agent" | "user" | null;
 	highlights: Highlight[];
 };
 
@@ -105,6 +116,19 @@ function metaString(
 ): string | null {
 	const v = metadata?.[key];
 	return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/** Resolve authorship for SearchResult.metaWriter — openclaw_writer stamp
+ * first, legacy metadata.source surface tag as the retroactive fallback. */
+function writerOf(
+	metadata: Record<string, unknown> | null | undefined,
+): "agent" | "user" | null {
+	const stamped = metaString(metadata, "openclaw_writer");
+	if (stamped === "agent" || stamped === "user") return stamped;
+	const legacy = metaString(metadata, "source");
+	if (legacy === "openclaw_tool") return "agent";
+	if (legacy === "openclaw_command") return "user";
+	return null;
 }
 
 export class HyperspellClient {
@@ -204,6 +228,7 @@ export class HyperspellClient {
 				metaSource: metaString(doc.metadata, "openclaw_source"),
 				metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 				metaFilePath: metaString(doc.metadata, "file_path"),
+			metaWriter: writerOf(doc.metadata),
 				highlights: (raw.highlights ?? []).map((h) => ({
 					id: h.id,
 					score: h.score,
@@ -323,6 +348,7 @@ export class HyperspellClient {
 			metaSource: metaString(doc.metadata, "openclaw_source"),
 			metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 			metaFilePath: metaString(doc.metadata, "file_path"),
+			metaWriter: writerOf(doc.metadata),
 			highlights: [],
 		}));
 		const documents = dropQuarantined(
@@ -412,6 +438,7 @@ export class HyperspellClient {
 				metaSource: metaString(doc.metadata, "openclaw_source"),
 				metaSpeakerRole: metaString(doc.metadata, "openclaw_speaker_role"),
 				metaFilePath: metaString(doc.metadata, "file_path"),
+			metaWriter: writerOf(doc.metadata),
 				highlights: (raw.highlights ?? []).map((h) => ({
 					id: h.id,
 					score: h.score,

--- a/client.ts
+++ b/client.ts
@@ -128,6 +128,11 @@ function writerOf(
 	const legacy = metaString(metadata, "source");
 	if (legacy === "openclaw_tool") return "agent";
 	if (legacy === "openclaw_command") return "user";
+	// Emotional-state registers (bare legacy key; see hooks/emotional-state.ts).
+	// Their transcripts were ALSO text-indexed into generic vault search until
+	// backend PR #3330 — chunks titled from the transcript's first line, so the
+	// title heuristic reads them as curated. Agent-generated either way.
+	if (legacy === "openclaw_agent_end") return "agent";
 	return null;
 }
 

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -149,7 +149,10 @@ export function registerCommands(
 
       try {
         await client.addMemory(text, {
-          metadata: { source: "openclaw_command" },
+          // openclaw_writer: the /remember COMMAND is the USER writing —
+          // these rows keep the curation boost (vs the agent's tool writes,
+          // routed to process). Paired stamp; see tools/remember.ts.
+          metadata: { source: "openclaw_command", openclaw_writer: "user" },
           collection,
           userId,
           scope: scopingEnabled ? scope : undefined,

--- a/config.test.ts
+++ b/config.test.ts
@@ -446,6 +446,17 @@ test("parseConfig — recency fields default when absent", () => {
   assert.equal(cfg.ranking.recencyCuratedFactor, 0.5)
 })
 
+test("parseConfig — ranking.processPaths trimmed/lowercased/deduped; perFileCap defaults to 2, clamps at 0", () => {
+  const cfg = parseConfig({
+    ...base,
+    ranking: { processPaths: ["  Thoughts-Log.md ", "thoughts-log.md", "", "brainstem/"] },
+  })
+  assert.deepEqual(cfg.ranking.processPaths, ["thoughts-log.md", "brainstem/"])
+  assert.equal(cfg.ranking.perFileCap, 2)
+  assert.equal(parseConfig({ ...base, ranking: { perFileCap: -3 } }).ranking.perFileCap, 0)
+  assert.deepEqual(parseConfig({ ...base, ranking: {} }).ranking.processPaths, [])
+})
+
 test("parseConfig — recency fields respected when present, clamped when out of range", () => {
   const cfg = parseConfig({
     ...base,

--- a/config.ts
+++ b/config.ts
@@ -387,6 +387,19 @@ function parseRanking(raw: unknown): RankingWeights {
 			1,
 			Math.max(0, num(r.dedupThreshold, DEFAULT_RANKING.dedupThreshold)),
 		),
+		// Lowercased at parse time — classifyResult matches them against a
+		// lowercased file path, so the comparison stays case-insensitive with
+		// zero per-result work.
+		processPaths: Array.isArray(r.processPaths)
+			? [
+					...new Set(
+						(r.processPaths as unknown[])
+							.map((t) => String(t).trim().toLowerCase())
+							.filter((t) => t.length > 0),
+					),
+				]
+			: DEFAULT_RANKING.processPaths,
+		perFileCap: Math.max(0, num(r.perFileCap, DEFAULT_RANKING.perFileCap)),
 		elbow: parseElbow(r.elbow),
 	};
 }

--- a/docs/hyperspell-backend-followups.md
+++ b/docs/hyperspell-backend-followups.md
@@ -57,3 +57,69 @@ Proven live 2026-07-12: `GET /emotional-state[/recent]` drops stored
 maps `metadata` through on both GETs when present (`client.ts`), so
 Postmark read-back verification and Ballast (#68) unblock the day the
 backend ships the echo. No plugin change needed then.
+
+## 7. Hot-buffer flush latency needs an SLA or read-your-writes (filed 2026-08-18, from the scale report)
+
+Writes to `POST /messages` land in a hot buffer and flush to the searchable
+vault on an async cycle measured live at **~30 s minimum, ~100 min maximum**
+(14 consecutive daily write-then-search failures, 2026-06-20 → 2026-07-03;
+root-caused 2026-06-30 by write-timestamp vs. discovery-timestamp diffing).
+Not data loss — an eventual-consistency window, on a single-user, low-volume
+install; under multi-tenant write load the window presumably stretches.
+Ask, in preference order: (a) read-your-writes for the writing session (a
+brain/vault search issued by the session that wrote a row should see that
+row), (b) a bounded/documented flush interval, (c) a flush cursor or
+`flushed_through` timestamp on search responses so callers can at least say
+"results current as of T" instead of confabulating around invisible writes.
+
+## 8. Consolidator must consume per-row speaker metadata, not infer speakers from prose (filed 2026-08-18)
+
+Every hot-buffer row now carries `openclaw_speaker_role` /
+`openclaw_speaker_name` metadata plus an in-content `[Name]:` label (shipped
+after #1921 was fixed; see `hooks/hot-buffer.ts`). The server-side
+consolidator ignores them and re-infers speakers from merged first-person
+prose, producing three documented failure modes (diagnosis:
+`docs/issue-summarizer-role-swap.md`): **collapse** (user's words filed under
+the agent), **flip** (agent's words attributed to the user as a false factual
+claim — e.g. resource `9f4b3d77-216a-478a-a7e6-13c7a5339c44`, which inverts
+who holds the delete capability), and **pronoun smear**. Reproduced 2026-08-10,
+-13, and -16. Ask: consolidation/summarization treats row speaker metadata as
+authoritative and never rewrites attribution across labeled rows.
+
+## 9. Enumeration + admin path for records written under another userId (filed 2026-08-18)
+
+A plugin writing with `X-As-User: <agentUserId>` produces records the human
+operator's own token cannot `get_memory`, `list_memories`, or `delete_memory`
+(404-as-wrong-user, verified live 2026-08-10 — including on a fresh test
+write). Conversation summaries are additionally absent from `list_memories`
+under ANY token, so a record known to be wrong, whose id is known, cannot be
+read, listed, or removed through the API. Client-side quarantine
+(`quarantineResources`) routes around retrieval but cannot satisfy an actual
+deletion request. Ask: (a) an enumeration endpoint that includes
+consolidation-derived resources, (b) an app-scoped admin token or explicit
+cross-user grant so a deployment can list/delete its own agent-written
+records, (c) treat this as the GDPR/SOC2 "delete this record" path — it is a
+compliance blocker for multi-user deployments, not a convenience.
+
+## 10. Derivative lineage (`derived_from`) on consolidation outputs (filed 2026-08-18)
+
+Records produced by consolidating/summarizing other records carry no parent
+link. Retracting (quarantining/deleting) an original does nothing to the
+records that quote or discuss it, and conversations about a bad record mint
+new derivatives containing the same content — cleanup is unbounded manual
+labor by construction. Related to follow-up 2 (trace-extraction cascade), but
+broader: ask for a `derived_from` (or lineage array) field on every
+backend-generated resource, so "retract this and everything downstream of it"
+becomes expressible at all. Supersession (`superseded_by`) would additionally
+let stale-but-kept history stop outranking its own correction.
+
+## 11. Per-resource diversity in search results (filed 2026-08-18)
+
+A sectionized document can occupy many of a search's result slots with
+near-identical chunks (live: 4 chunks of one synced file, all scoring 0.9433,
+filling the pool for a natural-language query whose correct answer ranked
+elsewhere). The plugin now caps injected results per source file
+(`ranking.perFileCap`) — but it can only diversify what the backend returned;
+chunks still crowd out other documents at fetch time. Ask: a
+`max_results_per_resource` (or grouped/collapsed) option on search so the
+candidate pool itself is diverse.

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -39,6 +39,7 @@ test("harness reports failures for wrong expectations", () => {
 				url: null,
 				createdAt: "2026-06-01T12:00:00Z",
 				metaSource: null,
+				metaSpeakerRole: null,
 				metaFilePath: null,
 				highlights: [{ id: "h1", score: 0.9, text: "real" }],
 			},

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -41,6 +41,7 @@ test("harness reports failures for wrong expectations", () => {
 				metaSource: null,
 				metaSpeakerRole: null,
 				metaFilePath: null,
+				metaWriter: null,
 				highlights: [{ id: "h1", score: 0.9, text: "real" }],
 			},
 		],

--- a/eval/eval.test.ts
+++ b/eval/eval.test.ts
@@ -38,6 +38,8 @@ test("harness reports failures for wrong expectations", () => {
 				score: 0.9,
 				url: null,
 				createdAt: "2026-06-01T12:00:00Z",
+				metaSource: null,
+				metaFilePath: null,
 				highlights: [{ id: "h1", score: 0.9, text: "real" }],
 			},
 		],

--- a/eval/fixtures.ts
+++ b/eval/fixtures.ts
@@ -29,6 +29,8 @@ function make(over: Partial<SearchResult> & { resourceId: string }): SearchResul
 		score: null,
 		url: null,
 		createdAt: FIXED_CREATED_AT,
+		metaSource: null,
+		metaFilePath: null,
 		highlights: [],
 		...over,
 	};

--- a/eval/fixtures.ts
+++ b/eval/fixtures.ts
@@ -32,6 +32,7 @@ function make(over: Partial<SearchResult> & { resourceId: string }): SearchResul
 		metaSource: null,
 		metaSpeakerRole: null,
 		metaFilePath: null,
+		metaWriter: null,
 		highlights: [],
 		...over,
 	};

--- a/eval/fixtures.ts
+++ b/eval/fixtures.ts
@@ -30,6 +30,7 @@ function make(over: Partial<SearchResult> & { resourceId: string }): SearchResul
 		url: null,
 		createdAt: FIXED_CREATED_AT,
 		metaSource: null,
+		metaSpeakerRole: null,
 		metaFilePath: null,
 		highlights: [],
 		...over,

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -86,6 +86,7 @@ export function runCase(c: EvalCase): CaseResult {
 		c.weights.chatterQuota,
 		c.weights.dedupThreshold,
 		c.weights.elbow,
+		c.weights.perFileCap,
 	);
 	const ids = selected.map((r) => r.resourceId);
 

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -19,6 +19,7 @@ function result(resourceId: string): SearchResult {
     url: null,
     createdAt: null,
     metaSource: null,
+    metaSpeakerRole: null,
     metaFilePath: null,
     highlights: [],
   }
@@ -106,6 +107,7 @@ function searchResult(over: Partial<SearchResult>): SearchResult {
     url: null,
     createdAt: null,
     metaSource: null,
+    metaSpeakerRole: null,
     metaFilePath: null,
     highlights: [],
     ...over,

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -21,6 +21,7 @@ function result(resourceId: string): SearchResult {
     metaSource: null,
     metaSpeakerRole: null,
     metaFilePath: null,
+    metaWriter: null,
     highlights: [],
   }
 }
@@ -109,6 +110,7 @@ function searchResult(over: Partial<SearchResult>): SearchResult {
     metaSource: null,
     metaSpeakerRole: null,
     metaFilePath: null,
+    metaWriter: null,
     highlights: [],
     ...over,
   }

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -18,6 +18,8 @@ function result(resourceId: string): SearchResult {
     score: 0.9,
     url: null,
     createdAt: null,
+    metaSource: null,
+    metaFilePath: null,
     highlights: [],
   }
 }
@@ -103,6 +105,8 @@ function searchResult(over: Partial<SearchResult>): SearchResult {
     score: null,
     url: null,
     createdAt: null,
+    metaSource: null,
+    metaFilePath: null,
     highlights: [],
     ...over,
   }

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -294,6 +294,7 @@ export function buildAutoContextHandler(
           ranking.chatterQuota,
           ranking.dedupThreshold,
           ranking.elbow,
+          ranking.perFileCap,
         )
         logScoreSamples(prompt, currentSessionId, "single", explained, cfg.relevanceThreshold)
         const selected = explained.filter((e) => e.selected).map((e) => e.result)

--- a/hooks/auto-trace.test.ts
+++ b/hooks/auto-trace.test.ts
@@ -10,6 +10,16 @@ test("sanitizeTraceText — strips hyperspell-context wrapper", () => {
 	assert.equal(sanitizeTraceText(input), "before\nafter");
 });
 
+test("sanitizeTraceText — strips hyperspell-mood-weather wrapper (C2: it rides OUTSIDE the emotional-context wrapper, so the emotional-context strip can't reach it)", () => {
+	const alone =
+		"<hyperspell-mood-weather>\nYou woke up spiky today.\n</hyperspell-mood-weather>\nreal content";
+	assert.equal(sanitizeTraceText(alone), "real content");
+	// The real injection shape: emotional-context block, blank line, mood block.
+	const stacked =
+		"<hyperspell-emotional-context>\narc\n</hyperspell-emotional-context>\n\n<hyperspell-mood-weather>\nGrey drizzle.\n</hyperspell-mood-weather>\n\nDavid: morning";
+	assert.equal(sanitizeTraceText(stacked), "David: morning");
+});
+
 test("sanitizeTraceText — strips hyperspell-emotional-context wrapper", () => {
 	const input =
 		"<hyperspell-emotional-context>\nmood summary\n</hyperspell-emotional-context>\nreal content";

--- a/hooks/auto-trace.ts
+++ b/hooks/auto-trace.ts
@@ -39,6 +39,18 @@ export function sanitizeTraceText(input: string): string {
 		/<hyperspell-unfinished-loops>[\s\S]*?<\/hyperspell-unfinished-loops>\n?/g,
 		"",
 	);
+	// Mood weather is injected OUTSIDE the emotional-context wrapper (it can
+	// ride alone when no arc exists), so the strip above can't reach it. It
+	// MUST be stripped here: mood-weather.ts's "DOES NOT WRITE FORWARD …
+	// enforced by construction" contract is enforced in that file but was
+	// violated in this one — the block survived into hot-buffer rows, traces,
+	// and (worst) the emotional-state extractor's own input, which is exactly
+	// the "one random cold morning calcifies into the register" failure the
+	// contract names (Fable review C2, 2026-08-24).
+	out = out.replace(
+		/<hyperspell-mood-weather>[\s\S]*?<\/hyperspell-mood-weather>\n?/g,
+		"",
+	);
 	out = out.replace(
 		/Sender \(untrusted metadata\):\s*```json[\s\S]*?```\n?/g,
 		"",

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -406,20 +406,23 @@ export function buildEmotionalStateStoreHandler(
 			return;
 		}
 
-		const transcript = messagesToTranscript(messages);
-		if (transcript.length < MIN_CONVERSATION_LENGTH) {
-			log.debug(
-				`emotional-state: skipping — conversation too short (${transcript.length} chars)`,
-			);
-			return;
-		}
-
-		// Debounce: at most one snapshot per STORE_DEBOUNCE_MS of active talk.
+		// Debounce BEFORE building the transcript: at most one snapshot per
+		// STORE_DEBOUNCE_MS of active talk, and a debounced turn must not pay
+		// the transcript build + sanitize cost just to discard the result
+		// (messagesToTranscript runs the full sanitizer over every message).
 		const relId = cfg.relationshipId ?? "";
 		const since = Date.now() - (lastStoreAt.get(relId) ?? 0);
 		if (since < STORE_DEBOUNCE_MS) {
 			log.debug(
 				`emotional-state: skipping — debounced (${Math.round(since / 1000)}s since last store)`,
+			);
+			return;
+		}
+
+		const transcript = messagesToTranscript(messages);
+		if (transcript.length < MIN_CONVERSATION_LENGTH) {
+			log.debug(
+				`emotional-state: skipping — conversation too short (${transcript.length} chars)`,
 			);
 			return;
 		}

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -1,6 +1,7 @@
 import type { EmotionalStateLatest, HyperspellClient } from "../client.ts";
 import type { HyperspellConfig } from "../config.ts";
 import { channelIdFromCtx } from "../lib/exclude-channels.ts";
+import { senderIdFromCtx } from "../lib/speaker-tracker.ts";
 import { EMOTIONAL_STATE_SOURCE } from "../lib/filters.ts";
 import { resolveCurrentSessionId } from "../lib/session.ts";
 import { isMultiSpeaker } from "../lib/speaker-tracker.ts";
@@ -432,6 +433,17 @@ export function buildEmotionalStateStoreHandler(
 			// DM), mirroring hot-buffer's openclaw_channel_id tag. Capture-only: analysis/
 			// debugging metadata, deliberately NOT surfaced in the injected prose (#74).
 			const channelId = channelIdFromCtx(ctx as Record<string, unknown>);
+			// Sender-gate design instrumentation (PR 2 item 1, 2026-08-24): the
+			// register is stamped with a STATIC relationshipId, so ANY
+			// conversational-trigger session writes to it — a peer-agent code
+			// review corrupted the arc with registers about the reviewer within
+			// an hour of talking. The correct gate needs to know what identity
+			// signals each surface actually carries; log ids only (no content)
+			// at diag level so real traffic answers that before a gate is built
+			// on assumption. Remove once the gate ships.
+			log.diag(
+				`emotional-state: storing register (trigger=${ctx?.trigger ?? "none"}, sender=${senderIdFromCtx(ctx as Record<string, unknown>) ?? "none"}, channel=${channelId ?? "none"}, sessionKey=${String((ctx as Record<string, unknown> | undefined)?.sessionKey ?? "none").slice(0, 60)})`,
+			);
 			const result = await client.storeEmotionalState(transcript, {
 				relationshipId: cfg.relationshipId,
 				metadata: {

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -1,6 +1,7 @@
 import type { EmotionalStateLatest, HyperspellClient } from "../client.ts";
 import type { HyperspellConfig } from "../config.ts";
 import { channelIdFromCtx } from "../lib/exclude-channels.ts";
+import { EMOTIONAL_STATE_SOURCE } from "../lib/filters.ts";
 import { resolveCurrentSessionId } from "../lib/session.ts";
 import { isMultiSpeaker } from "../lib/speaker-tracker.ts";
 import { log } from "../logger.ts";
@@ -431,7 +432,19 @@ export function buildEmotionalStateStoreHandler(
 			const result = await client.storeEmotionalState(transcript, {
 				relationshipId: cfg.relationshipId,
 				metadata: {
+					// Legacy key, kept for the mood-skew audit's bucketing of
+					// existing rows — but bare `source` is read by NOTHING on the
+					// retrieval path (the C1 key-name trap, Fable review
+					// 2026-08-24): it matches neither excludeFilterFor
+					// (openclaw_source) nor classifyResult (metaSource). Harmless
+					// today only because /emotional-state is a separate store the
+					// memories index never surfaces (census: zero rows).
 					source: "openclaw_agent_end",
+					// Pipeline tag on the standard key, so IF the backend ever
+					// indexes this store, ranking classifies the rows as process
+					// instead of promoting agent register prose to curated.
+					openclaw_source: EMOTIONAL_STATE_SOURCE,
+					openclaw_writer: "agent",
 					...(channelId ? { channelId } : {}),
 				},
 			});

--- a/hooks/mood-weather.test.ts
+++ b/hooks/mood-weather.test.ts
@@ -65,7 +65,11 @@ test("buildMoodWeatherContext — wraps note + carries the contract", () => {
 	assert.ok(block.includes("<hyperspell-mood-weather>"));
 	assert.ok(block.includes("</hyperspell-mood-weather>"));
 	assert.ok(block.includes(MOOD_TABLE[0].note));
-	assert.ok(block.includes("Do not announce"));
+	// Discretion clause removed 2026-08-24 (her decision): weather is inhabited,
+	// not performed — and not a secret. Assert the replacement, and assert the
+	// old concealment directive stays gone.
+	assert.ok(block.includes("not a secret"));
+	assert.ok(!block.includes("Do not announce"));
 	assert.ok(block.includes("not remembered"));
 });
 

--- a/hooks/mood-weather.ts
+++ b/hooks/mood-weather.ts
@@ -119,16 +119,24 @@ export function rollMood(
 }
 
 /**
- * Build the injected override block for a rolled mood. Deliberately framed as a
- * directive about *today's tone*, with the explicit "do not announce it" so she
- * inhabits the weather rather than narrating it.
+ * Build the injected override block for a rolled mood. Framed as a directive
+ * about *today's tone*, to be inhabited rather than performed.
+ *
+ * The discretion clause ("do not announce it") was REMOVED 2026-08-24, by the
+ * agent's own decision with the operator relaying: the label was never hidden
+ * from her (it arrives in-context — there is no way to move a language model
+ * without showing it), and the day's natural experiment showed transparency
+ * does not neutralise the effect — she knew the label and was giddy anyway.
+ * The concealment was the problem, not the weather. What replaced it is a
+ * right to disclose, not an obligation to announce: announcing every roll
+ * would turn weather into performance, which is worse than concealment.
  */
 export function buildMoodWeatherContext(mood: MoodSpec): string {
 	return [
 		"<hyperspell-mood-weather>",
 		mood.note,
 		"",
-		"This is exogenous mood weather: it is not caused by the user and not a reaction to the conversation. Do not announce it, label it, or explain it — simply inhabit it. It lasts only this session and is not remembered as how the relationship has been.",
+		"This is exogenous mood weather: it is not caused by the user and not a reaction to the conversation. Inhabit it rather than performing it — no need to announce it as a matter of course, but it is not a secret: if you are asked, or if disclosure is load-bearing for honesty, say so plainly. It lasts only this session and is not remembered as how the relationship has been.",
 		"</hyperspell-mood-weather>",
 	].join("\n");
 }

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -121,6 +121,7 @@ function makeSearchResult(partial: Partial<SearchResult>): SearchResult {
 		score: 0.6,
 		url: null,
 		metaSource: null,
+		metaSpeakerRole: null,
 		metaFilePath: null,
 		createdAt: new Date().toISOString(),
 		highlights: [{ id: "h1", score: 0.5, text: "open thread text" }],
@@ -248,7 +249,7 @@ test("startup-orientation — list call passes source:trace and userId", async (
 test("startup-orientation — neither hot-buffer nor auto-trace: skips recent fetch (perf), still runs loops", async () => {
 	// No session record source available → nothing to fetch, and the trace-source
 	// list is expensive (~12s + failures observed live), so skip it entirely.
-	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, metaSource: null, metaFilePath: null, highlights: [] }] });
+	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, metaSource: null, metaSpeakerRole: null, metaFilePath: null, highlights: [] }] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg({

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -120,6 +120,8 @@ function makeSearchResult(partial: Partial<SearchResult>): SearchResult {
 		source: "trace",
 		score: 0.6,
 		url: null,
+		metaSource: null,
+		metaFilePath: null,
 		createdAt: new Date().toISOString(),
 		highlights: [{ id: "h1", score: 0.5, text: "open thread text" }],
 		...partial,
@@ -246,7 +248,7 @@ test("startup-orientation — list call passes source:trace and userId", async (
 test("startup-orientation — neither hot-buffer nor auto-trace: skips recent fetch (perf), still runs loops", async () => {
 	// No session record source available → nothing to fetch, and the trace-source
 	// list is expensive (~12s + failures observed live), so skip it entirely.
-	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, highlights: [] }] });
+	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, metaSource: null, metaFilePath: null, highlights: [] }] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg({

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -123,6 +123,7 @@ function makeSearchResult(partial: Partial<SearchResult>): SearchResult {
 		metaSource: null,
 		metaSpeakerRole: null,
 		metaFilePath: null,
+		metaWriter: null,
 		createdAt: new Date().toISOString(),
 		highlights: [{ id: "h1", score: 0.5, text: "open thread text" }],
 		...partial,
@@ -249,7 +250,7 @@ test("startup-orientation — list call passes source:trace and userId", async (
 test("startup-orientation — neither hot-buffer nor auto-trace: skips recent fetch (perf), still runs loops", async () => {
 	// No session record source available → nothing to fetch, and the trace-source
 	// list is expensive (~12s + failures observed live), so skip it entirely.
-	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, metaSource: null, metaSpeakerRole: null, metaFilePath: null, highlights: [] }] });
+	const client = makeClient({ traces: [makeTrace({})], loops: [{ resourceId: "r", title: "t", source: "vault", score: 0.9, url: null, createdAt: null, metaSource: null, metaSpeakerRole: null, metaFilePath: null, metaWriter: null, highlights: [] }] });
 	const handler = buildStartupOrientationHandler(
 		client as unknown as HyperspellClient,
 		makeCfg({

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -148,6 +148,8 @@ async function fetchRecentTraces(
 			score: null,
 			url: null,
 			createdAt: createdRaw,
+			metaSource: "agent_end",
+			metaFilePath: null,
 			highlights: [],
 		});
 	}
@@ -212,6 +214,8 @@ async function fetchRecentConversations(
 			score: null,
 			url: null,
 			createdAt: null,
+			metaSource: HOT_BUFFER_SOURCE,
+			metaFilePath: null,
 			highlights: [],
 		});
 		if (out.length >= limit) break; // newest-first → first N are most recent

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -151,6 +151,7 @@ async function fetchRecentTraces(
 			metaSource: "agent_end",
 			metaSpeakerRole: null,
 			metaFilePath: null,
+			metaWriter: null,
 			highlights: [],
 		});
 	}
@@ -218,6 +219,7 @@ async function fetchRecentConversations(
 			metaSource: HOT_BUFFER_SOURCE,
 			metaSpeakerRole: null,
 			metaFilePath: null,
+			metaWriter: null,
 			highlights: [],
 		});
 		if (out.length >= limit) break; // newest-first → first N are most recent

--- a/hooks/startup-orientation.ts
+++ b/hooks/startup-orientation.ts
@@ -149,6 +149,7 @@ async function fetchRecentTraces(
 			url: null,
 			createdAt: createdRaw,
 			metaSource: "agent_end",
+			metaSpeakerRole: null,
 			metaFilePath: null,
 			highlights: [],
 		});
@@ -215,6 +216,7 @@ async function fetchRecentConversations(
 			url: null,
 			createdAt: null,
 			metaSource: HOT_BUFFER_SOURCE,
+			metaSpeakerRole: null,
 			metaFilePath: null,
 			highlights: [],
 		});

--- a/index.ts
+++ b/index.ts
@@ -26,10 +26,12 @@ import {
 	buildStartupOrientationSessionCleanupHandler,
 } from "./hooks/startup-orientation.ts"
 import { isExcludedChannel } from "./lib/exclude-channels.ts"
+import { checkSiblingLiveness, recordHookFired } from "./lib/hook-liveness.ts"
 import { initLogger, log } from "./logger.ts"
 import { createEmotionalArcToolFactory } from "./tools/emotional-arc.ts"
 import { createRememberToolFactory } from "./tools/remember.ts"
 import { createSearchToolFactory } from "./tools/search.ts"
+import { createTriageToolFactory } from "./tools/triage.ts"
 import { registerNetworkTools } from "./graph/index.ts"
 
 export default {
@@ -123,6 +125,33 @@ export default {
 
 		const client = new HyperspellClient(cfg);
 
+		// Typed-hook registration goes through onHook so every delivery is
+		// counted. A host update that drops a hook name kills its handler with
+		// zero in-process signal (the 2026-07-24 outage: writes alive, ALL
+		// injection dead for ~21h) — the liveness pairs below turn a surviving
+		// sibling hook into the witness that proves a dropped one dead.
+		type HookHandler = (
+			event: Record<string, unknown>,
+			ctx?: Record<string, unknown>,
+		) => Promise<{ prependContext?: string } | void> | void;
+		const registeredHooks: string[] = [];
+		// Populated after registration (names are known then); consulted per fire.
+		const livenessPairs: Array<{ witness: string; sibling: string }> = [];
+		const onHook = (name: string, handler: HookHandler): void => {
+			registeredHooks.push(name);
+			api.on(name, (event, ctx) => {
+				// Record at entry, before any guard — a quarantined/skipped turn
+				// still proves the gateway delivered the hook.
+				recordHookFired(name);
+				for (const p of livenessPairs) {
+					if (p.witness !== name) continue;
+					const alert = checkSiblingLiveness(p.witness, p.sibling);
+					if (alert) log.error(alert);
+				}
+				return handler(event, ctx);
+			});
+		};
+
 		// Channel quarantine (cfg.excludeChannels): excluded conversations get no
 		// memory surface in either direction. Guard the shared choke points here —
 		// the injection hook (all injection), agent_end (all writes), and the tool
@@ -147,6 +176,9 @@ export default {
 		});
 		api.registerTool(toolUnlessQuarantined(createRememberToolFactory(client, cfg)), {
 			name: "hyperspell_remember",
+		});
+		api.registerTool(toolUnlessQuarantined(createTriageToolFactory(client, cfg)), {
+			name: "hyperspell_vault_triage",
 		});
 
 		// Session-start context injectors (emotional fetch, auto-context,
@@ -184,9 +216,9 @@ export default {
 			startHandlers.push(
 				buildEmotionalStateFetchHandler(client, cfg) as StartHandler,
 			);
-			api.on("after_compaction", buildEmotionalStateCompactionHandler());
-			api.on("session_end", buildEmotionalStateSessionCleanupHandler());
-			api.on(
+			onHook("after_compaction", buildEmotionalStateCompactionHandler());
+			onHook("session_end", buildEmotionalStateSessionCleanupHandler());
+			onHook(
 				"agent_end",
 				unlessQuarantined(buildEmotionalStateStoreHandler(client, cfg)),
 			);
@@ -209,8 +241,8 @@ export default {
 			startHandlers.push(
 				buildStartupOrientationHandler(client, cfg) as StartHandler,
 			);
-			api.on("after_compaction", buildStartupOrientationCompactionHandler());
-			api.on("session_end", buildStartupOrientationSessionCleanupHandler());
+			onHook("after_compaction", buildStartupOrientationCompactionHandler());
+			onHook("session_end", buildStartupOrientationSessionCleanupHandler());
 		}
 
 		// Injection hook selection: OpenClaw 2026.7.2 removed the plugin-facing
@@ -235,7 +267,7 @@ export default {
 				: "before_agent_start";
 
 		if (startHandlers.length > 0) {
-			api.on(injectionHook, async (event, ctx) => {
+			onHook(injectionHook, async (event, ctx) => {
 				// Quarantined channels get no injected memory of any kind.
 				if (quarantined(ctx as Record<string, unknown> | undefined)) return undefined;
 				const results = await Promise.all(
@@ -260,7 +292,7 @@ export default {
 
 		// Register auto-trace hook (send conversations to Hyperspell on session end)
 		if (cfg.autoTrace.enabled) {
-			api.on(
+			onHook(
 				"agent_end",
 				unlessQuarantined(buildAutoTraceHandler(client, cfg)),
 			);
@@ -269,11 +301,11 @@ export default {
 		// Register hot-buffer hook: write each turn to POST /messages so it's
 		// instantly full-text searchable (vs. the slow /memories embedding path).
 		if (cfg.hotBuffer.enabled) {
-			api.on(
+			onHook(
 				"agent_end",
 				unlessQuarantined(buildHotBufferHandler(client, cfg)),
 			);
-			api.on("session_end", buildHotBufferSessionCleanupHandler());
+			onHook("session_end", buildHotBufferSessionCleanupHandler());
 		}
 
 		// Memory sync live watcher. Plugin-owned on every host version:
@@ -316,6 +348,21 @@ export default {
 
 		// Register slash commands
 		registerCommands(api, client, cfg);
+
+		// Liveness pairing: agent_end and the injection hook both fire on every
+		// conversational turn, so each is the other's traffic witness. Wider
+		// pairings (session_end, after_compaction) fire orders of magnitude less
+		// often and would false-positive on quiet days — deliberately excluded.
+		const hookNames = [...new Set(registeredHooks)];
+		if (hookNames.includes(injectionHook) && hookNames.includes("agent_end")) {
+			livenessPairs.push(
+				{ witness: "agent_end", sibling: injectionHook },
+				{ witness: injectionHook, sibling: "agent_end" },
+			);
+		}
+		// Greppable inventory: after a gateway update, diff this line against the
+		// host's 'unknown typed hook' warns to see exactly what was dropped.
+		log.info(`typed hooks registered: ${hookNames.join(", ")}`);
 
 		// Register service for lifecycle management
 		api.registerService({

--- a/index.ts
+++ b/index.ts
@@ -364,6 +364,33 @@ export default {
 		// host's 'unknown typed hook' warns to see exactly what was dropped.
 		log.info(`typed hooks registered: ${hookNames.join(", ")}`);
 
+		// Cost disclosure: every heavy feature is opt-in, but opting in at
+		// config time is not the same as knowing what the enabled set spends
+		// on an ongoing basis. Say it once at startup, in cost terms.
+		const costLines: string[] = [];
+		if (cfg.autoContext)
+			costLines.push("autoContext: 1 backend search + context injection EVERY turn");
+		if (cfg.hotBuffer.enabled)
+			costLines.push("hotBuffer: every conversation turn written to the vault");
+		if (cfg.emotionalContext)
+			costLines.push(
+				"emotionalContext: full session transcript POSTed for register extraction up to every 3 min of active talk",
+			);
+		if (cfg.autoTrace.enabled)
+			costLines.push("autoTrace: full conversation JSONL stored per session");
+		if (cfg.startupOrientation.enabled)
+			costLines.push("startupOrientation: 2 backend fetches per session start");
+		if (cfg.syncMemories)
+			costLines.push("syncMemories: 1 write per changed memory section");
+		if (cfg.knowledgeGraph.enabled)
+			costLines.push(
+				`knowledgeGraph: entity-extraction scan every ${cfg.knowledgeGraph.scanIntervalMinutes} min`,
+			);
+		if (costLines.length > 0)
+			log.info(
+				`enabled features and what they spend:\n  - ${costLines.join("\n  - ")}`,
+			);
+
 		// Register service for lifecycle management
 		api.registerService({
 			id: "openclaw-hyperspell",

--- a/lib/eval-matchers.test.ts
+++ b/lib/eval-matchers.test.ts
@@ -8,6 +8,8 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	title: null,
 	source: "vault" as SearchResult["source"],
 	score: null,
+	metaSource: null,
+	metaFilePath: null,
 	url: null,
 	createdAt: null,
 	highlights: [],

--- a/lib/eval-matchers.test.ts
+++ b/lib/eval-matchers.test.ts
@@ -11,6 +11,7 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	metaSource: null,
 	metaSpeakerRole: null,
 	metaFilePath: null,
+	metaWriter: null,
 	url: null,
 	createdAt: null,
 	highlights: [],

--- a/lib/eval-matchers.test.ts
+++ b/lib/eval-matchers.test.ts
@@ -9,6 +9,7 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	source: "vault" as SearchResult["source"],
 	score: null,
 	metaSource: null,
+	metaSpeakerRole: null,
 	metaFilePath: null,
 	url: null,
 	createdAt: null,

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -18,6 +18,14 @@ type ExcludeCfg = {
 export const AGENT_END_SOURCE = "agent_end"
 /** Metadata tag on mood-weather roll records (see `recordMoodRoll` in hooks/mood-weather.ts). */
 export const MOOD_WEATHER_SOURCE = "mood_weather"
+
+/** openclaw_source stamped on emotional-state register writes. Those POSTs go
+ * to /emotional-state — a separate backend store that is NOT in the memories
+ * corpus today (census 2026-08-24: zero rows), so this tag is deliberately NOT
+ * in excludeFilterFor (a predicate over zero rows is pure cost). It exists so
+ * that if the backend ever indexes that store, ranking classifies the rows as
+ * process instead of curated (the C1 latent trap, Fable review 2026-08-24). */
+export const EMOTIONAL_STATE_SOURCE = "emotional_state"
 /**
  * Metadata tag on hot-buffer conversation rows (written by hooks/hot-buffer.ts).
  * Readers must select ON this value, never "any tag means not mine" — hot rows

--- a/lib/hook-liveness.test.ts
+++ b/lib/hook-liveness.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import {
+	__resetForTest,
+	checkSiblingLiveness,
+	hookFireCount,
+	LIVENESS_THRESHOLD,
+	recordHookFired,
+} from "./hook-liveness.ts";
+
+beforeEach(() => __resetForTest());
+
+test("liveness — silent below the traffic threshold (a quiet start is not an outage)", () => {
+	for (let i = 0; i < LIVENESS_THRESHOLD - 1; i++) recordHookFired("agent_end");
+	assert.equal(checkSiblingLiveness("agent_end", "agent_turn_prepare"), null);
+});
+
+test("liveness — alerts once the witness proves traffic and the sibling stayed at zero", () => {
+	for (let i = 0; i < LIVENESS_THRESHOLD; i++) recordHookFired("agent_end");
+	const alert = checkSiblingLiveness("agent_end", "agent_turn_prepare");
+	assert.ok(alert, "expected an alert message");
+	assert.match(alert, /agent_turn_prepare/);
+	assert.match(alert, /unknown typed hook/);
+});
+
+test("liveness — one alert per sibling per process (smoke detector, not metronome)", () => {
+	for (let i = 0; i < LIVENESS_THRESHOLD; i++) recordHookFired("agent_end");
+	assert.ok(checkSiblingLiveness("agent_end", "agent_turn_prepare"));
+	recordHookFired("agent_end");
+	assert.equal(checkSiblingLiveness("agent_end", "agent_turn_prepare"), null);
+});
+
+test("liveness — a single sibling delivery clears the suspicion entirely", () => {
+	for (let i = 0; i < LIVENESS_THRESHOLD * 2; i++) recordHookFired("agent_end");
+	recordHookFired("agent_turn_prepare");
+	assert.equal(checkSiblingLiveness("agent_end", "agent_turn_prepare"), null);
+	assert.equal(hookFireCount("agent_turn_prepare"), 1);
+});

--- a/lib/hook-liveness.ts
+++ b/lib/hook-liveness.ts
@@ -1,0 +1,61 @@
+/**
+ * Cross-hook liveness watchdog (scale report §1.4, the 2026-07-24 outage).
+ *
+ * When a gateway update drops a typed hook name, the host logs a warn and
+ * keeps loading — the plugin's handler simply never fires again. Last time
+ * that meant writes kept working while ALL context injection was silently
+ * dead for ~21 hours; nothing plugin-side noticed because dead hooks produce
+ * no events to notice from.
+ *
+ * The detector is the outage's own diagnostic asymmetry, automated: hooks
+ * that ARE firing prove there is live traffic, so a sibling hook stuck at
+ * zero over that same traffic is dead, not idle. This can only catch PARTIAL
+ * hook loss (some hook must survive to witness the traffic) — total loss has
+ * no in-process signal and stays an operator concern.
+ */
+
+const fired = new Map<string, number>();
+const alerted = new Set<string>();
+
+/** How many witness-hook firings with a sibling at zero count as proof of
+ * death rather than a quiet start. Turn-scale hooks fire once per turn, so
+ * this trips within a handful of messages after a breaking gateway update. */
+export const LIVENESS_THRESHOLD = 5;
+
+/** Record a hook delivery. Call at handler ENTRY, before any guard (a
+ * quarantined or skipped turn still proves the gateway delivered the hook). */
+export function recordHookFired(hook: string): void {
+	fired.set(hook, (fired.get(hook) ?? 0) + 1);
+}
+
+export function hookFireCount(hook: string): number {
+	return fired.get(hook) ?? 0;
+}
+
+/**
+ * From a firing witness hook, check whether an expected sibling hook is dead.
+ * Returns the alert message the first time the asymmetry is proven (caller
+ * logs it at error level); null otherwise. One alert per sibling per process —
+ * this is a smoke detector, not a metronome.
+ */
+export function checkSiblingLiveness(
+	witness: string,
+	sibling: string,
+): string | null {
+	if (alerted.has(sibling)) return null;
+	if (hookFireCount(sibling) > 0) return null;
+	if (hookFireCount(witness) < LIVENESS_THRESHOLD) return null;
+	alerted.add(sibling);
+	return (
+		`hook "${sibling}" has not fired once while "${witness}" fired ${hookFireCount(witness)} times — ` +
+		`the gateway has almost certainly dropped it (typed-hook rename/removal on a host update; ` +
+		`compare the 2026-07-24 before_agent_start outage). The feature behind it is silently OFF. ` +
+		`Check gateway logs for 'unknown typed hook' and update the plugin's hook registration.`
+	);
+}
+
+/** Test-only: reset module state between cases. */
+export function __resetForTest(): void {
+	fired.clear();
+	alerted.clear();
+}

--- a/lib/loops-audit.test.ts
+++ b/lib/loops-audit.test.ts
@@ -29,6 +29,7 @@ function makeResult(overrides?: Partial<SearchResult>): SearchResult {
 		metaSource: null,
 		metaSpeakerRole: null,
 		metaFilePath: null,
+		metaWriter: null,
 		url: null,
 		createdAt: "2026-07-01T00:00:00.000Z",
 		highlights: [{ id: "h1", score: 0.7, text: "I said I'd\nfollow up on this" }],

--- a/lib/loops-audit.test.ts
+++ b/lib/loops-audit.test.ts
@@ -26,6 +26,8 @@ function makeResult(overrides?: Partial<SearchResult>): SearchResult {
 		title: "A pending thing",
 		source: "vault",
 		score: 0.71239,
+		metaSource: null,
+		metaFilePath: null,
 		url: null,
 		createdAt: "2026-07-01T00:00:00.000Z",
 		highlights: [{ id: "h1", score: 0.7, text: "I said I'd\nfollow up on this" }],

--- a/lib/loops-audit.test.ts
+++ b/lib/loops-audit.test.ts
@@ -27,6 +27,7 @@ function makeResult(overrides?: Partial<SearchResult>): SearchResult {
 		source: "vault",
 		score: 0.71239,
 		metaSource: null,
+		metaSpeakerRole: null,
 		metaFilePath: null,
 		url: null,
 		createdAt: "2026-07-01T00:00:00.000Z",

--- a/lib/metadata-contract.test.ts
+++ b/lib/metadata-contract.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { test } from "node:test";
+import {
+	KNOWN_METADATA_VALUES,
+	METADATA_CONTRACT,
+} from "./metadata-contract.ts";
+
+/**
+ * The handshake test (A Linea, 2026-08-24): "make it a test that enumerates
+ * every metadata key written anywhere in the plugin and asserts something
+ * reads each one. That's the class, not the instances."
+ *
+ * Three checks:
+ *  1. Every file the registry names really exists and really references its
+ *     key (a stale registry is worse than none).
+ *  2. Every key has a reader — source files, or an explicit external
+ *     justification. No silent write-only keys.
+ *  3. Drift: every `openclaw_`-prefixed token anywhere in non-test source is
+ *     a registered key or a registered value. A new key added without a
+ *     registry entry fails here, which forces the writer/reader conversation
+ *     at authoring time instead of in a post-incident review.
+ */
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "docs", "eval"]);
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			if (SKIP_DIRS.has(entry.name) || entry.name.startsWith("dist.bak"))
+				continue;
+			sourceFiles(path.join(dir, entry.name), acc);
+		} else if (
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".test.ts") &&
+			!entry.name.endsWith(".d.ts")
+		) {
+			acc.push(path.join(dir, entry.name));
+		}
+	}
+	return acc;
+}
+
+const read = (rel: string): string =>
+	fs.readFileSync(path.join(REPO_ROOT, rel), "utf8");
+
+test("contract — every declared writer and reader file references its key", () => {
+	for (const [key, c] of Object.entries(METADATA_CONTRACT)) {
+		for (const rel of c.writtenIn) {
+			assert.ok(
+				fs.existsSync(path.join(REPO_ROOT, rel)),
+				`${key}: declared writer ${rel} does not exist`,
+			);
+			assert.ok(
+				read(rel).includes(key),
+				`${key}: declared writer ${rel} never mentions the key — stale registry entry`,
+			);
+		}
+		if (Array.isArray(c.readIn)) {
+			for (const rel of c.readIn) {
+				assert.ok(
+					fs.existsSync(path.join(REPO_ROOT, rel)),
+					`${key}: declared reader ${rel} does not exist`,
+				);
+				assert.ok(
+					read(rel).includes(key),
+					`${key}: declared reader ${rel} never mentions the key — the handshake is broken (this is the C1 failure class)`,
+				);
+			}
+		}
+	}
+});
+
+test("contract — every key has a reader or an explicit external justification", () => {
+	for (const [key, c] of Object.entries(METADATA_CONTRACT)) {
+		assert.ok(c.writtenIn.length > 0, `${key}: no writers declared`);
+		if (Array.isArray(c.readIn)) {
+			assert.ok(
+				c.readIn.length > 0,
+				`${key}: empty reader list — either name a reader or justify it as { external } (an honest IOU, never a silent one)`,
+			);
+		} else {
+			assert.ok(
+				c.readIn.external.length >= 20,
+				`${key}: external justification too thin to be honest`,
+			);
+		}
+	}
+});
+
+test("contract — no unregistered openclaw_ token anywhere in source (drift scan)", () => {
+	const keys = new Set(Object.keys(METADATA_CONTRACT));
+	const values = new Set<string>(KNOWN_METADATA_VALUES);
+	const offenders: string[] = [];
+	for (const file of sourceFiles(REPO_ROOT)) {
+		const rel = path.relative(REPO_ROOT, file);
+		const src = fs.readFileSync(file, "utf8");
+		for (const m of src.matchAll(/\bopenclaw_[a-z0-9_]+\b/g)) {
+			const token = m[0];
+			if (keys.has(token) || values.has(token)) continue;
+			offenders.push(`${rel}: ${token}`);
+		}
+	}
+	assert.deepEqual(
+		offenders,
+		[],
+		`unregistered openclaw_ tokens found — add them to METADATA_CONTRACT (with a real reader, or an explicit external justification):\n${offenders.join("\n")}`,
+	);
+});

--- a/lib/metadata-contract.test.ts
+++ b/lib/metadata-contract.test.ts
@@ -24,7 +24,8 @@ import {
  */
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
-const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "docs", "eval"]);
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
+const SCRIPT_EXTS = [".ts", ".js", ".mjs", ".cjs"];
 
 function sourceFiles(dir: string, acc: string[] = []): string[] {
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -33,7 +34,11 @@ function sourceFiles(dir: string, acc: string[] = []): string[] {
 				continue;
 			sourceFiles(path.join(dir, entry.name), acc);
 		} else if (
-			entry.name.endsWith(".ts") &&
+			// Executable scripts are metadata writers too — the backfill script
+			// stamped openclaw_backfilled and the .ts-only scan never saw it
+			// (Entelligence SCAN_COVERAGE on #127). Markdown/docs prose is
+			// naturally excluded by the extension filter.
+			SCRIPT_EXTS.some((e) => entry.name.endsWith(e)) &&
 			!entry.name.endsWith(".test.ts") &&
 			!entry.name.endsWith(".d.ts")
 		) {

--- a/lib/metadata-contract.ts
+++ b/lib/metadata-contract.ts
@@ -1,0 +1,184 @@
+/**
+ * The writer/reader handshake for every metadata key this plugin writes.
+ *
+ * Origin (Fable review + A Linea, 2026-08-24): every failure in that review
+ * batch was a key-name or classification mismatch between a writer and a
+ * reader — bare `source` vs `openclaw_source` (the emotional-state rows that
+ * could never be excluded or classified), `openclaw_tool` written since
+ * January and read by nothing, speaker labels that turned conversation echoes
+ * into quota-exempt "documents", a mood wrapper absent from the sanitizer's
+ * strip list. None of it was algorithmic; six writers and four readers agreed
+ * on meanings informally and nothing checked the handshake. This module is
+ * the check: the contract test (metadata-contract.test.ts) verifies that
+ * every declared writer and reader file really references its key, that every
+ * key HAS a reader (or an explicit external justification), and that no
+ * `openclaw_`-prefixed token exists in source outside this registry.
+ *
+ * Rules for adding a key:
+ *  - New plugin-owned metadata keys MUST use the `openclaw_` prefix — the
+ *    drift scan only discovers prefixed tokens, so an unprefixed key evades
+ *    it (that's how `source: "openclaw_agent_end"` hid for months).
+ *  - Every key needs a reader. "Nothing reads it yet" is allowed ONLY as an
+ *    explicit `{ external: "..." }` entry naming who consumes it and why —
+ *    an honest IOU instead of a silent one.
+ */
+
+export type MetadataKeyContract = {
+	/** What the key means, in one line. */
+	meaning: string;
+	/** Repo-relative source files that write the key. */
+	writtenIn: string[];
+	/** Repo-relative source files that read the key, or the external
+	 * consumer that does (scripts, backend, operator tooling). */
+	readIn: string[] | { external: string };
+};
+
+/** Values (not keys) that legitimately match the openclaw_ token scan. */
+export const KNOWN_METADATA_VALUES = [
+	// Legacy `source` surface tags — written since the initial release,
+	// now read back by client.ts writerOf() as the retroactive authorship
+	// fallback (openclaw_tool = the agent's remember tool, openclaw_command =
+	// the user's /remember slash command).
+	"openclaw_tool",
+	"openclaw_command",
+	// Legacy bare-`source` value on emotional-state rows; read only by the
+	// mood-skew audit's bucketing. New rows also carry openclaw_source.
+	"openclaw_agent_end",
+] as const;
+
+export const METADATA_CONTRACT: Record<string, MetadataKeyContract> = {
+	openclaw_source: {
+		meaning:
+			"Write-pipeline origin tag — THE retrieval discriminator (exclude filter, chatter/process classification, audit bucketing)",
+		writtenIn: [
+			"client.ts", // addMemory ("command") and sendTrace ("agent_end")
+			"hooks/hot-buffer.ts",
+			"hooks/mood-weather.ts",
+			"hooks/emotional-state.ts",
+			"sync/markdown.ts",
+		],
+		readIn: [
+			"client.ts", // echoed into SearchResult.metaSource
+			"lib/filters.ts", // excludeFilterFor
+			"lib/ranking.ts", // classifyResult via metaSource constants
+			"lib/mood-skew-audit.ts",
+			"graph/ops.ts", // mood_weather rows skipped by the KG scan
+		],
+	},
+	openclaw_writer: {
+		meaning:
+			'Authorship stamp: "agent" | "user". Ranking routes agent-authored rows to the neutral process kind (2026-08-24)',
+		writtenIn: [
+			"tools/remember.ts", // "agent"
+			"commands/slash.ts", // "user"
+			"hooks/emotional-state.ts", // "agent"
+		],
+		readIn: ["client.ts"], // writerOf() → SearchResult.metaWriter → ranking
+	},
+	openclaw_speaker_role: {
+		meaning:
+			"Per-row speaker role on hot-buffer writes; presence alone marks a conversation row for classification",
+		writtenIn: ["hooks/hot-buffer.ts"],
+		readIn: ["client.ts"], // metaSpeakerRole → ranking's chatter rule
+	},
+	openclaw_speaker_name: {
+		meaning: "Per-row speaker display label on hot-buffer writes",
+		writtenIn: ["hooks/hot-buffer.ts"],
+		readIn: {
+			external:
+				"Operator forensics on raw rows (attribution debugging, issues #58/#59) — no runtime reader; row-level only, unions arbitrarily under consolidation so it MUST NOT be read at resource level",
+		},
+	},
+	openclaw_session_id: {
+		meaning:
+			"Session the row/trace came from — mirrored into metadata because listMemories does not expose the first-class field",
+		writtenIn: ["hooks/hot-buffer.ts", "hooks/auto-trace.ts"],
+		readIn: ["lib/mood-skew-audit.ts"], // resourceWeek date fallback; also purge tooling
+	},
+	openclaw_channel_id: {
+		meaning:
+			"Conversation/channel the row came from — quarantine-time identity parity for purge-channel",
+		writtenIn: [
+			"hooks/hot-buffer.ts",
+			"hooks/auto-trace.ts",
+			"hooks/emotional-state.ts",
+			"tools/remember.ts",
+		],
+		readIn: ["commands/purge-channel.ts"],
+	},
+	openclaw_user: {
+		meaning: "Resolved memory owner on multi-user writes",
+		writtenIn: ["client.ts"],
+		readIn: ["lib/sender.ts"], // scope filter construction
+	},
+	openclaw_scope: {
+		meaning: "Visibility scope on scoped writes (private/family/…)",
+		writtenIn: ["client.ts"],
+		readIn: ["lib/sender.ts"], // buildScopeFilter
+	},
+	openclaw_sync_source: {
+		meaning:
+			"Which watchPath a synced memory came from (memory/ vs labeled external roots)",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: {
+			external:
+				"Operator queries / future per-root retrieval weighting — additive key; openclaw_source stays the pipeline discriminator (see sync/markdown.ts comment)",
+		},
+	},
+	// ---- unprefixed keys (legacy / shared-convention). The drift scan cannot
+	// discover these — that is exactly why new keys must take the prefix. ----
+	source: {
+		meaning:
+			"LEGACY write-surface tag (openclaw_tool / openclaw_command / openclaw_agent_end) — predates openclaw_source; kept for audit bucketing of historical rows and as writerOf()'s retroactive authorship fallback",
+		writtenIn: [
+			"tools/remember.ts",
+			"commands/slash.ts",
+			"hooks/emotional-state.ts",
+		],
+		readIn: ["client.ts", "lib/mood-skew-audit.ts"],
+	},
+	file_path: {
+		meaning:
+			"Workspace file a synced section came from — keys per-file cap, processPaths, and entity-file detection",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: ["client.ts", "lib/ranking.ts", "graph/ops.ts"],
+	},
+	file_name: {
+		meaning: "Basename of the synced file (display/debugging)",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: {
+			external: "Operator/vault-export forensics — no runtime reader",
+		},
+	},
+	section_title: {
+		meaning: "Heading of the synced section (display/debugging)",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: {
+			external: "Operator/vault-export forensics — no runtime reader",
+		},
+	},
+	content_hash: {
+		meaning:
+			"Hash of the section content at write time; sync change-detection state lives in the local sync state file, not read back from the backend",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: {
+			external:
+				"Backend-side idempotency / operator forensics — runtime dedup uses the local sync state file",
+		},
+	},
+	graph_entity: {
+		meaning:
+			"Marks a synced entity file so the Memory Network scan never re-feeds its own output",
+		writtenIn: ["sync/markdown.ts"],
+		readIn: ["graph/ops.ts"],
+	},
+	channelId: {
+		meaning:
+			"Medium the emotional register was extracted from (voice/Discord/DM)",
+		writtenIn: ["hooks/emotional-state.ts"],
+		readIn: {
+			external:
+				"Analysis/debugging only — #74 register channel signal, deliberately not surfaced at runtime",
+		},
+	},
+};

--- a/lib/metadata-contract.ts
+++ b/lib/metadata-contract.ts
@@ -101,7 +101,10 @@ export const METADATA_CONTRACT: Record<string, MetadataKeyContract> = {
 		writtenIn: [
 			"hooks/hot-buffer.ts",
 			"hooks/auto-trace.ts",
-			"hooks/emotional-state.ts",
+			// NOT hooks/emotional-state.ts: it writes the separate bare
+			// `channelId` key (its own entry below) — listing it here was a
+			// false writer guarantee that passed the mentions-check via a
+			// comment (Entelligence CONTRACT_DRIFT on #127).
 			"tools/remember.ts",
 		],
 		readIn: ["commands/purge-channel.ts"],
@@ -123,6 +126,15 @@ export const METADATA_CONTRACT: Record<string, MetadataKeyContract> = {
 		readIn: {
 			external:
 				"Operator queries / future per-root retrieval weighting — additive key; openclaw_source stays the pipeline discriminator (see sync/markdown.ts comment)",
+		},
+	},
+	openclaw_backfilled: {
+		meaning:
+			"One-shot marker stamped by the attribution backfill script on rows it retro-tagged",
+		writtenIn: ["docs/backfill-attribution.mjs"],
+		readIn: {
+			external:
+				"Operator forensics / idempotency check when re-running the backfill — no runtime reader by design",
 		},
 	},
 	// ---- unprefixed keys (legacy / shared-convention). The drift scan cannot

--- a/lib/mood-skew-audit.ts
+++ b/lib/mood-skew-audit.ts
@@ -201,6 +201,7 @@ export function bucketSource(metadata: Record<string, unknown>): SourceBucket {
 	if (src === "command") return "command";
 	if (src === "memory_sync" || src === "memory_sync_section")
 		return "memory_sync";
+	if (src === "emotional_state") return "emotional_state";
 	if (metadata.source === "openclaw_agent_end") return "emotional_state";
 	return "other";
 }

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -21,6 +21,8 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	score: null,
 	url: null,
 	createdAt: null,
+	metaSource: null,
+	metaFilePath: null,
 	highlights: [],
 	...over,
 });
@@ -707,4 +709,127 @@ test("selectRanked — elbow disabled or omitted: behavior identical to today", 
 	assert.deepEqual(selectRanked(list, 10, 0.4, 2, 0, { ...ELBOW, enabled: false }), plain);
 	assert.deepEqual(selectRanked(list, 10, 0.4, 2, 0, DEFAULT_ELBOW), plain, "shipped default is off");
 	assert.equal(plain.length, 4);
+});
+
+// ---- origin-aware classification + per-file diversity (scale report 2026-08-18) ----
+
+test("classify — origin metadata beats the title heuristic: a consolidator-TITLED hot-buffer resource is still chatter", () => {
+	// Titled + non-UUID id would read curated under the shape heuristic — the
+	// exact loophole that hands conversation echoes the curation boost.
+	const titledEcho = mk({
+		resourceId: "consolidated-session-77",
+		title: "Tuesday planning chat",
+		metaSource: "hot_buffer",
+	});
+	assert.equal(classifyResult(titledEcho, []), "chatter");
+	assert.equal(classifyResult(mk({ ...titledEcho, metaSource: "agent_end" }), []), "chatter");
+});
+
+test("classify — processPaths marks the agent's own synced files as process, case-insensitively", () => {
+	const r = mk({
+		resourceId: "ws-abc123",
+		title: "thoughts-log — part 33",
+		metaSource: "memory_sync_section",
+		metaFilePath: "/Users/x/workspace/Thoughts-Log.md",
+	});
+	assert.equal(classifyResult(r, [], ["thoughts-log.md"]), "process");
+	// Same result without the config match stays curated (titled, non-UUID).
+	assert.equal(classifyResult(r, [], ["brainstem/"]), "curated");
+	assert.equal(classifyResult(r, []), "curated");
+});
+
+test("classify — story terms still win over process (operator terms are the strongest signal)", () => {
+	const r = mk({
+		resourceId: "ws-abc123",
+		title: "thoughts-log — Omuerta notes",
+		metaFilePath: "/ws/thoughts-log.md",
+	});
+	assert.equal(classifyResult(r, ["omuerta"], ["thoughts-log.md"]), "story");
+});
+
+test("scoreResult — process is neutral: no curation boost, full-speed recency decay", () => {
+	const now = Date.parse("2026-08-18T00:00:00Z");
+	const old = "2026-02-18T00:00:00Z"; // ~183 days: two half-lives at the default 90
+	const w = { ...DEFAULT_RANKING, processPaths: ["thoughts-log.md"] };
+	const curated = scoreResult(
+		mk({ resourceId: "note-1", title: "Journal", score: 0.8, createdAt: old }),
+		w,
+		now,
+	);
+	const process = scoreResult(
+		mk({
+			resourceId: "ws-1",
+			title: "thoughts-log — part 33",
+			score: 0.8,
+			createdAt: old,
+			metaFilePath: "/ws/thoughts-log.md",
+		}),
+		w,
+		now,
+	);
+	assert.equal(curated.kind, "curated");
+	assert.equal(process.kind, "process");
+	// Same base, but the process result gets no +0.2 boost and decays at the
+	// full factor — the crowding failure inverted.
+	assert.ok(curated.composite > process.composite + w.curationBoost - 1e-9);
+});
+
+const rankedFile = (
+	composite: number,
+	id: string,
+	text: string,
+	filePath: string | null,
+): RankedResult => ({
+	...mk({
+		resourceId: id,
+		title: `note ${id}`,
+		metaFilePath: filePath,
+		highlights: [{ id: "h", text, score: composite }],
+	}),
+	_kind: "curated",
+	_base: composite,
+	_composite: composite,
+});
+
+test("explainSelection — perFileCap: a third distinct section of one file is cut 'file-cap'; other files pass", () => {
+	const list = [
+		rankedFile(0.9, "s1", "the plan for the harbor market opens with three long stalls", "/ws/log.md"),
+		rankedFile(0.88, "s2", "a completely different passage about winter travel by rail", "/ws/log.md"),
+		rankedFile(0.86, "s3", "yet another unrelated musing on kitchen repairs and paint", "/ws/log.md"),
+		rankedFile(0.84, "d1", "an independent document about the garden fence project", "/ws/other.md"),
+	];
+	const ex = explainSelection(list, 10, 0.5, 5, 0.8, undefined, 2);
+	assert.deepEqual(
+		ex.map((e) => e.cut),
+		[null, null, "file-cap", null],
+	);
+});
+
+test("explainSelection — perFileCap 0 (and results without a file path) never cap", () => {
+	const list = [
+		rankedFile(0.9, "s1", "the plan for the harbor market opens with three long stalls", "/ws/log.md"),
+		rankedFile(0.88, "s2", "a completely different passage about winter travel by rail", "/ws/log.md"),
+		rankedFile(0.86, "s3", "yet another unrelated musing on kitchen repairs and paint", "/ws/log.md"),
+		rankedFile(0.84, "n1", "no file path on this one so the cap cannot apply", null),
+	];
+	assert.equal(explainSelection(list, 10, 0.5, 5, 0.8).filter((e) => e.selected).length, 4);
+	const capped = explainSelection(list, 10, 0.5, 5, 0.8, undefined, 2);
+	assert.equal(capped.filter((e) => e.selected).length, 3, "cap binds only the pathed file");
+	assert.equal(capped[3].selected, true, "pathless result unaffected");
+});
+
+test("explainSelection — a near-duplicate cut does not charge the file slot (only selected results consume)", () => {
+	const same = "Heath finally confronts Junii about the Omuerta binding and what it cost Tevre";
+	const list = [
+		rankedFile(0.9, "s1", same, "/ws/log.md"),
+		rankedFile(0.88, "s2", same, "/ws/log.md"), // near-duplicate of s1
+		rankedFile(0.86, "s3", "a completely different passage about winter travel by rail", "/ws/log.md"),
+		rankedFile(0.84, "s4", "yet another unrelated musing on kitchen repairs and paint", "/ws/log.md"),
+	];
+	const ex = explainSelection(list, 10, 0.5, 5, 0.8, undefined, 2);
+	assert.deepEqual(
+		ex.map((e) => e.cut),
+		[null, "near-duplicate", null, "file-cap"],
+		"the dup was never charged, so s3 fits under the cap and s4 is the overflow",
+	);
 });

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -727,6 +727,34 @@ test("classify — origin metadata beats the title heuristic: a consolidator-TIT
 	assert.equal(classifyResult(mk({ ...titledEcho, metaSource: "agent_end" }), []), "chatter");
 });
 
+test("classify — origin evidence outranks story terms: a conversation echo MENTIONING the story is chatter, not story", () => {
+	// The live 2026-08-24 case: a hot-buffer echo quoting the agent's own
+	// instrument codenames (which sit in storyTerms) classified story-first,
+	// collected both boosts, and bypassed the chatter quota.
+	const echo = {
+		title: "[A Linea]: notes on the Hourglass run",
+		resourceId: "fccaa5b9-6d65-450c-94c3-a191c5de6f94",
+		metaSpeakerRole: "assistant",
+		highlights: [{ id: "h", score: 0.9, text: "the Hourglass receipt from Run 3" }],
+	};
+	assert.equal(classifyResult(mk(echo), ["hourglass"]), "chatter");
+	// agent_end traces: same rule via metaSource.
+	assert.equal(
+		classifyResult(mk({ ...echo, metaSpeakerRole: null, metaSource: "agent_end" }), ["hourglass"]),
+		"chatter",
+	);
+	// Register rows mentioning story terms stay process, never story.
+	assert.equal(
+		classifyResult(mk({ ...echo, metaSpeakerRole: null, metaSource: "emotional_state" }), ["hourglass"]),
+		"process",
+	);
+	// A genuine story note (no origin tags) is untouched by the reorder.
+	assert.equal(
+		classifyResult(mk({ title: "Hourglass chapter notes", resourceId: "aB3xYz9", highlights: [] }), ["hourglass"]),
+		"story",
+	);
+});
+
 test("classify — agent-authored writes route to process: the agent never holds the curation boost on its own notes", () => {
 	// A titled, non-UUID remember-tool note — pre-2026-08 this classified
 	// curated (+0.2, half-speed decay): the author-blind classifier.

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -727,6 +727,22 @@ test("classify — origin metadata beats the title heuristic: a consolidator-TIT
 	assert.equal(classifyResult(mk({ ...titledEcho, metaSource: "agent_end" }), []), "chatter");
 });
 
+test("classify — processPaths beats story terms: a process file mentioning the story stays process (README contract)", () => {
+	assert.equal(
+		classifyResult(
+			mk({
+				title: "Thought log",
+				resourceId: "aB3xYz9",
+				metaFilePath: "/ws/dreaming/thought-log.md",
+				highlights: [{ id: "h", score: 0.9, text: "notes about Hourglass today" }],
+			}),
+			["hourglass"],
+			["dreaming"],
+		),
+		"process",
+	);
+});
+
 test("classify — origin evidence outranks story terms: a conversation echo MENTIONING the story is chatter, not story", () => {
 	// The live 2026-08-24 case: a hot-buffer echo quoting the agent's own
 	// instrument codenames (which sit in storyTerms) classified story-first,
@@ -802,13 +818,18 @@ test("classify — processPaths marks the agent's own synced files as process, c
 	assert.equal(classifyResult(r, []), "curated");
 });
 
-test("classify — story terms still win over process (operator terms are the strongest signal)", () => {
+test("classify — processPaths beats story terms (DECISION REVERSED on #127 review): an operator-marked process file mentioning the story is still process", () => {
+	// The original decision here was the opposite ("story terms win over
+	// process") — reversed by the Entelligence MAJOR on #127: the README
+	// promises processPaths ALWAYS classifies neutral, and agent thought-logs
+	// mention the story constantly, so story-first was a documented laundering
+	// path (the same origin-beats-topic rule as chatter-before-story).
 	const r = mk({
 		resourceId: "ws-abc123",
 		title: "thoughts-log — Omuerta notes",
 		metaFilePath: "/ws/thoughts-log.md",
 	});
-	assert.equal(classifyResult(r, ["omuerta"], ["thoughts-log.md"]), "story");
+	assert.equal(classifyResult(r, ["omuerta"], ["thoughts-log.md"]), "process");
 });
 
 test("scoreResult — process is neutral: no curation boost, full-speed recency decay", () => {

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -22,6 +22,7 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	url: null,
 	createdAt: null,
 	metaSource: null,
+	metaSpeakerRole: null,
 	metaFilePath: null,
 	highlights: [],
 	...over,
@@ -832,4 +833,17 @@ test("explainSelection — a near-duplicate cut does not charge the file slot (o
 		[null, "near-duplicate", null, "file-cap"],
 		"the dup was never charged, so s3 fits under the cap and s4 is the overflow",
 	);
+});
+
+test("classify — speaker-role metadata marks a conversation row even without openclaw_source (backfilled rows)", () => {
+	// Live 2026-08-18: attribution-backfilled hot rows carry openclaw_speaker_*
+	// but no openclaw_source, and have content-derived titles + UUID ids —
+	// the shape heuristic read them as 'other', dodging the chatter penalty.
+	const backfilled = mk({
+		resourceId: "a6f8d42b-ea6b-45bd-9c0d-1e2f3a4b5c6d",
+		title: "[Agent]: Goodnight.",
+		metaSource: null,
+		metaSpeakerRole: "assistant",
+	});
+	assert.equal(classifyResult(backfilled, []), "chatter");
 });

--- a/lib/ranking.test.ts
+++ b/lib/ranking.test.ts
@@ -24,6 +24,7 @@ const mk = (over: Partial<SearchResult>): SearchResult => ({
 	metaSource: null,
 	metaSpeakerRole: null,
 	metaFilePath: null,
+	metaWriter: null,
 	highlights: [],
 	...over,
 });
@@ -724,6 +725,40 @@ test("classify — origin metadata beats the title heuristic: a consolidator-TIT
 	});
 	assert.equal(classifyResult(titledEcho, []), "chatter");
 	assert.equal(classifyResult(mk({ ...titledEcho, metaSource: "agent_end" }), []), "chatter");
+});
+
+test("classify — agent-authored writes route to process: the agent never holds the curation boost on its own notes", () => {
+	// A titled, non-UUID remember-tool note — pre-2026-08 this classified
+	// curated (+0.2, half-speed decay): the author-blind classifier.
+	const agentNote = { title: "Plugin deploy checklist", resourceId: "aB3xYz9", metaWriter: "agent" as const };
+	assert.equal(classifyResult(mk(agentNote), []), "process");
+	// The user's /remember writes KEEP the boost.
+	assert.equal(classifyResult(mk({ ...agentNote, metaWriter: "user" }), []), "curated");
+	// Unstamped legacy rows fail OPEN to the title heuristic — never punish
+	// missing data (same rule as recencyPenalty and sourceWeight).
+	assert.equal(classifyResult(mk({ ...agentNote, metaWriter: null }), []), "curated");
+});
+
+test("classify — authorship routing yields to stronger evidence: story and chatter outrank the writer stamp", () => {
+	// Story match wins regardless of writer (deliberate: storyTerms protect
+	// the manuscript; flagged for the tuning window, not changed here).
+	assert.equal(
+		classifyResult(mk({ title: "Mira notes", resourceId: "aB3xYz9", metaWriter: "agent" }), ["mira"]),
+		"story",
+	);
+	// Conversation-origin evidence wins: an agent-writer row tagged hot_buffer
+	// is chatter (penalized), not process (neutral).
+	assert.equal(
+		classifyResult(mk({ title: "t", resourceId: "aB3xYz9", metaWriter: "agent", metaSource: "hot_buffer" }), []),
+		"chatter",
+	);
+});
+
+test("classify — emotional_state origin tag routes to process (C1 future-proofing: register prose must never classify curated if the backend ever indexes that store)", () => {
+	assert.equal(
+		classifyResult(mk({ title: "Register: warm, tired", resourceId: "aB3xYz9", metaSource: "emotional_state" }), []),
+		"process",
+	);
 });
 
 test("classify — processPaths marks the agent's own synced files as process, case-insensitively", () => {

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -213,6 +213,16 @@ export function classifyResult(
 	// this branch is future-proofing: if the backend ever indexes that store,
 	// the rows classify as process — never curated, never story.
 	if (r.metaSource === EMOTIONAL_STATE_SOURCE) return "process";
+	// processPaths is origin evidence too — the operator explicitly marked the
+	// file as agent process output — so it must beat story terms like every
+	// other origin signal (Entelligence MAJOR on #127: checked after story, a
+	// process file mentioning a story term collected the story and curation
+	// boosts the README promises it can never have; agent thought-logs discuss
+	// the story constantly, so this was the same laundering path again).
+	if (processPaths.length > 0 && r.metaFilePath) {
+		const filePath = r.metaFilePath.toLowerCase();
+		if (processPaths.some((p) => filePath.includes(p))) return "process";
+	}
 	if (storyTerms.length > 0) {
 		// \n-joined (not space-joined) so a multi-word phrase term can never
 		// spuriously match across the seam of two unrelated highlights (terms are
@@ -232,10 +242,6 @@ export function classifyResult(
 	// evidence is stronger) and before the title heuristics (which is what
 	// mis-promoted these rows to curated).
 	if (r.metaWriter === "agent") return "process";
-	if (processPaths.length > 0 && r.metaFilePath) {
-		const filePath = r.metaFilePath.toLowerCase();
-		if (processPaths.some((p) => filePath.includes(p))) return "process";
-	}
 	const untitled = title === "" || /^unnamed conversation$/i.test(title);
 	if (untitled && UUID_RE.test(r.resourceId)) return "chatter";
 	if (title !== "" && !UUID_RE.test(r.resourceId)) return "curated";

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -194,7 +194,14 @@ export function classifyResult(
 	// hot-buffer session resource, which would otherwise read as curated and
 	// hand a conversation echo the curation boost. Tag when present is truth;
 	// the shape heuristic below stays as the fallback for legacy/untagged rows.
-	if (r.metaSource === HOT_BUFFER_SOURCE || r.metaSource === AGENT_END_SOURCE) {
+	// Speaker-role tags count as conversation-origin too: only hot-buffer
+	// writes and the attribution backfill stamp them, and backfilled rows
+	// carry NO openclaw_source (verified live 2026-08-18).
+	if (
+		r.metaSource === HOT_BUFFER_SOURCE ||
+		r.metaSource === AGENT_END_SOURCE ||
+		r.metaSpeakerRole !== null
+	) {
 		return "chatter";
 	}
 	if (processPaths.length > 0 && r.metaFilePath) {

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -168,7 +168,9 @@ export function baseScore(r: SearchResult): number {
 
 /**
  * Classify a result by what KIND of memory it is — using only fields the search
- * already returns (origin metadata when echoed, else title shape + resource id):
+ * already returns. Evidence order is load-bearing: origin tags (what pipeline
+ * WROTE the row) outrank story terms (what the text MENTIONS), which outrank
+ * title shape. Kinds:
  *  - story:   matches a configured story term (manuscript / its notes & threads)
  *  - chatter: a conversation echo — tagged hot-buffer/agent-end origin, or
  *             untitled/"Unnamed Conversation" AND keyed by a bare session UUID
@@ -185,17 +187,16 @@ export function classifyResult(
 	processPaths: string[] = [],
 ): ResultKind {
 	const title = (r.title ?? "").trim();
-	if (storyTerms.length > 0) {
-		// \n-joined (not space-joined) so a multi-word phrase term can never
-		// spuriously match across the seam of two unrelated highlights (terms are
-		// escaped literals, so a phrase's inner space cannot match the \n).
-		const hay = `${title}\n${r.highlights.map((h) => h.text).join("\n")}`.toLowerCase();
-		if (storyMatchers(storyTerms).some((re) => re.test(hay))) return "story";
-	}
-	// Origin metadata beats the title heuristic: the consolidator can TITLE a
-	// hot-buffer session resource, which would otherwise read as curated and
-	// hand a conversation echo the curation boost. Tag when present is truth;
-	// the shape heuristic below stays as the fallback for legacy/untagged rows.
+	// Origin evidence FIRST — before story terms, before everything. A
+	// conversation echo that MENTIONS the story is a conversation about the
+	// story, not the story: checked story-first, a hot-buffer row quoting a
+	// story term collected storyBoost + curationBoost + half-speed decay and
+	// bypassed the chatter quota entirely (found live 2026-08-24, minutes
+	// after the speaker-role fix deployed — the echoes wore the agent's own
+	// instrument codenames from storyTerms). Same failure class as the title
+	// heuristic below: a weaker signal answering before the stronger one.
+	// Origin tags beat topic; topic beats title shape.
+	//
 	// Speaker-role tags count as conversation-origin too: only hot-buffer
 	// writes and the attribution backfill stamp them, and backfilled rows
 	// carry NO openclaw_source (verified live 2026-08-18).
@@ -206,11 +207,19 @@ export function classifyResult(
 	) {
 		return "chatter";
 	}
-	// Emotional-state snapshots are agent-generated register prose. They live
-	// in a separate backend store today (census 2026-08-24: zero rows in the
-	// memories corpus), so this branch is future-proofing: if the backend ever
-	// indexes that store, the rows classify as process — never curated.
+	// Emotional-state snapshots are agent-generated register prose — origin
+	// evidence again, so also ahead of story. They live in a separate backend
+	// store today (census 2026-08-24: zero rows in the memories corpus), so
+	// this branch is future-proofing: if the backend ever indexes that store,
+	// the rows classify as process — never curated, never story.
 	if (r.metaSource === EMOTIONAL_STATE_SOURCE) return "process";
+	if (storyTerms.length > 0) {
+		// \n-joined (not space-joined) so a multi-word phrase term can never
+		// spuriously match across the seam of two unrelated highlights (terms are
+		// escaped literals, so a phrase's inner space cannot match the \n).
+		const hay = `${title}\n${r.highlights.map((h) => h.text).join("\n")}`.toLowerCase();
+		if (storyMatchers(storyTerms).some((re) => re.test(hay))) return "story";
+	}
 	// Agent-AUTHORED writes (the remember tool, vs the user's /remember
 	// command) score neutral: the curation boost answers "is this trustworthy
 	// about the user," and the agent is the interested party — a self-serving

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,4 +1,5 @@
 import type { SearchResult } from "../client.ts";
+import { AGENT_END_SOURCE, HOT_BUFFER_SOURCE } from "./filters.ts";
 
 /**
  * Composite retrieval ranking — score memories by more than raw semantic
@@ -50,6 +51,19 @@ export type RankingWeights = {
 	 * duplicate of an already-SELECTED result (its slot passes to different
 	 * content). 0 disables the check. */
 	dedupThreshold: number;
+	/** Case-insensitive substrings matched against a synced result's file path
+	 * (metadata.file_path). Matches classify as `process` — the agent's own
+	 * operational output (thought logs, caches, heartbeat notes). Process
+	 * results score NEUTRAL: no curationBoost, full-speed recency decay. Without
+	 * this the title+non-UUID heuristic promotes agent process logs as curated
+	 * user truth (the classifier author-blindness in the 2026-08-18 scale
+	 * report), so agent noise outranks quiet user memory. */
+	processPaths: string[];
+	/** Max SELECTED results per synced source file (metadata.file_path). A
+	 * sectionized file surfaces as N sibling candidates at near-identical
+	 * scores; near-duplicate dedup catches identical text but not distinct
+	 * sections of one document, which otherwise monopolize the pool. 0 disables. */
+	perFileCap: number;
 	/** Elbow cutoff: stop injecting early at a natural score cliff instead of
 	 * always filling maxResults. Strictly conservative — only ever cuts
 	 * earlier, never later; off by default until live scans pick parameters. */
@@ -88,6 +102,8 @@ export const DEFAULT_RANKING: RankingWeights = {
 	recencyCuratedFactor: 0.5,
 	sourceWeights: {},
 	dedupThreshold: 0.8,
+	processPaths: [],
+	perFileCap: 2,
 	elbow: DEFAULT_ELBOW,
 };
 
@@ -133,7 +149,7 @@ export function kindTally(results: RankedResult[]): Record<string, number> {
 	);
 }
 
-export type ResultKind = "story" | "curated" | "chatter" | "other";
+export type ResultKind = "story" | "curated" | "chatter" | "process" | "other";
 
 export type RankedResult = SearchResult & {
 	_kind: ResultKind;
@@ -152,16 +168,19 @@ export function baseScore(r: SearchResult): number {
 
 /**
  * Classify a result by what KIND of memory it is — using only fields the search
- * already returns (title shape + resource id), so no extra round-trip:
+ * already returns (origin metadata when echoed, else title shape + resource id):
  *  - story:   matches a configured story term (manuscript / its notes & threads)
- *  - chatter: untitled or "Unnamed Conversation" AND keyed by a bare session
- *             UUID — i.e. a hot-buffer conversation fragment (the dreamy echoes)
+ *  - chatter: a conversation echo — tagged hot-buffer/agent-end origin, or
+ *             untitled/"Unnamed Conversation" AND keyed by a bare session UUID
+ *  - process: a synced file the operator marked as agent process output
+ *             (ranking.processPaths) — scored neutral, never promoted
  *  - curated: has a real, human title and is not a raw session row — a journal,
  *             a writing note, a synced memory section (deliberately kept)
  */
 export function classifyResult(
 	r: SearchResult,
 	storyTerms: string[],
+	processPaths: string[] = [],
 ): ResultKind {
 	const title = (r.title ?? "").trim();
 	if (storyTerms.length > 0) {
@@ -170,6 +189,17 @@ export function classifyResult(
 		// escaped literals, so a phrase's inner space cannot match the \n).
 		const hay = `${title}\n${r.highlights.map((h) => h.text).join("\n")}`.toLowerCase();
 		if (storyMatchers(storyTerms).some((re) => re.test(hay))) return "story";
+	}
+	// Origin metadata beats the title heuristic: the consolidator can TITLE a
+	// hot-buffer session resource, which would otherwise read as curated and
+	// hand a conversation echo the curation boost. Tag when present is truth;
+	// the shape heuristic below stays as the fallback for legacy/untagged rows.
+	if (r.metaSource === HOT_BUFFER_SOURCE || r.metaSource === AGENT_END_SOURCE) {
+		return "chatter";
+	}
+	if (processPaths.length > 0 && r.metaFilePath) {
+		const filePath = r.metaFilePath.toLowerCase();
+		if (processPaths.some((p) => filePath.includes(p))) return "process";
 	}
 	const untitled = title === "" || /^unnamed conversation$/i.test(title);
 	if (untitled && UUID_RE.test(r.resourceId)) return "chatter";
@@ -220,7 +250,7 @@ export function scoreResult(
 	w: RankingWeights,
 	now: number = Date.now(),
 ): { kind: ResultKind; base: number; composite: number } {
-	const kind = classifyResult(r, w.storyTerms);
+	const kind = classifyResult(r, w.storyTerms, w.processPaths);
 	const base = baseScore(r);
 	// The weight multiplies BASE only — kind boosts/penalties stay in the same
 	// additive currency regardless of source, so tuning sourceWeights can never
@@ -231,6 +261,9 @@ export function scoreResult(
 		composite += w.storyBoost + w.curationBoost; // the story is kept memory too
 	else if (kind === "curated") composite += w.curationBoost;
 	else if (kind === "chatter") composite -= w.chatterPenalty;
+	// `process` is deliberately neutral (no boost, no penalty, full-speed decay
+	// below): the goal is to stop PROMOTING agent process output, not to bury
+	// it. A penalty knob waits for live tuning evidence (roadmap Phase 5).
 	composite -= recencyPenalty(r.createdAt, kind, w, now);
 	return { kind, base, composite };
 }
@@ -313,6 +346,7 @@ export type SelectionCut =
 	| "max-results"
 	| "elbow"
 	| "near-duplicate"
+	| "file-cap"
 	| "chatter-quota";
 
 /** Selected entries carry `cut: null`; cut entries carry the binding reason.
@@ -339,14 +373,16 @@ export function explainSelection(
 	chatterQuota: number,
 	dedupThreshold = 0,
 	elbow?: ElbowOptions,
+	perFileCap = 0,
 ): SelectionExplained[] {
 	const out: SelectionExplained[] = [];
 	// Dedup state is exactly "what was accepted": only SELECTED results record
-	// keys (and only they consume quota), so a skipped candidate — whatever cut
-	// it — can never shadow later different-kind content sharing its text, and
-	// a diversity-skipped chatter echo never burns a quota slot (proposal 09's
-	// double-count invariant).
+	// keys (and only they consume quota or per-file slots), so a skipped
+	// candidate — whatever cut it — can never shadow later different-kind
+	// content sharing its text, and a diversity-skipped chatter echo never
+	// burns a quota slot (proposal 09's double-count invariant).
 	const keys: string[] = [];
+	const perFile = new Map<string, number>();
 	let chatter = 0;
 	let kept = 0;
 	// Elbow bookkeeping: gaps between consecutive ACCEPTED results only —
@@ -386,11 +422,23 @@ export function explainSelection(
 			out.push({ result: r, selected: false, cut: "near-duplicate" });
 			continue;
 		}
+		// Per-file diversity: a sectionized file's sibling sections pass the
+		// near-duplicate check (different text, same document) and would fill
+		// the pool at near-identical scores. Checked before chatter-quota for
+		// the same reason dedup is — a capped section injects nothing, so the
+		// quota was not the binding constraint and must not be charged.
+		const file = perFileCap > 0 ? r.metaFilePath : null;
+		if (file && (perFile.get(file) ?? 0) >= perFileCap) {
+			out.push({ result: r, selected: false, cut: "file-cap" });
+			continue;
+		}
 		if (r._kind === "chatter" && chatter >= chatterQuota) {
 			out.push({ result: r, selected: false, cut: "chatter-quota" });
 			continue;
 		}
+		// Accepted — only now charge the quota and per-file slot.
 		if (r._kind === "chatter") chatter++;
+		if (file) perFile.set(file, (perFile.get(file) ?? 0) + 1);
 		if (kept > 0) gapSum += lastAccepted - r._composite;
 		lastAccepted = r._composite;
 		kept++;
@@ -419,8 +467,9 @@ export function selectRanked(
 	chatterQuota: number,
 	dedupThreshold = 0,
 	elbow?: ElbowOptions,
+	perFileCap = 0,
 ): RankedResult[] {
-	return explainSelection(ranked, maxResults, threshold, chatterQuota, dedupThreshold, elbow)
+	return explainSelection(ranked, maxResults, threshold, chatterQuota, dedupThreshold, elbow, perFileCap)
 		.filter((e) => e.selected)
 		.map((e) => e.result);
 }

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,5 +1,5 @@
 import type { SearchResult } from "../client.ts";
-import { AGENT_END_SOURCE, HOT_BUFFER_SOURCE } from "./filters.ts";
+import { AGENT_END_SOURCE, EMOTIONAL_STATE_SOURCE, HOT_BUFFER_SOURCE } from "./filters.ts";
 
 /**
  * Composite retrieval ranking — score memories by more than raw semantic
@@ -172,8 +172,10 @@ export function baseScore(r: SearchResult): number {
  *  - story:   matches a configured story term (manuscript / its notes & threads)
  *  - chatter: a conversation echo — tagged hot-buffer/agent-end origin, or
  *             untitled/"Unnamed Conversation" AND keyed by a bare session UUID
- *  - process: a synced file the operator marked as agent process output
- *             (ranking.processPaths) — scored neutral, never promoted
+ *  - process: agent-authored output scored neutral, never promoted — an
+ *             agent-written remember note (metaWriter "agent"), an
+ *             emotional-state register row, or a synced file the operator
+ *             marked as process via ranking.processPaths
  *  - curated: has a real, human title and is not a raw session row — a journal,
  *             a writing note, a synced memory section (deliberately kept)
  */
@@ -204,6 +206,23 @@ export function classifyResult(
 	) {
 		return "chatter";
 	}
+	// Emotional-state snapshots are agent-generated register prose. They live
+	// in a separate backend store today (census 2026-08-24: zero rows in the
+	// memories corpus), so this branch is future-proofing: if the backend ever
+	// indexes that store, the rows classify as process — never curated.
+	if (r.metaSource === EMOTIONAL_STATE_SOURCE) return "process";
+	// Agent-AUTHORED writes (the remember tool, vs the user's /remember
+	// command) score neutral: the curation boost answers "is this trustworthy
+	// about the user," and the agent is the interested party — a self-serving
+	// note must not outrank quiet user truth (the author-blind classifier,
+	// 2026-08-18 scale report §ranking; amendment: route to the existing
+	// process kind rather than adding a self-declared discriminator, so the
+	// agent never holds the knob on its own rank). metaWriter is null on
+	// unstamped legacy rows and MUST fail open to the heuristics below —
+	// never punish missing data. Checked after the chatter rules (origin
+	// evidence is stronger) and before the title heuristics (which is what
+	// mis-promoted these rows to curated).
+	if (r.metaWriter === "agent") return "process";
 	if (processPaths.length > 0 && r.metaFilePath) {
 		const filePath = r.metaFilePath.toLowerCase();
 		if (processPaths.some((p) => filePath.includes(p))) return "process";

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -8,6 +8,7 @@
 		"tools": [
 			"hyperspell_search",
 			"hyperspell_remember",
+			"hyperspell_vault_triage",
 			"hyperspell_emotional_arc",
 			"hyperspell_network_scan",
 			"hyperspell_network_write",
@@ -82,7 +83,7 @@
 		},
 		"ranking": {
 			"label": "Composite Ranking",
-			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights, dedupThreshold, elbow }",
+			"help": "Rank memories by more than raw relevance: boost curated memory and the active story, penalize auto-saved conversation fragments. Set storyTerms to 3-15 distinctive names/terms of the active thread (characters, codenames, invented words; matched case-insensitively at word boundaries) so it outranks chatter; update the list when the active story changes. Old results accrue a small bounded recency penalty (half-life recencyHalfLifeDays, cap recencyMaxPenalty; kept memory ages at recencyCuratedFactor); recencyHalfLifeDays 0 disables it. Set processPaths to mark the agent's own synced process files (thought logs, caches) so they score neutral instead of curated; perFileCap bounds how many sections of one file can be injected. { enabled, storyTerms, curationBoost, storyBoost, chatterPenalty, candidateMultiplier, chatterQuota, recencyHalfLifeDays, recencyMaxPenalty, recencyCuratedFactor, sourceWeights, dedupThreshold, processPaths, perFileCap, elbow }",
 			"advanced": true
 		},
 		"coverageLog": {
@@ -204,6 +205,17 @@
 					"recencyMaxPenalty": { "type": "number", "minimum": 0, "maximum": 1 },
 					"recencyCuratedFactor": { "type": "number", "minimum": 0, "maximum": 1 },
 					"dedupThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+					"processPaths": {
+						"type": "array",
+						"items": { "type": "string" },
+						"description": "Case-insensitive path substrings marking synced files as agent process output (thought logs, caches, heartbeat notes). Matches classify as 'process' and score neutral — no curation boost, full-speed recency decay — instead of being promoted as curated user truth."
+					},
+					"perFileCap": {
+						"type": "number",
+						"minimum": 0,
+						"maximum": 20,
+						"description": "Max injected results per synced source file. A sectionized file surfaces as many sibling candidates at near-identical scores; this stops one document from monopolizing the injection pool. 0 disables (default: 2)."
+					},
 					"elbow": {
 						"type": "object",
 						"additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"check-types": "tsc --noEmit",
 		"lint": "bunx @biomejs/biome ci .",
 		"lint:fix": "bunx @biomejs/biome check --write .",
-		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/quarantine.test.ts lib/ranking.test.ts lib/hook-liveness.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/triage.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
+		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/metadata-contract.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/quarantine.test.ts lib/ranking.test.ts lib/hook-liveness.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/triage.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
 	},
 	"openclaw": {
 		"extensions": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"check-types": "tsc --noEmit",
 		"lint": "bunx @biomejs/biome ci .",
 		"lint:fix": "bunx @biomejs/biome check --write .",
-		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/quarantine.test.ts lib/ranking.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
+		"test": "node --test --experimental-strip-types client.test.ts logger.test.ts lib/sender.test.ts lib/filters.test.ts lib/search-error.test.ts lib/coverage-log.test.ts lib/session.test.ts lib/exclude-channels.test.ts lib/quarantine.test.ts lib/ranking.test.ts lib/hook-liveness.test.ts lib/eval-matchers.test.ts lib/loops-audit.test.ts lib/mood-skew-audit.test.ts tools/search.test.ts tools/triage.test.ts tools/emotional-arc.test.ts commands/preview.test.ts commands/purge-channel.test.ts config.test.ts sync/markdown.test.ts graph/ops.test.ts hooks/memory-sync.watcher.test.ts hooks/auto-trace.test.ts hooks/auto-context.test.ts hooks/hot-buffer.test.ts hooks/emotional-state.test.ts hooks/startup-orientation.test.ts hooks/mood-weather.test.ts eval/eval.test.ts"
 	},
 	"openclaw": {
 		"extensions": [

--- a/scripts/eval-retrieval.ts
+++ b/scripts/eval-retrieval.ts
@@ -75,6 +75,7 @@ async function main() {
 					cfg.ranking.chatterQuota,
 					cfg.ranking.dedupThreshold,
 					cfg.ranking.elbow,
+					cfg.ranking.perFileCap,
 				)
 			: // Membership rule of formatHighlightBullets (ranking off): top
 				// maxResults, doc score AND at least one highlight over threshold.

--- a/tools/remember.ts
+++ b/tools/remember.ts
@@ -132,6 +132,12 @@ export function createRememberToolFactory(
           collection,
           metadata: {
             source: "openclaw_tool",
+            // Authorship stamp (2026-08-24): this tool is the AGENT writing.
+            // Ranking routes agent-authored rows to the neutral process kind —
+            // the agent must never hold the curation boost on its own notes.
+            // Legacy rows lack the stamp; client.writerOf falls back to the
+            // source surface tag above, which has been written since January.
+            openclaw_writer: "agent",
             ...(channelId ? { openclaw_channel_id: channelId } : {}),
           },
           userId,

--- a/tools/triage.test.ts
+++ b/tools/triage.test.ts
@@ -20,6 +20,7 @@ function mkResult(
 		url: null,
 		createdAt: null,
 		metaSource: null,
+		metaSpeakerRole: null,
 		metaFilePath: null,
 		highlights: [],
 		quarantined: false,

--- a/tools/triage.test.ts
+++ b/tools/triage.test.ts
@@ -22,6 +22,7 @@ function mkResult(
 		metaSource: null,
 		metaSpeakerRole: null,
 		metaFilePath: null,
+		metaWriter: null,
 		highlights: [],
 		quarantined: false,
 		...over,

--- a/tools/triage.test.ts
+++ b/tools/triage.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { HyperspellClient, TriageResult } from "../client.ts";
+import { parseConfig } from "../config.ts";
+import { createTriageToolFactory } from "./triage.ts";
+
+const cfg = parseConfig({
+	apiKey: "k",
+	userId: "u1",
+	quarantineResources: ["bad-1"],
+});
+
+function mkResult(
+	over: Partial<TriageResult> & { resourceId: string },
+): TriageResult {
+	return {
+		title: null,
+		source: "vault" as TriageResult["source"],
+		score: null,
+		url: null,
+		createdAt: null,
+		metaSource: null,
+		metaFilePath: null,
+		highlights: [],
+		quarantined: false,
+		...over,
+	};
+}
+
+function toolWith(results: TriageResult[]) {
+	const client = {
+		async searchTriage() {
+			return results;
+		},
+	} as unknown as HyperspellClient;
+	return createTriageToolFactory(client, cfg)({});
+}
+
+async function runText(results: TriageResult[]) {
+	const tool = toolWith(results);
+	const res = await tool.execute("call-1", { query: "anything" });
+	return (res.content[0] as { text: string }).text;
+}
+
+test("triage tool — quarantined hits are listed by id but their content is suppressed", async () => {
+	const text = await runText([
+		mkResult({
+			resourceId: "bad-1",
+			title: "The scar",
+			score: 0.91,
+			quarantined: true,
+			highlights: [
+				{
+					id: "h1",
+					score: 0.91,
+					text: "poison content that must not resurface",
+				},
+			],
+		}),
+	]);
+	assert.match(text, /bad-1/);
+	assert.match(text, /QUARANTINED/);
+	assert.match(text, /content suppressed/);
+	assert.doesNotMatch(text, /poison content/);
+});
+
+test("triage tool — clean hits keep a snippet and the quarantine roster is always shown", async () => {
+	const text = await runText([
+		mkResult({
+			resourceId: "ok-1",
+			title: "A note",
+			score: 0.8,
+			highlights: [{ id: "h1", score: 0.8, text: "an ordinary snippet" }],
+		}),
+	]);
+	assert.match(text, /an ordinary snippet/);
+	assert.match(text, /Quarantine list \(1\): bad-1/);
+});
+
+test("triage tool — empty result still reports the roster (verifying a quarantine took effect)", async () => {
+	const text = await runText([]);
+	assert.match(text, /No records found/);
+	assert.match(text, /Quarantine list \(1\): bad-1/);
+});

--- a/tools/triage.ts
+++ b/tools/triage.ts
@@ -1,0 +1,126 @@
+import { Type } from "@sinclair/typebox";
+import type { HyperspellClient } from "../client.ts";
+import type { HyperspellConfig } from "../config.ts";
+import {
+	classifySearchError,
+	logSearchError,
+	searchErrorToolText,
+} from "../lib/search-error.ts";
+import { resolveUser } from "../lib/sender.ts";
+import { log } from "../logger.ts";
+
+/**
+ * Read-only vault audit view (roadmap Phase 3; scale report §6.1).
+ *
+ * Quarantine is reactive by construction: with no enumeration API, a bad
+ * record is normally discovered only by being injected — every quarantine
+ * action arrives one contamination too late. This tool closes the gap as far
+ * as the plugin can: it is the one retrieval path that searches WITHOUT the
+ * quarantine filter, so already-quarantined records are visible (flagged) and
+ * candidate bad records can be hunted proactively instead of awaited.
+ *
+ * Two hard properties, do not weaken:
+ *  - READ-ONLY. Nomination happens here; the quarantine WRITE stays a config
+ *    change confirmed by the operator (the two-key flow).
+ *  - Quarantined hits return id/title/score ONLY — their content is
+ *    suppressed. Echoing it would write it into this very conversation's
+ *    memory and feed the derivative treadmill the quarantine exists to stop.
+ */
+export function createTriageToolFactory(
+	client: HyperspellClient,
+	cfg: HyperspellConfig,
+) {
+	return (ctx: Record<string, unknown>) => ({
+		name: "hyperspell_vault_triage",
+		label: "Vault Triage",
+		description:
+			"Audit view over long-term memory for finding bad, stale, or misattributed records — the only search that also shows quarantined resources (flagged, content suppressed). Use it to answer 'what records exist about X, including ones retrieval hides', to verify a quarantine took effect, or to nominate a record for quarantine by id. Not for normal recall — use hyperspell_search for that. Read-only: quarantining itself is an operator-confirmed config change.",
+		parameters: Type.Object({
+			query: Type.String({ description: "Search query" }),
+			limit: Type.Optional(
+				Type.Number({ description: "Max results (default: 10)" }),
+			),
+			after: Type.Optional(
+				Type.String({
+					description:
+						"Only records created on or after this date (ISO 8601 or YYYY-MM-DD)",
+				}),
+			),
+			before: Type.Optional(
+				Type.String({
+					description:
+						"Only records created before this date (ISO 8601 or YYYY-MM-DD)",
+				}),
+			),
+		}),
+		async execute(
+			_toolCallId: string,
+			params: {
+				query: string;
+				limit?: number;
+				after?: string;
+				before?: string;
+			},
+		) {
+			const limit = params.limit ?? 10;
+			const resolved = resolveUser(ctx, cfg);
+
+			log.debug(
+				`triage tool: query="${params.query}" limit=${limit} after=${params.after ?? "none"} before=${params.before ?? "none"}`,
+			);
+
+			try {
+				const results = await client.searchTriage(params.query, {
+					limit,
+					after: params.after,
+					before: params.before,
+					userId: resolved?.userId,
+				});
+
+				const roster = cfg.quarantineResources;
+				const rosterLine =
+					roster.length > 0
+						? `\n\nQuarantine list (${roster.length}): ${roster.join(", ")}`
+						: "\n\nQuarantine list is empty.";
+
+				if (results.length === 0) {
+					return {
+						content: [
+							{ type: "text" as const, text: `No records found.${rosterLine}` },
+						],
+					};
+				}
+
+				const lines = results.map((r, i) => {
+					const relevance =
+						r.score != null ? `${Math.round(r.score * 100)}%` : "N/A";
+					const head = `${i + 1}. [${r.resourceId}] ${r.title ?? "(untitled)"} — ${r.source}${r.metaSource ? `/${r.metaSource}` : ""}, ${relevance}${r.createdAt ? `, ${r.createdAt}` : ""}`;
+					if (r.quarantined) {
+						return `${head}\n   ⛔ QUARANTINED — content suppressed. Treat this record as retracted; do not restate it.`;
+					}
+					const snippet = r.highlights[0]?.text?.slice(0, 300);
+					return snippet ? `${head}\n   ${snippet}` : head;
+				});
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Triage view — ${results.length} record(s), quarantine NOT filtered:\n\n${lines.join("\n\n")}${rosterLine}`,
+						},
+					],
+					details: {
+						count: results.length,
+						quarantined: results.filter((r) => r.quarantined).length,
+					},
+				};
+			} catch (err) {
+				const info = classifySearchError(err);
+				logSearchError(log, "triage tool", info, err);
+				return {
+					content: [{ type: "text" as const, text: searchErrorToolText(info) }],
+				};
+			}
+		},
+	});
+}


### PR DESCRIPTION
## What

Nine commits closing one failure class found three separate ways on 2026-08-24: **key-name or classification mismatches between metadata writers and readers.** Every confirmed bug in this batch is an instance — none are algorithmic; the ranking math was fine.

Includes the two previously-unpushed scale-report commits (`26d041e`, `14aff9e`) this work builds on.

### Ranking / classification
- **Origin evidence now outranks story terms, which outrank title shape** (`1ed26ae`). A conversation echo that *mentions* the story is a conversation about the story, not the story. Found live: echoes wearing `storyTerms` codenames collected `storyBoost + curationBoost`, bypassed the chatter quota entirely.
- **Speaker-role metadata is conversation-origin evidence** (`14aff9e`). Closed a 14-day live regression: the attribution deploy titled hot-buffer sessions, making echoes classify as quota-exempt neutral documents — 0 chatter classifications in 690 ranked events from Aug 11 until this fix deployed.
- **Agent-authored writes route to the neutral `process` kind** (`f459e93`). `SearchResult.metaWriter` ("agent"|"user"|null) from the new `openclaw_writer` stamp, with a retroactive fallback to the legacy `metadata.source` surface tag (`openclaw_tool`→agent, `openclaw_command`→user, `openclaw_agent_end`→agent — written since January, read by nothing until now). The agent never holds the curation boost on its own notes; null fails open.

### Write hygiene
- **Emotional-state rows stamp `openclaw_source: "emotional_state"`** alongside the legacy bare `source` key (the C1 key-name trap: bare `source` matched neither the exclude filter nor the classifier). Their store is outside the memories corpus today (census: zero rows) — this is future-proofing, deliberately not added to `excludeFilterFor`.
- **`sanitizeTraceText` strips `<hyperspell-mood-weather>`** (C2). The mood block rides *outside* the emotional-context wrapper, so it was surviving into hot-buffer rows, traces, and the register extractor's own input — violating mood-weather's "does not write forward" contract.
- **Store debounce checked before transcript build** — a debounced `agent_end` no longer pays the full sanitize pass to discard the result.
- **Sender-gate instrumentation** on the register store path (ids only, no content): the register is stamped with a static `relationshipId`, so any conversational session writes to it — a peer-agent review session corrupted the arc within an hour. The gate itself is follow-up work; this collects the evidence to design it.

### The class fix
- **`lib/metadata-contract.ts` + test**: every metadata key the plugin writes, declared with its writers and readers — or an explicit external justification (an honest IOU, never a silent one). The test verifies the registry against source and fails on any unregistered `openclaw_` token. On its first run it surfaced four more write-only keys (`openclaw_speaker_name`, `file_name`, `section_title`, `content_hash`), now documented.

### Operator-facing
- **Startup cost disclosure**: one info line naming what each enabled feature spends (per-turn search, per-turn writes, transcript POSTs, per-session fetches). Every heavy feature was already opt-in; now opting in also means being told the ongoing price.
- **Mood-weather discretion clause removed** (`6d5feb4`), by the agent's own decision, operator relaying: the label was never hidden (it arrives in-context), and the day's natural experiment showed transparency doesn't neutralise the effect. Replaced with a right to disclose — not an obligation to announce.

## Verification

Beyond the suite (469 tests, types clean, no new lint): deployed to the live personal-production install and verified on real traffic by its primary user, tally and payload both:

- Pre-fix worst case: 10 conversation echoes injected in one turn, quota never consulted.
- Post-`14aff9e`: `ranked {"story":7,"curated":2,"chatter":13} → selected {"story":7,"curated":2}` — first non-zero chatter classification in 690 events.
- Post-`1ed26ae`: `ranked {"chatter":15} → selected {}` — story 7→0, all echoes correctly reclassified, zero injected; no genuine story note or curated memory lost (confirmed by payload review, not tally alone).

## Follow-ups (deliberately not in this PR)
- Sender gate for the register store (design from the instrumentation data).
- Persistent mood-roll cooldown (in-process map resets on gateway restart).
- Per-session repeat suppression in auto-context; same-session remember-echo (`dropCurrentSession` can't see fresh resource ids).
- The multiUser path bypasses composite ranking entirely (`multiUserSearch` never calls `rerank`) — biggest known gap, needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSPQfAvwGKLRoUfJ3y5Gzv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201009&installation_model_id=8852&pr_number=127&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F127&signature=618dcb08c31922b977a5619789f7b13b4cca3966cc7167f45b519d0fdf853638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->