### PR TITLE
Consume summary_source: backend-authoritative register provenance

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -78,6 +78,9 @@ export type EmotionalStateResponse = {
   resourceId: string
   summary: string
   extractedAt: string
+  /** See EmotionalStateLatest.summarySource. At store time this is
+   * "placeholder" by construction once hyperspell #3364 deploys. */
+  summarySource: "placeholder" | "extracted" | "unknown" | null
   sessionId: string | null
   relationshipId: string | null
   status: string
@@ -89,6 +92,15 @@ export type EmotionalStateLatest = {
   extractedAt: string
   sessionId: string | null
   relationshipId: string | null
+  /**
+   * Backend-authoritative provenance of `summary` (hyperspell PR #3364):
+   * "placeholder" = store-time transcript slice (extraction pending or
+   * yielded no mood memory); "extracted" = the LLM register; "unknown" =
+   * legacy row, could be either. Null until the backend deploys the field —
+   * callers fall back to the looksLikeRawTranscript heuristic. First-class
+   * on the response, so NOT gated on the metadata-echo issue (#116).
+   */
+  summarySource: "placeholder" | "extracted" | "unknown" | null
   /**
    * Echo of store-time metadata — Postmark's `channelId` (#74), future depth
    * signals (#68). Absent until the backend echoes stored metadata on
@@ -811,6 +823,12 @@ export class HyperspellClient {
 			resourceId: data.resource_id,
 			summary: data.summary,
 			extractedAt: data.extracted_at,
+			summarySource:
+				data.summary_source === "placeholder" ||
+				data.summary_source === "extracted" ||
+				data.summary_source === "unknown"
+					? data.summary_source
+					: null,
 			sessionId: data.session_id ?? null,
 			relationshipId: data.relationship_id ?? null,
 			status: data.status,
@@ -846,6 +864,12 @@ export class HyperspellClient {
 			resourceId: data.resource_id,
 			summary: data.summary,
 			extractedAt: data.extracted_at,
+			summarySource:
+				data.summary_source === "placeholder" ||
+				data.summary_source === "extracted" ||
+				data.summary_source === "unknown"
+					? data.summary_source
+					: null,
 			sessionId: data.session_id ?? null,
 			relationshipId: data.relationship_id ?? null,
 			// Metadata echo maps through only when present and object-shaped —
@@ -895,6 +919,12 @@ export class HyperspellClient {
 			resourceId: d.resource_id as string,
 			summary: (d.summary as string) ?? "",
 			extractedAt: (d.extracted_at as string) ?? "",
+			summarySource:
+				d.summary_source === "placeholder" ||
+				d.summary_source === "extracted" ||
+				d.summary_source === "unknown"
+					? d.summary_source
+					: null,
 			sessionId: (d.session_id as string | null) ?? null,
 			relationshipId: (d.relationship_id as string | null) ?? null,
 			// Same conditional echo as getEmotionalState — see the note there.

--- a/hooks/emotional-state.test.ts
+++ b/hooks/emotional-state.test.ts
@@ -856,6 +856,7 @@ test("selectUsableRegisters — settling window drops live-session echo; fail-op
 		extractedAt: "2026-08-24T19:00:00Z", // 3h old — settled
 		sessionId: null,
 		relationshipId: "rel",
+		summarySource: null,
 		...over,
 	});
 	const fresh = mk({ resourceId: "es-fresh", extractedAt: "2026-08-24T21:30:00Z" }); // 30m — inside window
@@ -939,4 +940,29 @@ test("appendRegisterLedger — ids-only line per store, never throws on a bad ro
 	assert.ok(!("summary" in lines[0]), "ids only — never content");
 	// Unwritable root: swallowed, not thrown.
 	appendRegisterLedger({ resourceId: "es-c3" }, "/nonexistent/deeply/bad");
+});
+
+test("selectUsableRegisters — summary_source is authoritative when present; heuristic only for legacy", () => {
+	const now = Date.parse("2026-08-25T22:00:00Z");
+	const mk = (over: Partial<EmotionalStateLatest>): EmotionalStateLatest => ({
+		resourceId: "es-x",
+		summary: "Settled register prose.",
+		extractedAt: "2026-08-25T19:00:00Z",
+		sessionId: null,
+		relationshipId: "rel",
+		summarySource: null,
+		...over,
+	});
+	// Flagged placeholder: dropped even though the shape heuristic would pass it.
+	const flaggedPh = mk({ resourceId: "es-ph", summary: "Reads like normal prose.", summarySource: "placeholder" });
+	// Flagged extracted: kept even though it QUOTES dialogue (heuristic would drop it).
+	const quoting = mk({
+		resourceId: "es-quote",
+		summary: 'The moment that mattered: user: "stay" — and the register shifted.',
+		summarySource: "extracted",
+	});
+	// Legacy transcript-shaped: heuristic still catches it.
+	const legacyPh = mk({ resourceId: "es-legacy", summary: "user: hello\nassistant: hi", summarySource: "unknown" });
+	const out = selectUsableRegisters([flaggedPh, quoting, legacyPh], 10, { now });
+	assert.deepEqual(out.map((s) => s.resourceId), ["es-quote"]);
 });

--- a/hooks/emotional-state.ts
+++ b/hooks/emotional-state.ts
@@ -279,7 +279,17 @@ export function selectUsableRegisters(
 ): EmotionalStateLatest[] {
 	const now = opts?.now ?? Date.now();
 	return states
-		.filter((s) => s.summary && !looksLikeRawTranscript(s.summary))
+		.filter((s) => {
+			if (!s.summary) return false;
+			// Backend-authoritative provenance when present (hyperspell #3364):
+			// "placeholder" is a raw transcript slice regardless of shape, and
+			// "extracted" is the genuine register even when it QUOTES dialogue
+			// (the heuristic would false-positive on that). Legacy/pre-deploy
+			// rows (null/"unknown") keep the shape heuristic.
+			if (s.summarySource === "placeholder") return false;
+			if (s.summarySource === "extracted") return true;
+			return !looksLikeRawTranscript(s.summary);
+		})
 		.filter((s) => {
 			const ts = Date.parse(s.extractedAt ?? "");
 			if (Number.isNaN(ts)) return true; // unknown age — keep (fail open)
@@ -398,7 +408,10 @@ export function buildEmotionalStateFetchHandler(
 			// "no injectable arc this session" and must fall through (mood may
 			// still roll, the session caches) or a busy day re-fetches every turn.
 			const anyExtracted = states.some(
-				(s) => s.summary && !looksLikeRawTranscript(s.summary),
+				(s) =>
+					s.summary &&
+					s.summarySource !== "placeholder" &&
+					(s.summarySource === "extracted" || !looksLikeRawTranscript(s.summary)),
 			);
 			if (usable.length === 0 && states.length > 0 && !anyExtracted) {
 				log.debug(


### PR DESCRIPTION
Client half of hyperspell#3364. The shared register selector now prefers the first-class `summary_source` field over the `looksLikeRawTranscript` shape heuristic — flagged placeholders dropped even when prose-shaped, flagged registers kept even when they quote dialogue, heuristic retained for legacy/pre-deploy rows. Forward-compatible either side of the backend deploy. 487 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSPQfAvwGKLRoUfJ3y5Gzv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790286597&installation_model_id=8852&pr_number=131&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F131&signature=082b937d1bd3f1da8cad530c3a7be7a8bf5b93f61e1e38552903035585e090ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->