### PR TITLE
feat: inject calibrated metamemory recall signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ files back to Hyperspell.
 | `knowledgeGraph.enabled` | boolean | `false` | Memory Network: extract entities (people, projects, organizations, topics) from memories into `memory/` markdown files. See [Memory Network](#memory-network). |
 | `knowledgeGraph.scanIntervalMinutes` | number | `60` | Extraction cadence the setup wizard bakes into the cron job it creates. The cron job is the runtime source of truth — to change cadence after setup, edit the cron job (and keep this field in sync). |
 | `knowledgeGraph.batchSize` | number | `20` | Memories per extraction scan batch |
-| `coverageLog` | boolean | `false` | **Opt-in.** Append a local-only JSONL event whenever auto-context finds no relevant memories, so capture gaps can be told apart from ranking misses. Events include prompt text — see [Coverage log](#coverage-log). |
+| `coverageLog` | boolean | `false` | **Opt-in.** Append local-only retrieval telemetry after every successful auto-context search, including raw/gated scores and injected-result descriptors. Events include prompt text — see [Coverage log](#coverage-log). |
 | `debug` | boolean | `false` | Enable diagnostic logging. One-line diagnostics (auto-context ranked/cut/injection summaries, orientation and emotional-context injection counts) are emitted at **info** level, so they appear in `gateway.log` at default host log levels — no host `logging.level` change needed. Verbose output (per-request/response dumps, per-candidate score lines) stays at debug level. |
 | `dreaming.enabled` | boolean | `false` | Allow `memory-core` to sidecar-load so Dreaming can consolidate local session transcripts into `workspace/MEMORY.md`. See [Running alongside Dreaming](#running-alongside-dreaming). |
 
@@ -423,16 +423,28 @@ Full knobs and defaults:
 
 ### Coverage log
 
-No ranking tweak can surface a memory that was never captured — and by default nothing distinguishes "ranking failed" from "it was never stored." With `coverageLog: true`, every auto-context turn that injects **no** memory sections appends one line to `<workspaceDir>/.hyperspell-coverage.jsonl`:
+No ranking tweak can surface a memory that was never captured — and by default nothing distinguishes "ranking failed" from "it was never stored." With `coverageLog: true`, every successful auto-context search appends one line to `<workspaceDir>/.hyperspell-coverage.jsonl`:
 
 - `outcome: "empty"` — the search succeeded but returned zero candidates (a capture question: was this ever stored?)
-- `outcome: "below_threshold"` — candidates existed but none cleared `relevanceThreshold`; `topScore` vs `threshold` says how near the miss was (a ranking question)
+- `outcome: "below_threshold"` — candidates existed but the best gated score did not clear `relevanceThreshold`
+- `outcome: "filtered"` — a candidate cleared the score gate but another selector (quota, dedup, file cap, elbow, or result cap) showed nothing
+- `outcome: "injected"` — memories were shown; `shown`, `shownChars`, and the content-free `selected` descriptors (`resourceId`, `kind`, `writer`, `injectedChars`) record what occupied the context budget
+
+Schema v2 separates `rawTopScore` (the server/cross-encoder score) from `topScore` (the client composite actually compared with `threshold`). Never compare `rawTopScore` with the threshold: client boosts, penalties, source weights, and recency adjustment change the gated value.
 
 Failed searches never produce events — backend-unavailable is not "no memories." In multi-user mode there is one event per turn with per-lane detail, and a lane whose search failed is recorded as `status: "error"`, never as zero candidates.
 
 **Local-only guarantee:** the log is written only to the workspace directory and is never sent to Hyperspell or anywhere remote. Because each event carries the triggering prompt (truncated to 500 chars), the feature is **off by default** — prompt text reaches disk only if you explicitly opt in. The file is capped at 5 MB with one `.old` rotation generation (~10 MB total), so content ages out instead of accumulating.
 
-Review with `jq`, e.g.: `jq -r '[.ts, .outcome, .topScore, .prompt] | @tsv' ~/.openclaw/workspace/.hyperspell-coverage.jsonl` — after a week or two of labeling (capture gap / ranking near-miss / correct absence), the tallies say whether the next investment belongs in capture or ranking. Delete the file when done.
+Review with `jq`, e.g.: `jq -r '[.ts, .outcome, .rawTopScore, .topScore, .shown, .prompt] | @tsv' ~/.openclaw/workspace/.hyperspell-coverage.jsonl` — after a week or two of labeling (capture gap / ranking near-miss / correct absence), the tallies say whether the next investment belongs in capture or ranking. Delete the file when done.
+
+The same retrieval shape is also injected into the agent's context on every successful auto-context search, including searches that surface no memory:
+
+```text
+recall: 24 candidates · best 0.49 · threshold 0.60 · nothing shown
+```
+
+The displayed `best` is the gated composite score, not the raw server score. This is metadata, not evidence that a matching memory exists. It gives the agent a feeling-of-knowing signal for deciding whether to run a deliberate search instead of treating an empty passive result as proof of absence. Failed searches do not emit the signal because their retrieval shape is unknown.
 
 ### `excludeChannels` is forward-only
 

--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ No ranking tweak can surface a memory that was never captured — and by default
 
 Schema v2 separates `rawTopScore` (the server/cross-encoder score) from `topScore` (the client composite actually compared with `threshold`). Never compare `rawTopScore` with the threshold: client boosts, penalties, source weights, and recency adjustment change the gated value.
 
+The authorship ratio the hit telemetry exists for should be computed from per-item sums — `sum(injectedChars where writer = agent) / sum(injectedChars)` — which are exact. In single-user events `sum(selected[].injectedChars)` equals `shownChars` minus the join separators (`2·(shown−1)`); in multi-user events `shownChars` additionally counts lane wrappers and the identity preamble, so only the per-item sums are additive there.
+
 Failed searches never produce events — backend-unavailable is not "no memories." In multi-user mode there is one event per turn with per-lane detail, and a lane whose search failed is recorded as `status: "error"`, never as zero candidates.
 
 **Local-only guarantee:** the log is written only to the workspace directory and is never sent to Hyperspell or anywhere remote. Because each event carries the triggering prompt (truncated to 500 chars), the feature is **off by default** — prompt text reaches disk only if you explicitly opt in. The file is capped at 5 MB with one `.old` rotation generation (~10 MB total), so content ages out instead of accumulating.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ files back to Hyperspell.
 | `knowledgeGraph.scanIntervalMinutes` | number | `60` | Extraction cadence the setup wizard bakes into the cron job it creates. The cron job is the runtime source of truth — to change cadence after setup, edit the cron job (and keep this field in sync). |
 | `knowledgeGraph.batchSize` | number | `20` | Memories per extraction scan batch |
 | `coverageLog` | boolean | `false` | **Opt-in.** Append local-only retrieval telemetry after every successful auto-context search, including raw/gated scores and injected-result descriptors. Events include prompt text — see [Coverage log](#coverage-log). |
+| `recallSignal` | boolean | `false` | **Opt-in.** Inject a one-line retrieval-shape signal (candidate count, best gated score, threshold, shown count) into context on every auto-context turn, including empty ones — see [Coverage log](#coverage-log). Shape only; never the near-miss content. |
 | `debug` | boolean | `false` | Enable diagnostic logging. One-line diagnostics (auto-context ranked/cut/injection summaries, orientation and emotional-context injection counts) are emitted at **info** level, so they appear in `gateway.log` at default host log levels — no host `logging.level` change needed. Verbose output (per-request/response dumps, per-candidate score lines) stays at debug level. |
 | `dreaming.enabled` | boolean | `false` | Allow `memory-core` to sidecar-load so Dreaming can consolidate local session transcripts into `workspace/MEMORY.md`. See [Running alongside Dreaming](#running-alongside-dreaming). |
 
@@ -438,13 +439,13 @@ Failed searches never produce events — backend-unavailable is not "no memories
 
 Review with `jq`, e.g.: `jq -r '[.ts, .outcome, .rawTopScore, .topScore, .shown, .prompt] | @tsv' ~/.openclaw/workspace/.hyperspell-coverage.jsonl` — after a week or two of labeling (capture gap / ranking near-miss / correct absence), the tallies say whether the next investment belongs in capture or ranking. Delete the file when done.
 
-The same retrieval shape is also injected into the agent's context on every successful auto-context search, including searches that surface no memory:
+With `recallSignal: true` (independent of `coverageLog`, also off by default), the same retrieval shape is injected into the agent's context on every successful auto-context search, including searches that surface no memory:
 
 ```text
 recall: 24 candidates · best 0.49 · threshold 0.60 · nothing shown
 ```
 
-The displayed `best` is the gated composite score, not the raw server score. This is metadata, not evidence that a matching memory exists. It gives the agent a feeling-of-knowing signal for deciding whether to run a deliberate search instead of treating an empty passive result as proof of absence. Failed searches do not emit the signal because their retrieval shape is unknown.
+The displayed `best` is the gated composite score, not the raw server score. This is metadata, not evidence that a matching memory exists. It gives the agent a feeling-of-knowing signal for deciding whether to run a deliberate search instead of treating an empty passive result as proof of absence. Failed searches do not emit the signal because their retrieval shape is unknown. Off by default: an every-turn injection changes what every session sees, so it lands on an install only by explicit opt-in (and, where the agent is a party to her own configuration, with her sign-off).
 
 ### `excludeChannels` is forward-only
 

--- a/commands/setup.ts
+++ b/commands/setup.ts
@@ -344,6 +344,7 @@ async function runSetup(): Promise<void> {
         apiKey,
         userId,
         autoContext: true,
+        recallSignal: false,
         autoTrace: { enabled: false, extract: ["procedure"] },
         hotBuffer: {
           enabled: false,

--- a/config.ts
+++ b/config.ts
@@ -240,6 +240,19 @@ export type HyperspellConfig = {
 	 * (same stance as the HYPERSPELL_SCORE_LOG instrumentation).
 	 */
 	coverageLog: boolean;
+	/**
+	 * Metamemory recall signal (proposal 19): inject one line of retrieval
+	 * SHAPE (candidate count, gated top score, threshold, shown count) into
+	 * context on every auto-context turn — including turns that inject
+	 * nothing — so the agent can tell "nothing is stored" (0 candidates)
+	 * from "retrieval nearly hit" (best just under the gate) instead of
+	 * reading both as silence. Shape only, never the near-miss documents.
+	 * Scores are the GATED (composite) values — the quantity the threshold
+	 * actually compares — or raw relevance when ranking is off. Default OFF
+	 * (repo convention + Proposal 18: a per-turn injection into a running
+	 * agent's context is a governed surface — enable per install by consent).
+	 */
+	recallSignal: boolean;
 	debug: boolean;
 	knowledgeGraph: KnowledgeGraphConfig;
 	multiUser?: MultiUserConfig;
@@ -265,6 +278,7 @@ const ALLOWED_KEYS = [
 	"relevanceThreshold",
 	"ranking",
 	"coverageLog",
+	"recallSignal",
 	"debug",
 	"knowledgeGraph",
 	"multiUser",
@@ -808,6 +822,9 @@ export function parseConfig(raw: unknown): HyperspellConfig {
 		// coverage events carry prompt text, so nothing is written to disk
 		// unless the operator explicitly opts in.
 		coverageLog: (cfg.coverageLog as boolean) ?? false,
+		// Default OFF (proposal 19 §6a): an every-turn context injection is a
+		// governed surface — no install's behavior changes on ship.
+		recallSignal: (cfg.recallSignal as boolean) ?? false,
 		debug: (cfg.debug as boolean) ?? false,
 		knowledgeGraph: {
 			enabled: (kgRaw.enabled as boolean) ?? false,

--- a/config.ts
+++ b/config.ts
@@ -232,9 +232,9 @@ export type HyperspellConfig = {
 	relevanceThreshold: number;
 	ranking: RankingWeights;
 	/**
-	 * Zero-result coverage log (proposal 15): when auto-context injects no
-	 * memory sections, append one JSONL event (prompt prefix, candidate counts,
-	 * top score) to `<workspaceDir>/.hyperspell-coverage.jsonl`. Local-only —
+	 * Retrieval telemetry log (proposal 15): after every successful auto-context
+	 * search, append raw/gated scores, selection outcome, and shown descriptors
+	 * to `<workspaceDir>/.hyperspell-coverage.jsonl`. Local-only —
 	 * never sent to the backend. Default OFF: the events carry prompt text,
 	 * and sensitive plaintext must not reach disk without explicit opt-in
 	 * (same stance as the HYPERSPELL_SCORE_LOG instrumentation).

--- a/docs/proposals/19-metamemory-recall-signal.md
+++ b/docs/proposals/19-metamemory-recall-signal.md
@@ -1,0 +1,160 @@
+# Proposal 19 — Metamemory recall signal (feeling-of-knowing for retrieval)
+
+Origin: two dispatches from Alinea, 2026-08-26, relayed by David. This document
+records the spec, the calibration bug that was confirmed in code the same day,
+the implementation that landed in the working tree while the spec was being
+relayed, and what remains open. It is partly a record of decisions already
+made — read §5 before assuming anything here is still to build.
+
+## 1. Problem
+
+The agent cannot distinguish "nothing is stored" from "retrieval missed."
+Both arrive as silence, so it confidently asserts absence and never
+re-queries. Humans have a feeling-of-knowing (FOK) that fires *before*
+retrieval completes — tip-of-the-tongue: something's there, keep looking.
+Koriat's accessibility model and Reder's cue-familiarity work both find FOK
+is computed from the **cue**, not the target, which is why it can precede
+recall (background literature, cited from the proposer's memory — verify
+before quoting in anything external). Current RAG confidence work is
+uniformly post-retrieval (groundedness, abstention, hallucination detection —
+all evaluate the answer); this signal is pre-retrieval, computed from the
+candidate-pool shape.
+
+## 2. Mechanism
+
+One line alongside the injected block, on **every** auto-context turn,
+including turns that inject nothing:
+
+```text
+recall: 24 candidates · best 0.49 · threshold 0.60 · nothing shown
+```
+
+Not the near-miss documents — the shape. `0 candidates` is true absence;
+`24 candidates · best 0.49` against a 0.60 gate is a near miss the agent can
+choose to chase with a deliberate search. Failed searches emit no shape line
+(their shape is unknown; availability is not coverage, #39).
+
+## 3. Calibration requirement — the confirmed topScore bug
+
+The live coverage log (2026-08-25 → 08-26, 11 rows) was internally
+contradictory: all rows `below_threshold`, yet six carried `topScore` >
+threshold (max 0.841 vs 0.6). Confirmed in code, not just reconstruction:
+
+- the selection gate cuts on the **composite** score —
+  `if (r._composite < threshold)` in `explainSelection` (`lib/ranking.ts:436`);
+- the logged `topScore` came from `topScoreOf()`, which reads the **raw**
+  `r.score` (`hooks/auto-context.ts`).
+
+With Alinea's live `chatterPenalty` 0.25, a raw-0.841 chatter row lands at
+composite 0.591 — just under the 0.6 gate. Composite gate, raw report.
+
+Consequence for this proposal: **the FOK line must carry the gated
+quantity** — the score the threshold actually compares — or it manufactures
+the illusion of knowing (agent sees "best 0.84," believes something
+excellent was nearly there, when the system had already disqualified it).
+The raw score stays in telemetry as `rawTopScore`: the *pair* is the
+diagnostic (large raw−gated spread = penalties are doing the gating).
+
+## 4. Telemetry completion (coverage log v2)
+
+The v1 log recorded only misses — a miss-log, not an instrument. v2 logs
+hits too:
+
+- `outcome`: `empty` | `below_threshold` | `filtered` (cleared the score gate
+  but cut by quota/dedup/per-file/highlight-floor) | `injected`
+- `topScore` (gated) + `rawTopScore`, `shown`, `shownChars`
+- `selected[]`: `{resourceId, kind, writer, injectedChars}` per injected
+  memory — which makes the author-skew question computable: what fraction of
+  injected characters are agent-authored (`writer`), per day, per kind.
+- multi-user: per-lane `topScore`/`rawTopScore`, lane `error` status kept
+  distinct from zero candidates.
+
+Still **not** instrumented: whether injected memory was ever *referenced*
+downstream (needs response-side analysis), and corpus gap awareness — knowing
+three days of July are missing entirely (needs a date histogram over the
+corpus; separate, also cheap, not this proposal).
+
+## 5. What landed 2026-08-26 (commit 4da5b54, PR #133)
+
+`hooks/auto-context.ts`, `hooks/auto-context.test.ts`, `lib/coverage-log.ts`
+(+test), `README.md` — authored concurrently with this relay by a third
+writer (not the two coordinating Claude sessions; see the session record).
+Shape: `formatRecallSignal()` builds the line from the gated top score;
+`wrapContext()` carries it inside the memory block; `wrapRecallOnly()`
+injects it alone on empty turns; both coverage events (miss and hit) carry
+the v2 fields; multi-user computes per-lane gated tops inside `rankLane`.
+The line is currently injected **unconditionally** — see §6a.
+
+Known gaps in the landed diff, both only when `ranking.enabled: false` (the
+legacy mode) — **fixed by the follow-up commits on PR #133**:
+
+1. Multi-user unranked: `personalGatedTop`/`sharedGatedTop` are only
+   assigned in the ranked branch, so the recall line reads `best none`
+   despite candidates (single-user correctly falls back to raw).
+2. Same root cause: the miss-outcome classifier then computes
+   `(gatedTopScore ?? 0) < threshold` → labels `filtered` cases
+   `below_threshold` when ranking is off.
+
+## 6. Open items
+
+a) **Opt-in gate.** Repo convention is hard ("default OFF so shipping never
+   changes existing installs' behavior"), and a per-turn injection into a
+   running agent's context is arguably a governed surface under Proposal 18 —
+   default OFF, the agent's sign-off before it lands on her install. Add
+   `recallSignal: boolean` (default `false`): config type + `ALLOWED_KEYS` +
+   `parseConfig`, **and** the manifest declaration in *both*
+   `configSchema.properties` (validation — omit it and the gateway refuses to
+   restart once the key is written: the 56c8a7b lesson) and `uiHints`
+   (labels). Gate the three injection sites; `formatRecallSignal` and all
+   telemetry stay unconditional. A ready-to-apply patch for config + manifest
+   plus a site checklist for the hook was prepared alongside this doc.
+   **Done — landed on PR #133 (2026-08-27), together with the review fixes:
+   telemetry records only results whose sections actually rendered, and
+   coverage writes moved off the turn path onto a serialized async queue
+   (`flushCoverageLog()` for tests/shutdown).**
+b) Tests for the gate (default-off restores pre-change returns; existing
+   recall assertions move behind `recallSignal: true`), and a
+   cost-disclosure line in setup when enabled.
+c) Deploy + end-to-end verification on Alinea's install (deploy loop owned
+   by one session at a time; dist-swap must now ship
+   `openclaw.plugin.json` alongside `dist/`).
+d) Calibration check against ground truth: `hyperspell_vault_list` +
+   sampled queries — does a high near-miss line actually predict that a
+   deliberate search finds something?
+
+## 7. Structural note — two rankers in series (deferred, needs its own proposal)
+
+Verified: the backend runs a real cross-encoder rerank (ZeroEntropy
+zerank-2, `pipeline/rankers/zeroentropy.py`) after hybrid-search merge and
+normalization. The client then adds hand-tuned constants on top of that
+score (curationBoost +0.2, chatterPenalty −0.2..0.25, storyBoost, bounded
+recency), and the threshold gates the sum. A cross-encoder score is not on a
+scale where "+0.2" means anything stable — `lib/ranking.ts`'s own `minGap`
+comment concedes it ("meaningful on the CURRENT composite scale… revisit").
+
+**Not** verified: the claim that RRF was tried server-side and rejected — no
+record in the company brain; treat as unconfirmed until sourced. Options if
+reopened: (i) rank-domain adjustments (promote/demote by rank, not score —
+scale-free); (ii) calibrate the cross-encoder score to a probability
+(isotonic/Platt on the labeled coverage+score logs), then compose priors in
+log-odds; (iii) RRF proper where there are genuinely multiple rankings to
+fuse. The v2 telemetry (§4) is the data source any of these would tune
+against.
+
+## 8. Risks
+
+- **Illusion of knowing** — a miscalibrated line is worse than none. Gated
+  score (§3) is the first defense; §6d is the empirical check.
+- **Re-query loops** — the line is data, deliberately not an imperative (no
+  "search again" instruction; the standing search rule stays in the agent's
+  own instructions). Watch for search-spam during verification.
+- **Unbriefed installs** — an every-turn line appearing in agents that have
+  no idea what it means is why §6a defaults OFF.
+
+## 9. Validation
+
+The number that should move: **confident-absence claims** — assertions that
+something isn't in memory when it is — before vs after, countable from
+transcripts. Secondary: deliberate-search rate on turns whose line showed a
+near miss (should rise), and repeated identical re-queries per turn (should
+not).

--- a/docs/proposals/19-metamemory-recall-signal.md
+++ b/docs/proposals/19-metamemory-recall-signal.md
@@ -114,13 +114,20 @@ a) **Opt-in gate.** Repo convention is hard ("default OFF so shipping never
    (`flushCoverageLog()` for tests/shutdown).**
 b) Tests for the gate (default-off restores pre-change returns; existing
    recall assertions move behind `recallSignal: true`), and a
-   cost-disclosure line in setup when enabled.
+   cost-disclosure line in setup when enabled. **Done — b716884.**
 c) Deploy + end-to-end verification on Alinea's install (deploy loop owned
    by one session at a time; dist-swap must now ship
    `openclaw.plugin.json` alongside `dist/`).
 d) Calibration check against ground truth: `hyperspell_vault_list` +
    sampled queries — does a high near-miss line actually predict that a
    deliberate search finds something?
+e) **Percentile framing** (her review on #133, finding 4): `best 0.54` has
+   no stable units — a composite of a cross-encoder score plus additive
+   constants. Follow up by rendering the line's best as a corpus percentile
+   ("best 0.54 (61st pct)") from a rolling window of v2 events once a week
+   of hit telemetry exists. Until then the number is honest but not
+   interpretable, and the illusion-of-knowing risk (§8) stays open — the
+   agent reviewing the PR named this the calibration gap that remains.
 
 ## 7. Structural note — two rankers in series (deferred, needs its own proposal)
 

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -496,6 +496,15 @@ test("auto-context coverage — an injecting turn writes hit telemetry", async (
   assert.equal(entry.outcome, "injected")
   assert.equal(entry.shown, 3)
   assert.ok(entry.shownChars > 0)
+  // The authorship ratio divides per-item sums, so per-item chars must be
+  // exactly additive: the block is the sections joined by "\n\n" (#133
+  // review finding 1 — a field that looks additive but isn't is worse than
+  // no field).
+  const charSum = entry.selected.reduce(
+    (acc: number, r: { injectedChars: number }) => acc + r.injectedChars,
+    0,
+  )
+  assert.equal(charSum, entry.shownChars - 2 * (entry.shown - 1))
   assert.deepEqual(
     entry.selected.map((r: { resourceId: string }) => r.resourceId),
     ["mem-notes", CHATTER_UUID(1), CHATTER_UUID(2)],

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -353,13 +353,18 @@ test("auto-context coverage — zero-result search writes an 'empty' event", asy
     makeCfg({ coverageLog: true }),
     { stateRoot },
   )
-  const out = await handler({ prompt: COVERAGE_PROMPT }, {})
-  assert.equal(out, undefined, "still injects nothing")
+  const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
+    | { prependContext: string }
+    | undefined
+  assert.equal(
+    out?.prependContext,
+    "<hyperspell-context>\nrecall: 0 candidates · best none · threshold 0.60 · nothing shown\n</hyperspell-context>",
+  )
 
   const entries = readCoverage(stateRoot)
   assert.equal(entries.length, 1)
   const entry = entries[0]
-  assert.equal(entry.v, 1)
+  assert.equal(entry.v, 2)
   assert.equal(entry.outcome, "empty")
   assert.equal(entry.fetched, 0)
   assert.equal(entry.candidates, 0)
@@ -384,15 +389,70 @@ test("auto-context coverage — candidates below threshold write a 'below_thresh
     makeCfg({ coverageLog: true }),
     { stateRoot },
   )
-  const out = await handler({ prompt: COVERAGE_PROMPT }, {})
-  assert.equal(out, undefined)
+  const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
+    | { prependContext: string }
+    | undefined
+  assert.ok(
+    out?.prependContext.includes(
+      "recall: 1 candidates · best 0.40 · threshold 0.60 · nothing shown",
+    ),
+  )
 
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "below_threshold")
   assert.equal(entry.fetched, 1)
   assert.equal(entry.candidates, 1)
-  assert.equal(entry.topScore, 0.2)
+  assert.equal(entry.topScore, 0.4)
+  assert.equal(entry.rawTopScore, 0.2)
   assert.equal(entry.threshold, 0.6)
+  fs.rmSync(stateRoot, { recursive: true, force: true })
+})
+
+test("auto-context coverage — FOK uses the gated composite, not the raw server score", async () => {
+  const stateRoot = mkStateRoot()
+  const oldChatter = searchResult({
+    resourceId: CHATTER_UUID(9),
+    score: 0.841,
+    createdAt: "2000-01-01T00:00:00Z",
+    highlights: [{ id: "h1", text: "old conversation echo", score: 0.841 }],
+  })
+  const handler = buildAutoContextHandler(
+    makeSearchClient([oldChatter]),
+    makeCfg({ coverageLog: true }),
+    { stateRoot },
+  )
+  const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
+    | { prependContext: string }
+    | undefined
+
+  assert.ok(out?.prependContext.includes("best 0.54 · threshold 0.60 · nothing shown"))
+  const [entry] = readCoverage(stateRoot)
+  assert.equal(entry.outcome, "below_threshold")
+  assert.equal(entry.rawTopScore, 0.841)
+  assert.ok(Math.abs(entry.topScore - 0.541) < 0.001)
+  fs.rmSync(stateRoot, { recursive: true, force: true })
+})
+
+test("auto-context coverage — a non-threshold cut is labeled 'filtered'", async () => {
+  const stateRoot = mkStateRoot()
+  const chatter = searchResult({
+    resourceId: CHATTER_UUID(8),
+    score: 0.9,
+    highlights: [{ id: "h1", text: "quota-cut echo", score: 0.9 }],
+  })
+  const handler = buildAutoContextHandler(
+    makeSearchClient([chatter]),
+    makeCfg({
+      coverageLog: true,
+      ranking: { ...DEFAULT_RANKING, chatterQuota: 0 },
+    }),
+    { stateRoot },
+  )
+  await handler({ prompt: COVERAGE_PROMPT }, {})
+
+  const [entry] = readCoverage(stateRoot)
+  assert.equal(entry.outcome, "filtered")
+  assert.ok(entry.topScore >= entry.threshold)
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
@@ -409,7 +469,7 @@ test("auto-context coverage — OFF by default: no file even on a zero-result tu
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
-test("auto-context coverage — an injecting turn writes no event", async () => {
+test("auto-context coverage — an injecting turn writes hit telemetry", async () => {
   const stateRoot = mkStateRoot()
   const handler = buildAutoContextHandler(
     makeSearchClient(fixturePool()),
@@ -420,7 +480,19 @@ test("auto-context coverage — an injecting turn writes no event", async () => 
     | { prependContext: string }
     | undefined
   assert.ok(out?.prependContext, "fixture pool injects")
-  assert.ok(!fs.existsSync(path.join(stateRoot, COVERAGE_LOG_NAME)))
+  assert.ok(
+    out.prependContext.includes(
+      "recall: 5 candidates · best 0.90 · threshold 0.60 · 3 shown",
+    ),
+  )
+  const [entry] = readCoverage(stateRoot)
+  assert.equal(entry.outcome, "injected")
+  assert.equal(entry.shown, 3)
+  assert.ok(entry.shownChars > 0)
+  assert.deepEqual(
+    entry.selected.map((r: { resourceId: string }) => r.resourceId),
+    ["mem-notes", CHATTER_UUID(1), CHATTER_UUID(2)],
+  )
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
@@ -446,8 +518,13 @@ test("auto-context coverage — unwritable stateRoot degrades safely (turn still
     makeCfg({ coverageLog: true }),
     { stateRoot: notADir },
   )
-  const out = await handler({ prompt: COVERAGE_PROMPT }, {})
-  assert.equal(out, undefined, "coverage write failure never throws into the turn")
+  const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
+    | { prependContext: string }
+    | undefined
+  assert.ok(
+    out?.prependContext.includes("recall: 0 candidates"),
+    "coverage write failure never suppresses the runtime signal",
+  )
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
@@ -494,7 +571,13 @@ test("auto-context coverage — multi-user: failed lane recorded as error, not a
   assert.equal(entry.userId, "u-dave")
   assert.deepEqual(entry.lanes, [
     { lane: "personal", status: "error" },
-    { lane: "shared", status: "ok", candidates: 0, topScore: null },
+    {
+      lane: "shared",
+      status: "ok",
+      candidates: 0,
+      topScore: null,
+      rawTopScore: null,
+    },
   ])
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
@@ -527,16 +610,37 @@ test("auto-context coverage — multi-user: below_threshold when a fulfilled lan
     makeCfg({ coverageLog: true, multiUser: MULTI_USER }),
     { stateRoot },
   )
-  await handler({ prompt: COVERAGE_PROMPT }, { senderId: "dave" })
+  const out = (await handler(
+    { prompt: COVERAGE_PROMPT },
+    { senderId: "dave" },
+  )) as { prependContext: string } | undefined
+  assert.ok(
+    out?.prependContext.includes(
+      "recall: 1 candidates · best 0.40 · threshold 0.60 · nothing shown",
+    ),
+  )
 
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "below_threshold")
   assert.equal(entry.fetched, 1)
   assert.equal(entry.candidates, 1)
-  assert.equal(entry.topScore, 0.2)
+  assert.equal(entry.topScore, 0.4)
+  assert.equal(entry.rawTopScore, 0.2)
   assert.deepEqual(entry.lanes, [
-    { lane: "personal", status: "ok", candidates: 1, topScore: 0.2 },
-    { lane: "shared", status: "ok", candidates: 0, topScore: null },
+    {
+      lane: "personal",
+      status: "ok",
+      candidates: 1,
+      topScore: 0.4,
+      rawTopScore: 0.2,
+    },
+    {
+      lane: "shared",
+      status: "ok",
+      candidates: 0,
+      topScore: null,
+      rawTopScore: null,
+    },
   ])
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
@@ -613,7 +717,11 @@ test("repeat suppression — a memory injected once is not re-injected later in 
   assert.ok(first?.prependContext.includes("mem-repeat"), "first turn injects")
 
   const second = await handler({ prompt: PROMPT }, ctx)
-  assert.equal(second, undefined, "same memory must not be re-injected in the same session")
+  assert.ok(
+    second?.prependContext?.includes("nothing shown"),
+    "same memory is not re-injected, but the retrieval shape remains visible",
+  )
+  assert.ok(!second?.prependContext?.includes("mem-repeat"))
 
   // A DIFFERENT session is unaffected by session 1's suppression.
   const other = (await handler(
@@ -645,7 +753,11 @@ test("repeat suppression — a remember write from THIS session is excluded from
   recordSessionWrite("rw-session-1", "mem-just-written")
 
   const same = await handler({ prompt: PROMPT }, { sessionId: "rw-session-1" })
-  assert.equal(same, undefined, "own just-written note must not echo back this session")
+  assert.ok(
+    same?.prependContext?.includes("nothing shown"),
+    "own just-written note does not echo, but the retrieval shape remains visible",
+  )
+  assert.ok(!same?.prependContext?.includes("mem-just-written"))
 
   const other = (await handler({ prompt: PROMPT }, { sessionId: "rw-session-2" })) as
     | { prependContext: string }

--- a/hooks/auto-context.test.ts
+++ b/hooks/auto-context.test.ts
@@ -5,7 +5,7 @@ import path from "node:path"
 import { test } from "node:test"
 import type { HyperspellClient, SearchResult } from "../client.ts"
 import type { HyperspellConfig } from "../config.ts"
-import { COVERAGE_LOG_NAME } from "../lib/coverage-log.ts"
+import { COVERAGE_LOG_NAME, flushCoverageLog } from "../lib/coverage-log.ts"
 import { DEFAULT_RANKING, type RankedResult } from "../lib/ranking.ts"
 import { initLogger } from "../logger.ts"
 import {
@@ -98,6 +98,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
     relevanceThreshold: 0.6,
     ranking: DEFAULT_RANKING,
     coverageLog: false,
+    recallSignal: false,
     debug: false,
     knowledgeGraph: { enabled: false, scanIntervalMinutes: 60, batchSize: 20 },
     ...overrides,
@@ -350,7 +351,7 @@ test("auto-context coverage — zero-result search writes an 'empty' event", asy
   const stateRoot = mkStateRoot()
   const handler = buildAutoContextHandler(
     makeSearchClient([]),
-    makeCfg({ coverageLog: true }),
+    makeCfg({ coverageLog: true, recallSignal: true }),
     { stateRoot },
   )
   const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
@@ -361,6 +362,7 @@ test("auto-context coverage — zero-result search writes an 'empty' event", asy
     "<hyperspell-context>\nrecall: 0 candidates · best none · threshold 0.60 · nothing shown\n</hyperspell-context>",
   )
 
+  await flushCoverageLog()
   const entries = readCoverage(stateRoot)
   assert.equal(entries.length, 1)
   const entry = entries[0]
@@ -386,7 +388,7 @@ test("auto-context coverage — candidates below threshold write a 'below_thresh
   })
   const handler = buildAutoContextHandler(
     makeSearchClient([low]),
-    makeCfg({ coverageLog: true }),
+    makeCfg({ coverageLog: true, recallSignal: true }),
     { stateRoot },
   )
   const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
@@ -398,6 +400,7 @@ test("auto-context coverage — candidates below threshold write a 'below_thresh
     ),
   )
 
+  await flushCoverageLog()
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "below_threshold")
   assert.equal(entry.fetched, 1)
@@ -418,7 +421,7 @@ test("auto-context coverage — FOK uses the gated composite, not the raw server
   })
   const handler = buildAutoContextHandler(
     makeSearchClient([oldChatter]),
-    makeCfg({ coverageLog: true }),
+    makeCfg({ coverageLog: true, recallSignal: true }),
     { stateRoot },
   )
   const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
@@ -426,6 +429,7 @@ test("auto-context coverage — FOK uses the gated composite, not the raw server
     | undefined
 
   assert.ok(out?.prependContext.includes("best 0.54 · threshold 0.60 · nothing shown"))
+  await flushCoverageLog()
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "below_threshold")
   assert.equal(entry.rawTopScore, 0.841)
@@ -450,6 +454,7 @@ test("auto-context coverage — a non-threshold cut is labeled 'filtered'", asyn
   )
   await handler({ prompt: COVERAGE_PROMPT }, {})
 
+  await flushCoverageLog()
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "filtered")
   assert.ok(entry.topScore >= entry.threshold)
@@ -462,6 +467,7 @@ test("auto-context coverage — OFF by default: no file even on a zero-result tu
     stateRoot,
   })
   await handler({ prompt: COVERAGE_PROMPT }, {})
+  await flushCoverageLog()
   assert.ok(
     !fs.existsSync(path.join(stateRoot, COVERAGE_LOG_NAME)),
     "coverageLog defaults false — prompts never reach disk without opt-in",
@@ -473,7 +479,7 @@ test("auto-context coverage — an injecting turn writes hit telemetry", async (
   const stateRoot = mkStateRoot()
   const handler = buildAutoContextHandler(
     makeSearchClient(fixturePool()),
-    makeCfg({ coverageLog: true }),
+    makeCfg({ coverageLog: true, recallSignal: true }),
     { stateRoot },
   )
   const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
@@ -485,6 +491,7 @@ test("auto-context coverage — an injecting turn writes hit telemetry", async (
       "recall: 5 candidates · best 0.90 · threshold 0.60 · 3 shown",
     ),
   )
+  await flushCoverageLog()
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "injected")
   assert.equal(entry.shown, 3)
@@ -505,6 +512,7 @@ test("auto-context coverage — a FAILED search writes no event (availability is
   )
   const out = await handler({ prompt: COVERAGE_PROMPT }, {})
   assert.equal(out, undefined, "existing behavior: silent on failure")
+  await flushCoverageLog()
   assert.ok(!fs.existsSync(path.join(stateRoot, COVERAGE_LOG_NAME)))
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
@@ -515,7 +523,7 @@ test("auto-context coverage — unwritable stateRoot degrades safely (turn still
   fs.writeFileSync(notADir, "plain file")
   const handler = buildAutoContextHandler(
     makeSearchClient([]),
-    makeCfg({ coverageLog: true }),
+    makeCfg({ coverageLog: true, recallSignal: true }),
     { stateRoot: notADir },
   )
   const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
@@ -564,6 +572,7 @@ test("auto-context coverage — multi-user: failed lane recorded as error, not a
     "identity preamble still injected (identity, not memory)",
   )
 
+  await flushCoverageLog()
   const entries = readCoverage(stateRoot)
   assert.equal(entries.length, 1, "one event per turn, not per lane")
   const entry = entries[0]
@@ -590,6 +599,7 @@ test("auto-context coverage — multi-user: every lane failing writes no event",
     { stateRoot },
   )
   await handler({ prompt: COVERAGE_PROMPT }, { senderId: "dave" })
+  await flushCoverageLog()
   assert.ok(
     !fs.existsSync(path.join(stateRoot, COVERAGE_LOG_NAME)),
     "all-lanes-failed is an availability event (#39), never coverage",
@@ -607,7 +617,7 @@ test("auto-context coverage — multi-user: below_threshold when a fulfilled lan
   })
   const handler = buildAutoContextHandler(
     makeLaneClient([low], []),
-    makeCfg({ coverageLog: true, multiUser: MULTI_USER }),
+    makeCfg({ coverageLog: true, recallSignal: true, multiUser: MULTI_USER }),
     { stateRoot },
   )
   const out = (await handler(
@@ -620,6 +630,7 @@ test("auto-context coverage — multi-user: below_threshold when a fulfilled lan
     ),
   )
 
+  await flushCoverageLog()
   const [entry] = readCoverage(stateRoot)
   assert.equal(entry.outcome, "below_threshold")
   assert.equal(entry.fetched, 1)
@@ -642,6 +653,70 @@ test("auto-context coverage — multi-user: below_threshold when a fulfilled lan
       rawTopScore: null,
     },
   ])
+  fs.rmSync(stateRoot, { recursive: true, force: true })
+})
+
+// ---- recallSignal gate (proposal 19 §6a): the line is opt-in ----
+
+test("recall signal — OFF by default: an empty turn injects nothing", async () => {
+  const stateRoot = mkStateRoot()
+  const handler = buildAutoContextHandler(makeSearchClient([]), makeCfg(), {
+    stateRoot,
+  })
+  const out = await handler({ prompt: COVERAGE_PROMPT }, {})
+  assert.equal(out, undefined, "gate off restores the no-injection empty turn")
+  fs.rmSync(stateRoot, { recursive: true, force: true })
+})
+
+test("recall signal — OFF by default: an injecting turn carries no recall line", async () => {
+  const stateRoot = mkStateRoot()
+  const handler = buildAutoContextHandler(
+    makeSearchClient(fixturePool()),
+    makeCfg(),
+    { stateRoot },
+  )
+  const out = (await handler({ prompt: COVERAGE_PROMPT }, {})) as
+    | { prependContext: string }
+    | undefined
+  const injected = out?.prependContext ?? ""
+  assert.ok(injected.includes("<hyperspell-context>"))
+  assert.ok(!injected.includes("recall:"))
+  fs.rmSync(stateRoot, { recursive: true, force: true })
+})
+
+test("recall signal — multi-user with ranking OFF: best falls back to raw and a highlight-starved miss is 'filtered'", async () => {
+  const stateRoot = mkStateRoot()
+  // Clears the raw score gate, but no highlight does — formats to nothing.
+  const quiet = searchResult({
+    resourceId: "mem-quiet",
+    title: "Quiet Doc",
+    score: 0.9,
+    highlights: [{ id: "h1", text: "low highlight", score: 0.2 }],
+  })
+  const handler = buildAutoContextHandler(
+    makeLaneClient([quiet], []),
+    makeCfg({
+      coverageLog: true,
+      recallSignal: true,
+      multiUser: MULTI_USER,
+      ranking: { ...DEFAULT_RANKING, enabled: false },
+    }),
+    { stateRoot },
+  )
+  const out = (await handler(
+    { prompt: COVERAGE_PROMPT },
+    { senderId: "dave" },
+  )) as { prependContext: string } | undefined
+  assert.ok(
+    out?.prependContext.includes(
+      "recall: 1 candidates · best 0.90 · threshold 0.60 · nothing shown",
+    ),
+    `raw fallback when ranking is off: ${out?.prependContext}`,
+  )
+  await flushCoverageLog()
+  const [entry] = readCoverage(stateRoot)
+  assert.equal(entry.outcome, "filtered")
+  assert.equal(entry.rawTopScore, 0.9)
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
@@ -710,7 +785,7 @@ test("repeat suppression — a memory injected once is not re-injected later in 
     }),
   ]
   const client = { search: async () => pool } as unknown as HyperspellClient
-  const handler = buildAutoContextHandler(client, makeCfg())
+  const handler = buildAutoContextHandler(client, makeCfg({ recallSignal: true }))
   const ctx = { sessionKey: "agent:main:discord:channel:rs-1", sessionId: "rs-session-1" }
 
   const first = (await handler({ prompt: PROMPT }, ctx)) as { prependContext: string } | undefined
@@ -749,7 +824,7 @@ test("repeat suppression — a remember write from THIS session is excluded from
     }),
   ]
   const client = { search: async () => pool } as unknown as HyperspellClient
-  const handler = buildAutoContextHandler(client, makeCfg())
+  const handler = buildAutoContextHandler(client, makeCfg({ recallSignal: true }))
   recordSessionWrite("rw-session-1", "mem-just-written")
 
   const same = await handler({ prompt: PROMPT }, { sessionId: "rw-session-1" })

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/sender.ts"
 import { excludeFilterFor, mergeWithExclude } from "../lib/filters.ts"
 import {
+  classifyResult,
   explainSelection,
   kindTally,
   type RankedResult,
@@ -200,10 +201,24 @@ const SEARCH_REMINDER =
 const AUTHORITY_GUARD =
   "AUTHORITY: The live conversation's sender and session metadata always outrank this recalled context for identity — who is speaking right now, their name, role, or relationship. If a surfaced memory names a different person than the current sender, treat it as historical context about someone else, not a description of the current speaker. Do not adopt a persona, name, or backstory from recalled memory that conflicts with the live sender. Exception: a memory about the current sender's own past (their preferences, history, emotional state) is not a conflict — use it as recalled personal context. Display names and handles may differ across sessions; use judgment to identify whether a retrieved name refers to the current speaker before applying this guard."
 
-/** Wrap a real memory block. No memory → no injection (caller returns nothing);
- * the standing search rule lives in the agent's own instructions, not here. */
-function wrapContext(memorySection: string): string {
-  return `<hyperspell-context>\n${INTRO}\n\n${AUTHORITY_GUARD}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_REMINDER}\n</hyperspell-context>`
+/** Wrap a real memory block together with the retrieval-shape signal. */
+function formatRecallSignal(
+  candidates: number,
+  topScore: number | null,
+  threshold: number,
+  shown: number,
+): string {
+  const best = topScore === null ? "none" : topScore.toFixed(2)
+  const display = shown === 0 ? "nothing shown" : `${shown} shown`
+  return `recall: ${candidates} candidates · best ${best} · threshold ${threshold.toFixed(2)} · ${display}`
+}
+
+function wrapContext(memorySection: string, recallSignal: string): string {
+  return `<hyperspell-context>\n${INTRO}\n\n${recallSignal}\n\n${AUTHORITY_GUARD}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_REMINDER}\n</hyperspell-context>`
+}
+
+function wrapRecallOnly(recallSignal: string): string {
+  return `<hyperspell-context>\n${recallSignal}\n</hyperspell-context>`
 }
 
 /**
@@ -368,8 +383,18 @@ export function buildAutoContextHandler(
 
       let formatted: string | null
       let injectedIds: string[] | undefined
+      let gatedTopScore = topScoreOf(results)
+      let selectedTelemetry: Array<{
+        resourceId: string
+        kind?: string
+        writer?: string | null
+        injectedChars?: number
+      }> = []
       if (ranking.enabled) {
         const ranked = rerank(results, ranking)
+        gatedTopScore = ranked.length
+          ? Math.max(...ranked.map((r) => r._composite))
+          : null
         // Threshold + chatter quota applied here, so a high-similarity echo can
         // inform but never flood (the quota bounds count; the penalty bounds rank).
         const explained = explainSelection(
@@ -426,6 +451,12 @@ export function buildAutoContextHandler(
         }
 
         injectedIds = selected.map((r) => r.resourceId)
+        selectedTelemetry = selected.map((r) => ({
+          resourceId: r.resourceId,
+          kind: r._kind,
+          writer: r.metaWriter,
+          injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
+        }))
         formatted = formatSelected(selected, cfg.relevanceThreshold)
         if (formatted) {
           log.diag(
@@ -434,35 +465,65 @@ export function buildAutoContextHandler(
         }
       } else {
         formatted = formatHighlightBullets(results, cfg.maxResults, cfg.relevanceThreshold)
-        if (formatted) log.debug(`auto-context: injecting ${results.length} memories`)
+        if (formatted) {
+          injectedIds = results
+            .slice(0, cfg.maxResults)
+            .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
+            .map((r) => r.resourceId)
+          selectedTelemetry = results
+            .slice(0, cfg.maxResults)
+            .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
+            .map((r) => ({
+              resourceId: r.resourceId,
+              kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
+              writer: r.metaWriter,
+              injectedChars:
+                formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
+            }))
+          log.debug(`auto-context: injecting ${results.length} memories`)
+        }
       }
 
-      // No memory cleared the bar → no injection. The standing "search before you
-      // conclude" rule lives in the agent's own instructions, not an ambient
-      // every-turn banner (which reads as framing and trains search-as-ritual).
+      const recallSignal = formatRecallSignal(
+        results.length,
+        gatedTopScore,
+        cfg.relevanceThreshold,
+        formatted ? (injectedIds?.length ?? 0) : 0,
+      )
+
+      // No memory cleared the bar: inject only the retrieval shape. This is an
+      // observation, not a standing search imperative; the agent decides whether
+      // a near miss warrants deliberate retrieval.
       if (!formatted) {
         log.debug("auto-context: no relevant memories found")
-        // Coverage signal (proposal 15): search SUCCEEDED but injected nothing —
-        // durably distinguish "never captured" (empty) from "captured but ranked
-        // out" (below_threshold). Thrown searches never reach here (the catch
-        // below owns them), so availability blips can't pollute the log.
+        // Search succeeded but injected nothing: distinguish an empty pool, a
+        // genuine composite-score miss, and a non-score selection cut. Thrown
+        // searches never reach here, so availability cannot pollute telemetry.
         if (cfg.coverageLog) {
           recordCoverageEvent(
             {
-              outcome: results.length > 0 ? "below_threshold" : "empty",
+              outcome:
+                results.length === 0
+                  ? "empty"
+                  : (gatedTopScore ?? 0) < cfg.relevanceThreshold
+                    ? "below_threshold"
+                    : "filtered",
               prompt,
               fetched: rawResults.length,
               candidates: results.length,
               droppedCurrentSession: rawResults.length - results.length,
-              topScore: topScoreOf(results),
+              topScore: gatedTopScore,
+              rawTopScore: topScoreOf(results),
               threshold: cfg.relevanceThreshold,
               ranking: ranking.enabled,
+              shown: 0,
+              shownChars: 0,
               sessionId: currentSessionId,
             },
             opts?.stateRoot,
           )
         }
-        return
+        return { prependContext: wrapRecallOnly(recallSignal) }
       }
       // Remember what landed so later turns spend their budget on NEW memory.
       // Ranked path records the exact selected ids; the legacy unranked path
@@ -476,7 +537,27 @@ export function buildAutoContextHandler(
               .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
               .map((r) => r.resourceId),
       )
-      return { prependContext: wrapContext(formatted) }
+      if (cfg.coverageLog) {
+        recordCoverageEvent(
+          {
+            outcome: "injected",
+            prompt,
+            fetched: rawResults.length,
+            candidates: results.length,
+            droppedCurrentSession: rawResults.length - results.length,
+            topScore: gatedTopScore,
+            rawTopScore: topScoreOf(results),
+            threshold: cfg.relevanceThreshold,
+            ranking: ranking.enabled,
+            sessionId: currentSessionId,
+            shown: selectedTelemetry.length,
+            shownChars: formatted.length,
+            selected: selectedTelemetry,
+          },
+          opts?.stateRoot,
+        )
+      }
+      return { prependContext: wrapContext(formatted, recallSignal) }
     } catch (err) {
       // A transient backend throttle (429 / Retry-After) must not be swallowed
       // as a generic failure — log it at warn, distinguished from real errors,
@@ -607,6 +688,14 @@ async function multiUserSearch(
 
   const sections: string[] = []
   const laneInjectedIds: string[] = []
+  const selectedTelemetry: Array<{
+    resourceId: string
+    kind?: string
+    writer?: string | null
+    injectedChars?: number
+  }> = []
+  let personalGatedTop = topScoreOf(personalResults)
+  let sharedGatedTop = topScoreOf(sharedResults)
 
   // One selection policy per lane, sharing the single-user machinery. Lanes
   // keep their own budgets and their own wrappers (scoping semantics), but a
@@ -627,16 +716,28 @@ async function multiUserSearch(
         cfg.relevanceThreshold,
       )
       if (formatted) {
-        laneInjectedIds.push(
-          ...laneResults
-            .slice(0, laneLimit)
-            .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-            .map((r) => r.resourceId),
+        const selected = laneResults
+          .slice(0, laneLimit)
+          .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
+        laneInjectedIds.push(...selected.map((r) => r.resourceId))
+        selectedTelemetry.push(
+          ...selected.map((r) => ({
+            resourceId: r.resourceId,
+            kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
+            writer: r.metaWriter,
+            injectedChars:
+              formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
+          })),
         )
       }
       return formatted
     }
     const ranked = rerank(laneResults, ranking)
+    const gatedTop = ranked.length
+      ? Math.max(...ranked.map((r) => r._composite))
+      : null
+    if (scope === "personal") personalGatedTop = gatedTop
+    else sharedGatedTop = gatedTop
     const explained = explainSelection(
       ranked,
       laneLimit,
@@ -652,7 +753,17 @@ async function multiUserSearch(
       `auto-context[${scope}]: ranked ${JSON.stringify(kindTally(ranked))} → selected ${JSON.stringify(kindTally(selected))} (chatter cap ${ranking.chatterQuota})`,
     )
     const formatted = formatSelected(selected, cfg.relevanceThreshold)
-    if (formatted) laneInjectedIds.push(...selected.map((r) => r.resourceId))
+    if (formatted) {
+      laneInjectedIds.push(...selected.map((r) => r.resourceId))
+      selectedTelemetry.push(
+        ...selected.map((r) => ({
+          resourceId: r.resourceId,
+          kind: r._kind,
+          writer: r.metaWriter,
+          injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
+        })),
+      )
+    }
     return formatted
   }
 
@@ -689,6 +800,20 @@ async function multiUserSearch(
   const haveMemorySections = sections.some(
     (s) => s.startsWith("<personal-context>") || s.startsWith("<shared-context>"),
   )
+  const candidates = personalResults.length + sharedResults.length
+  const anyLaneSucceeded = personalOk || sharedOk
+  const gatedScores = [personalGatedTop, sharedGatedTop].filter(
+    (score): score is number => score !== null,
+  )
+  const gatedTopScore = gatedScores.length ? Math.max(...gatedScores) : null
+  const recallSignal = anyLaneSucceeded
+    ? formatRecallSignal(
+        candidates,
+        gatedTopScore,
+        cfg.relevanceThreshold,
+        haveMemorySections ? laneInjectedIds.length : 0,
+      )
+    : undefined
 
   if (!haveMemorySections) {
     log.debug("auto-context: no relevant memories found")
@@ -706,7 +831,8 @@ async function multiUserSearch(
                 lane: "personal",
                 status: "ok",
                 candidates: personalResults.length,
-                topScore: topScoreOf(personalResults),
+                topScore: personalGatedTop,
+                rawTopScore: topScoreOf(personalResults),
               }
             : { lane: "personal", status: "error" },
         )
@@ -717,23 +843,31 @@ async function multiUserSearch(
                 lane: "shared",
                 status: "ok",
                 candidates: sharedResults.length,
-                topScore: topScoreOf(sharedResults),
+                topScore: sharedGatedTop,
+                rawTopScore: topScoreOf(sharedResults),
               }
             : { lane: "shared", status: "error" },
         )
       if (lanes.some((l) => l.status === "ok")) {
-        const candidates = personalResults.length + sharedResults.length
         const fetched = rawPersonalCount + rawSharedCount
         recordCoverageEvent(
           {
-            outcome: candidates > 0 ? "below_threshold" : "empty",
+            outcome:
+              candidates === 0
+                ? "empty"
+                : (gatedTopScore ?? 0) < cfg.relevanceThreshold
+                  ? "below_threshold"
+                  : "filtered",
             prompt,
             fetched,
             candidates,
             droppedCurrentSession: fetched - candidates,
-            topScore: topScoreOf([...personalResults, ...sharedResults]),
+            topScore: gatedTopScore,
+            rawTopScore: topScoreOf([...personalResults, ...sharedResults]),
             threshold: cfg.relevanceThreshold,
             ranking: cfg.ranking.enabled,
+            shown: 0,
+            shownChars: 0,
             sessionId: currentSessionId,
             userId: resolved?.userId,
             lanes,
@@ -745,10 +879,10 @@ async function multiUserSearch(
     if (isKnownSender && resolved) {
       const contextLine = resolved.context ? ` ${resolved.context}` : ""
       return {
-        prependContext: `<hyperspell-context>\nYou are speaking with ${resolved.name}.${contextLine}\n\n${AUTHORITY_GUARD}\n</hyperspell-context>`,
+        prependContext: `<hyperspell-context>\nYou are speaking with ${resolved.name}.${contextLine}${recallSignal ? `\n\n${recallSignal}` : ""}\n\n${AUTHORITY_GUARD}\n</hyperspell-context>`,
       }
     }
-    return
+    return recallSignal ? { prependContext: wrapRecallOnly(recallSignal) } : undefined
   }
 
   const totalCount = personalResults.length + sharedResults.length
@@ -760,7 +894,56 @@ async function multiUserSearch(
   // remembered per session so later turns spend the budget on NEW memory.
   recordInjected(currentSessionId, laneInjectedIds)
 
+  if (cfg.coverageLog) {
+    const lanes: CoverageLane[] = []
+    if (personalSearch)
+      lanes.push(
+        personalOk
+          ? {
+              lane: "personal",
+              status: "ok",
+              candidates: personalResults.length,
+              topScore: personalGatedTop,
+              rawTopScore: topScoreOf(personalResults),
+            }
+          : { lane: "personal", status: "error" },
+      )
+    if (sharedSearch)
+      lanes.push(
+        sharedOk
+          ? {
+              lane: "shared",
+              status: "ok",
+              candidates: sharedResults.length,
+              topScore: sharedGatedTop,
+              rawTopScore: topScoreOf(sharedResults),
+            }
+          : { lane: "shared", status: "error" },
+      )
+    recordCoverageEvent(
+      {
+        outcome: "injected",
+        prompt,
+        fetched: rawPersonalCount + rawSharedCount,
+        candidates,
+        droppedCurrentSession:
+          rawPersonalCount + rawSharedCount - candidates,
+        topScore: gatedTopScore,
+        rawTopScore: topScoreOf([...personalResults, ...sharedResults]),
+        threshold: cfg.relevanceThreshold,
+        ranking: cfg.ranking.enabled,
+        shown: selectedTelemetry.length,
+        shownChars: sections.join("\n\n").length,
+        selected: selectedTelemetry,
+        sessionId: currentSessionId,
+        userId: resolved?.userId,
+        lanes,
+      },
+      stateRoot,
+    )
+  }
+
   return {
-    prependContext: `<hyperspell-context>\n${sections.join("\n\n")}\n\n${AUTHORITY_GUARD}\n\n${DISCLAIMER}\n</hyperspell-context>`,
+    prependContext: `<hyperspell-context>\n${sections.join("\n\n")}\n\n${recallSignal}\n\n${AUTHORITY_GUARD}\n\n${DISCLAIMER}\n</hyperspell-context>`,
   }
 }

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -248,8 +248,12 @@ export function dropCurrentSession(
   return kept
 }
 
-/** Highest raw relevance among candidates — `topScore 0.54` vs `threshold 0.6`
- * is a ranking near-miss; `0.12` means the vault has nothing close (capture). */
+/** Highest RAW (pre-adjustment server) relevance across the POST-DROP
+ * candidate pool — the `rawTopScore` telemetry source. When ranking is on this
+ * is NOT comparable with `relevanceThreshold`: the gate runs on the client
+ * composite (see `gatedTopScore`), and comparing raw against the threshold is
+ * the exact miscalibration #133 removed. With ranking off, raw IS what the
+ * gate compares, so it doubles as the gated value. */
 function topScoreOf(results: SearchResult[]): number | null {
   return results.length ? Math.max(...results.map((r) => r.score ?? 0)) : null
 }
@@ -451,45 +455,54 @@ export function buildAutoContextHandler(
           )
         }
 
-        // Only what formatting actually injects: selection can admit a result
-        // on base score whose highlights then all fall under the floor —
-        // formatSelected renders no section for it, so it must not count as
-        // shown, be repeat-suppressed, or appear in hit telemetry (#133 review).
-        selectedTelemetry = selected
-          .map((r) => ({
-            resourceId: r.resourceId,
-            kind: r._kind,
-            writer: r.metaWriter,
-            injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
-          }))
-          .filter((t) => t.injectedChars > 0)
+        // ONE render per selected result, reused for both the injected block
+        // and telemetry (#133 review, findings 1+2): selection can admit a
+        // result on base score whose highlights then all fall under the floor
+        // — it renders no section, so it must not count as shown, be
+        // repeat-suppressed, or appear in hit telemetry. Deriving the block
+        // from the same sections makes the accounting exact by construction:
+        // sum(selected[].injectedChars) = shownChars − 2·(shown−1), the join
+        // separators — and costs no formatting work when telemetry is off
+        // (the batch call this replaces did the same per-result renders).
+        const rendered = selected.flatMap((r) => {
+          const section = formatSelected([r], cfg.relevanceThreshold)
+          return section ? [{ r, section }] : []
+        })
+        selectedTelemetry = rendered.map(({ r, section }) => ({
+          resourceId: r.resourceId,
+          kind: r._kind,
+          writer: r.metaWriter,
+          injectedChars: section.length,
+        }))
         injectedIds = selectedTelemetry.map((t) => t.resourceId)
-        formatted = formatSelected(selected, cfg.relevanceThreshold)
+        formatted = rendered.length
+          ? rendered.map((x) => x.section).join("\n\n")
+          : null
         if (formatted) {
           log.diag(
             `auto-context: injecting (ranked) ${JSON.stringify(kindTally(selected))} from ${results.length} candidates (chatter cap ${ranking.chatterQuota}, composite ${selected.at(-1)?._composite.toFixed(2)}–${selected[0]?._composite.toFixed(2)})`,
           )
         }
       } else {
-        formatted = formatHighlightBullets(results, cfg.maxResults, cfg.relevanceThreshold)
-        if (formatted) {
-          // Same only-what-landed rule as the ranked path: a doc that clears
-          // the score gate but has no above-threshold highlight renders no
-          // section and stays out of ids/telemetry (#133 review).
-          selectedTelemetry = results
-            .slice(0, cfg.maxResults)
-            .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-            .map((r) => ({
-              resourceId: r.resourceId,
-              kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
-              writer: r.metaWriter,
-              injectedChars:
-                formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
-            }))
-            .filter((t) => t.injectedChars > 0)
-          injectedIds = selectedTelemetry.map((t) => t.resourceId)
-          log.debug(`auto-context: injecting ${results.length} memories`)
-        }
+        // Same one-render rule as the ranked path (#133 review).
+        const rendered = results
+          .slice(0, cfg.maxResults)
+          .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
+          .flatMap((r) => {
+            const section = formatHighlightBullets([r], 1, cfg.relevanceThreshold)
+            return section ? [{ r, section }] : []
+          })
+        selectedTelemetry = rendered.map(({ r, section }) => ({
+          resourceId: r.resourceId,
+          kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
+          writer: r.metaWriter,
+          injectedChars: section.length,
+        }))
+        injectedIds = selectedTelemetry.map((t) => t.resourceId)
+        formatted = rendered.length
+          ? rendered.map((x) => x.section).join("\n\n")
+          : null
+        if (formatted) log.debug(`auto-context: injecting ${results.length} memories`)
       }
 
       const recallSignal = formatRecallSignal(
@@ -723,28 +736,25 @@ async function multiUserSearch(
       const rawTop = topScoreOf(laneResults)
       if (scope === "personal") personalGatedTop = rawTop
       else sharedGatedTop = rawTop
-      const formatted = formatHighlightBullets(
-        laneResults,
-        laneLimit,
-        cfg.relevanceThreshold,
+      // Same one-render rule as single-user (#133 review).
+      const rendered = laneResults
+        .slice(0, laneLimit)
+        .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
+        .flatMap((r) => {
+          const section = formatHighlightBullets([r], 1, cfg.relevanceThreshold)
+          return section ? [{ r, section }] : []
+        })
+      if (rendered.length === 0) return null
+      laneInjectedIds.push(...rendered.map((x) => x.r.resourceId))
+      selectedTelemetry.push(
+        ...rendered.map(({ r, section }) => ({
+          resourceId: r.resourceId,
+          kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
+          writer: r.metaWriter,
+          injectedChars: section.length,
+        })),
       )
-      if (formatted) {
-        // Same only-what-landed rule as single-user (#133 review).
-        const laneTelemetry = laneResults
-          .slice(0, laneLimit)
-          .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-          .map((r) => ({
-            resourceId: r.resourceId,
-            kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
-            writer: r.metaWriter,
-            injectedChars:
-              formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
-          }))
-          .filter((t) => t.injectedChars > 0)
-        laneInjectedIds.push(...laneTelemetry.map((t) => t.resourceId))
-        selectedTelemetry.push(...laneTelemetry)
-      }
-      return formatted
+      return rendered.map((x) => x.section).join("\n\n")
     }
     const ranked = rerank(laneResults, ranking)
     const gatedTop = ranked.length
@@ -766,21 +776,22 @@ async function multiUserSearch(
     log.diag(
       `auto-context[${scope}]: ranked ${JSON.stringify(kindTally(ranked))} → selected ${JSON.stringify(kindTally(selected))} (chatter cap ${ranking.chatterQuota})`,
     )
-    const formatted = formatSelected(selected, cfg.relevanceThreshold)
-    if (formatted) {
-      // Same only-what-landed rule as single-user (#133 review).
-      const laneTelemetry = selected
-        .map((r) => ({
-          resourceId: r.resourceId,
-          kind: r._kind,
-          writer: r.metaWriter,
-          injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
-        }))
-        .filter((t) => t.injectedChars > 0)
-      laneInjectedIds.push(...laneTelemetry.map((t) => t.resourceId))
-      selectedTelemetry.push(...laneTelemetry)
-    }
-    return formatted
+    // Same one-render rule as single-user (#133 review).
+    const rendered = selected.flatMap((r) => {
+      const section = formatSelected([r], cfg.relevanceThreshold)
+      return section ? [{ r, section }] : []
+    })
+    if (rendered.length === 0) return null
+    laneInjectedIds.push(...rendered.map((x) => x.r.resourceId))
+    selectedTelemetry.push(
+      ...rendered.map(({ r, section }) => ({
+        resourceId: r.resourceId,
+        kind: r._kind,
+        writer: r.metaWriter,
+        injectedChars: section.length,
+      })),
+    )
+    return rendered.map((x) => x.section).join("\n\n")
   }
 
   // User identity preamble

--- a/hooks/auto-context.ts
+++ b/hooks/auto-context.ts
@@ -213,8 +213,9 @@ function formatRecallSignal(
   return `recall: ${candidates} candidates · best ${best} · threshold ${threshold.toFixed(2)} · ${display}`
 }
 
-function wrapContext(memorySection: string, recallSignal: string): string {
-  return `<hyperspell-context>\n${INTRO}\n\n${recallSignal}\n\n${AUTHORITY_GUARD}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_REMINDER}\n</hyperspell-context>`
+function wrapContext(memorySection: string, recallSignal?: string): string {
+  const recallBlock = recallSignal ? `${recallSignal}\n\n` : ""
+  return `<hyperspell-context>\n${INTRO}\n\n${recallBlock}${AUTHORITY_GUARD}\n\n${memorySection}\n\n${DISCLAIMER}\n\n${SEARCH_REMINDER}\n</hyperspell-context>`
 }
 
 function wrapRecallOnly(recallSignal: string): string {
@@ -450,13 +451,19 @@ export function buildAutoContextHandler(
           )
         }
 
-        injectedIds = selected.map((r) => r.resourceId)
-        selectedTelemetry = selected.map((r) => ({
-          resourceId: r.resourceId,
-          kind: r._kind,
-          writer: r.metaWriter,
-          injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
-        }))
+        // Only what formatting actually injects: selection can admit a result
+        // on base score whose highlights then all fall under the floor —
+        // formatSelected renders no section for it, so it must not count as
+        // shown, be repeat-suppressed, or appear in hit telemetry (#133 review).
+        selectedTelemetry = selected
+          .map((r) => ({
+            resourceId: r.resourceId,
+            kind: r._kind,
+            writer: r.metaWriter,
+            injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
+          }))
+          .filter((t) => t.injectedChars > 0)
+        injectedIds = selectedTelemetry.map((t) => t.resourceId)
         formatted = formatSelected(selected, cfg.relevanceThreshold)
         if (formatted) {
           log.diag(
@@ -466,10 +473,9 @@ export function buildAutoContextHandler(
       } else {
         formatted = formatHighlightBullets(results, cfg.maxResults, cfg.relevanceThreshold)
         if (formatted) {
-          injectedIds = results
-            .slice(0, cfg.maxResults)
-            .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-            .map((r) => r.resourceId)
+          // Same only-what-landed rule as the ranked path: a doc that clears
+          // the score gate but has no above-threshold highlight renders no
+          // section and stays out of ids/telemetry (#133 review).
           selectedTelemetry = results
             .slice(0, cfg.maxResults)
             .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
@@ -480,6 +486,8 @@ export function buildAutoContextHandler(
               injectedChars:
                 formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
             }))
+            .filter((t) => t.injectedChars > 0)
+          injectedIds = selectedTelemetry.map((t) => t.resourceId)
           log.debug(`auto-context: injecting ${results.length} memories`)
         }
       }
@@ -523,20 +531,13 @@ export function buildAutoContextHandler(
             opts?.stateRoot,
           )
         }
-        return { prependContext: wrapRecallOnly(recallSignal) }
+        return cfg.recallSignal
+          ? { prependContext: wrapRecallOnly(recallSignal) }
+          : undefined
       }
       // Remember what landed so later turns spend their budget on NEW memory.
-      // Ranked path records the exact selected ids; the legacy unranked path
-      // approximates with the formatted window (first maxResults above bar).
-      recordInjected(
-        currentSessionId,
-        (injectedIds ?? []).length > 0
-          ? (injectedIds as string[])
-          : results
-              .slice(0, cfg.maxResults)
-              .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-              .map((r) => r.resourceId),
-      )
+      // Both paths now record exactly the ids whose sections rendered.
+      recordInjected(currentSessionId, injectedIds ?? [])
       if (cfg.coverageLog) {
         recordCoverageEvent(
           {
@@ -557,7 +558,12 @@ export function buildAutoContextHandler(
           opts?.stateRoot,
         )
       }
-      return { prependContext: wrapContext(formatted, recallSignal) }
+      return {
+        prependContext: wrapContext(
+          formatted,
+          cfg.recallSignal ? recallSignal : undefined,
+        ),
+      }
     } catch (err) {
       // A transient backend throttle (429 / Retry-After) must not be swallowed
       // as a generic failure — log it at warn, distinguished from real errors,
@@ -710,25 +716,33 @@ async function multiUserSearch(
     scope: "personal" | "shared",
   ): string | null => {
     if (!ranking.enabled) {
+      // With ranking off the gate runs on raw relevance, so the lane's gated
+      // top IS the raw top — mirror the single-user fallback or the recall
+      // line reads "best none" despite candidates and misses get mislabeled
+      // below_threshold when they were filtered.
+      const rawTop = topScoreOf(laneResults)
+      if (scope === "personal") personalGatedTop = rawTop
+      else sharedGatedTop = rawTop
       const formatted = formatHighlightBullets(
         laneResults,
         laneLimit,
         cfg.relevanceThreshold,
       )
       if (formatted) {
-        const selected = laneResults
+        // Same only-what-landed rule as single-user (#133 review).
+        const laneTelemetry = laneResults
           .slice(0, laneLimit)
           .filter((r) => (r.score ?? 0) >= cfg.relevanceThreshold)
-        laneInjectedIds.push(...selected.map((r) => r.resourceId))
-        selectedTelemetry.push(
-          ...selected.map((r) => ({
+          .map((r) => ({
             resourceId: r.resourceId,
             kind: classifyResult(r, ranking.storyTerms, ranking.processPaths),
             writer: r.metaWriter,
             injectedChars:
               formatHighlightBullets([r], 1, cfg.relevanceThreshold)?.length ?? 0,
-          })),
-        )
+          }))
+          .filter((t) => t.injectedChars > 0)
+        laneInjectedIds.push(...laneTelemetry.map((t) => t.resourceId))
+        selectedTelemetry.push(...laneTelemetry)
       }
       return formatted
     }
@@ -754,15 +768,17 @@ async function multiUserSearch(
     )
     const formatted = formatSelected(selected, cfg.relevanceThreshold)
     if (formatted) {
-      laneInjectedIds.push(...selected.map((r) => r.resourceId))
-      selectedTelemetry.push(
-        ...selected.map((r) => ({
+      // Same only-what-landed rule as single-user (#133 review).
+      const laneTelemetry = selected
+        .map((r) => ({
           resourceId: r.resourceId,
           kind: r._kind,
           writer: r.metaWriter,
           injectedChars: formatSelected([r], cfg.relevanceThreshold)?.length ?? 0,
-        })),
-      )
+        }))
+        .filter((t) => t.injectedChars > 0)
+      laneInjectedIds.push(...laneTelemetry.map((t) => t.resourceId))
+      selectedTelemetry.push(...laneTelemetry)
     }
     return formatted
   }
@@ -806,14 +822,15 @@ async function multiUserSearch(
     (score): score is number => score !== null,
   )
   const gatedTopScore = gatedScores.length ? Math.max(...gatedScores) : null
-  const recallSignal = anyLaneSucceeded
-    ? formatRecallSignal(
-        candidates,
-        gatedTopScore,
-        cfg.relevanceThreshold,
-        haveMemorySections ? laneInjectedIds.length : 0,
-      )
-    : undefined
+  const recallSignal =
+    cfg.recallSignal && anyLaneSucceeded
+      ? formatRecallSignal(
+          candidates,
+          gatedTopScore,
+          cfg.relevanceThreshold,
+          haveMemorySections ? laneInjectedIds.length : 0,
+        )
+      : undefined
 
   if (!haveMemorySections) {
     log.debug("auto-context: no relevant memories found")
@@ -944,6 +961,6 @@ async function multiUserSearch(
   }
 
   return {
-    prependContext: `<hyperspell-context>\n${sections.join("\n\n")}\n\n${recallSignal}\n\n${AUTHORITY_GUARD}\n\n${DISCLAIMER}\n</hyperspell-context>`,
+    prependContext: `<hyperspell-context>\n${sections.join("\n\n")}${recallSignal ? `\n\n${recallSignal}` : ""}\n\n${AUTHORITY_GUARD}\n\n${DISCLAIMER}\n</hyperspell-context>`,
   }
 }

--- a/hooks/startup-orientation.test.ts
+++ b/hooks/startup-orientation.test.ts
@@ -58,6 +58,7 @@ function makeCfg(overrides?: Partial<HyperspellConfig>): HyperspellConfig {
 	return {
 		apiKey: "k",
 		autoContext: false,
+		recallSignal: false,
 		// Recent-interactions are agent_end traces, fetched only when auto-trace
 		// is on — so the recent-path tests below run with it enabled.
 		autoTrace: { enabled: true, extract: ["procedure"] },

--- a/index.ts
+++ b/index.ts
@@ -408,6 +408,10 @@ export default {
 			costLines.push(
 				`knowledgeGraph: entity-extraction scan every ${cfg.knowledgeGraph.scanIntervalMinutes} min`,
 			);
+		if (cfg.recallSignal)
+			costLines.push(
+				"recallSignal: 1-line retrieval-shape injection EVERY turn (no extra backend call)",
+			);
 		if (costLines.length > 0)
 			log.info(
 				`enabled features and what they spend:\n  - ${costLines.join("\n  - ")}`,

--- a/lib/coverage-log.test.ts
+++ b/lib/coverage-log.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test"
 import {
   COVERAGE_LOG_NAME,
   type CoverageEvent,
+  flushCoverageLog,
   recordCoverageEvent,
 } from "./coverage-log.ts"
 
@@ -31,13 +32,14 @@ function event(over?: Partial<CoverageEvent>): CoverageEvent {
   }
 }
 
-test("coverage-log — appends one schema-stamped JSONL line per event", () => {
+test("coverage-log — appends one schema-stamped JSONL line per event", async () => {
   const stateRoot = mkStateRoot()
   recordCoverageEvent(event(), stateRoot)
   recordCoverageEvent(
     event({ outcome: "below_threshold", candidates: 4, topScore: 0.54 }),
     stateRoot,
   )
+  await flushCoverageLog()
 
   const lines = fs
     .readFileSync(path.join(stateRoot, COVERAGE_LOG_NAME), "utf-8")
@@ -54,10 +56,11 @@ test("coverage-log — appends one schema-stamped JSONL line per event", () => {
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
-test("coverage-log — prompt truncated to 500 chars", () => {
+test("coverage-log — prompt truncated to 500 chars", async () => {
   const stateRoot = mkStateRoot()
   const long = "x".repeat(600)
   recordCoverageEvent(event({ prompt: long }), stateRoot)
+  await flushCoverageLog()
 
   const entry = JSON.parse(
     fs.readFileSync(path.join(stateRoot, COVERAGE_LOG_NAME), "utf-8").trim(),
@@ -67,13 +70,14 @@ test("coverage-log — prompt truncated to 500 chars", () => {
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
-test("coverage-log — oversized file rotates to .old and the live file starts fresh", () => {
+test("coverage-log — oversized file rotates to .old and the live file starts fresh", async () => {
   const stateRoot = mkStateRoot()
   const p = path.join(stateRoot, COVERAGE_LOG_NAME)
   // Pre-seed just over the 5 MB cap so the next append rotates first.
   fs.writeFileSync(p, "x".repeat(5 * 1024 * 1024 + 1))
 
   recordCoverageEvent(event(), stateRoot)
+  await flushCoverageLog()
 
   assert.ok(fs.existsSync(`${p}.old`), "previous generation kept as .old")
   const lines = fs.readFileSync(p, "utf-8").trim().split("\n")
@@ -82,11 +86,13 @@ test("coverage-log — oversized file rotates to .old and the live file starts f
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })
 
-test("coverage-log — a failed append is swallowed, never thrown", () => {
+test("coverage-log — a failed append is swallowed, never thrown", async () => {
   const stateRoot = mkStateRoot()
   // A regular FILE as stateRoot makes path.join produce an unwritable path.
   const notADir = path.join(stateRoot, "not-a-dir")
   fs.writeFileSync(notADir, "plain file")
   assert.doesNotThrow(() => recordCoverageEvent(event(), notADir))
+  // The queued write fails inside the chain; flush must resolve, not reject.
+  await flushCoverageLog()
   fs.rmSync(stateRoot, { recursive: true, force: true })
 })

--- a/lib/coverage-log.test.ts
+++ b/lib/coverage-log.test.ts
@@ -21,8 +21,11 @@ function event(over?: Partial<CoverageEvent>): CoverageEvent {
     candidates: 0,
     droppedCurrentSession: 0,
     topScore: null,
+    rawTopScore: null,
     threshold: 0.6,
     ranking: true,
+    shown: 0,
+    shownChars: 0,
     sessionId: "sess-8f2c",
     ...over,
   }
@@ -42,7 +45,7 @@ test("coverage-log — appends one schema-stamped JSONL line per event", () => {
     .split("\n")
   assert.equal(lines.length, 2)
   const [first, second] = lines.map((l) => JSON.parse(l))
-  assert.equal(first.v, 1)
+  assert.equal(first.v, 2)
   assert.ok(!Number.isNaN(Date.parse(first.ts)))
   assert.equal(first.outcome, "empty")
   assert.equal(first.topScore, null)

--- a/lib/coverage-log.ts
+++ b/lib/coverage-log.ts
@@ -15,17 +15,27 @@ export interface CoverageLane {
   status: "ok" | "error"
   candidates?: number
   topScore?: number | null
+  rawTopScore?: number | null
 }
 
 export interface CoverageEvent {
-  outcome: "empty" | "below_threshold"
+  outcome: "empty" | "below_threshold" | "filtered" | "injected"
   prompt: string
   fetched: number
   candidates: number
   droppedCurrentSession: number
   topScore: number | null
+  rawTopScore: number | null
   threshold: number
   ranking: boolean
+  shown: number
+  shownChars: number
+  selected?: Array<{
+    resourceId: string
+    kind?: string
+    writer?: string | null
+    injectedChars?: number
+  }>
   sessionId?: string
   userId?: string
   lanes?: CoverageLane[]
@@ -46,7 +56,7 @@ export function recordCoverageEvent(event: CoverageEvent, stateRoot?: string): v
     const p = path.join(dir, COVERAGE_LOG_NAME)
     rotateIfOversized(p)
     const line = JSON.stringify({
-      v: 1,
+      v: 2,
       ts: new Date().toISOString(),
       ...event,
       prompt: event.prompt.slice(0, MAX_PROMPT_CHARS),

--- a/lib/coverage-log.ts
+++ b/lib/coverage-log.ts
@@ -41,6 +41,12 @@ export interface CoverageEvent {
   lanes?: CoverageLane[]
 }
 
+// Writes are serialized onto this queue so events land in call order and a
+// slow filesystem never blocks the turn (v2 fires on EVERY coverage-logged
+// turn, hits included — the sync-write shortcut stopped being cheap enough,
+// PR #133 review). The catch keeps the chain alive after a failed write.
+let pending: Promise<void> = Promise.resolve()
+
 /**
  * Append one coverage event to the LOCAL-ONLY coverage log
  * (`<workspaceDir>/.hyperspell-coverage.jsonl`). Never sent to the backend —
@@ -48,31 +54,44 @@ export interface CoverageEvent {
  * Prompt text is sensitive plaintext, so writes happen only behind the
  * explicit `coverageLog: true` opt-in (checked at call sites, default OFF).
  * Best-effort by contract: any failure is swallowed (debug-logged) — a
- * coverage write must never throw into, block, or delay the turn.
+ * coverage write must never throw into, block, or delay the turn. The event
+ * is stamped and serialized at call time (it describes THIS turn); only the
+ * filesystem work is deferred to the queue.
  */
 export function recordCoverageEvent(event: CoverageEvent, stateRoot?: string): void {
-  try {
-    const dir = stateRoot ?? getWorkspaceDir()
-    const p = path.join(dir, COVERAGE_LOG_NAME)
-    rotateIfOversized(p)
-    const line = JSON.stringify({
-      v: 2,
-      ts: new Date().toISOString(),
-      ...event,
-      prompt: event.prompt.slice(0, MAX_PROMPT_CHARS),
+  const line = JSON.stringify({
+    v: 2,
+    ts: new Date().toISOString(),
+    ...event,
+    prompt: event.prompt.slice(0, MAX_PROMPT_CHARS),
+  })
+  pending = pending
+    .then(() => appendLine(line, stateRoot))
+    .catch((err) => {
+      log.debug(`coverage-log: append failed — ${String(err)}`)
     })
-    fs.appendFileSync(p, `${line}\n`)
-  } catch (err) {
-    log.debug(`coverage-log: append failed — ${String(err)}`)
-  }
+}
+
+/** Await every coverage write queued so far — tests and shutdown paths.
+ * Never rejects: write failures are already swallowed inside the queue. */
+export function flushCoverageLog(): Promise<void> {
+  return pending
+}
+
+async function appendLine(line: string, stateRoot?: string): Promise<void> {
+  const dir = stateRoot ?? getWorkspaceDir()
+  const p = path.join(dir, COVERAGE_LOG_NAME)
+  await rotateIfOversized(p)
+  await fs.promises.appendFile(p, `${line}\n`)
 }
 
 /** One-generation rotation: current file > cap → rename to .old (replacing the
  * previous .old), start fresh. Total footprint bounded at ~2× MAX_LOG_BYTES. */
-function rotateIfOversized(p: string): void {
+async function rotateIfOversized(p: string): Promise<void> {
   try {
-    if (fs.statSync(p).size > MAX_LOG_BYTES) fs.renameSync(p, `${p}.old`)
+    const st = await fs.promises.stat(p)
+    if (st.size > MAX_LOG_BYTES) await fs.promises.rename(p, `${p}.old`)
   } catch {
-    /* missing file or rename race — appendFileSync creates/handles it */
+    /* missing file or rename race — appendFile creates/handles it */
   }
 }

--- a/lib/sender.test.ts
+++ b/lib/sender.test.ts
@@ -15,6 +15,7 @@ function cfg(overrides: Partial<HyperspellConfig["multiUser"]> = {}): Hyperspell
   return {
     apiKey: "test",
     autoContext: false,
+    recallSignal: false,
     autoTrace: { enabled: false, extract: ["procedure"] },
     hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
     emotionalContext: false,
@@ -264,6 +265,7 @@ function singleUserCfg(userId = "alinea"): HyperspellConfig {
   return {
     apiKey: "test",
     autoContext: false,
+    recallSignal: false,
     autoTrace: { enabled: false, extract: ["procedure"] },
     hotBuffer: { enabled: false, source: "vault", writeUser: true, writeAssistant: true },
     emotionalContext: false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -91,6 +91,11 @@
 			"help": "Append a local-only JSONL event when auto-context finds no relevant memories (zero results or all below threshold), so capture gaps can be told apart from ranking misses. Events include prompt text (truncated), so this is off by default. Never sent to Hyperspell.",
 			"advanced": true
 		},
+		"recallSignal": {
+			"label": "Recall Signal",
+			"help": "Inject one line of retrieval shape (candidate count, best gated score, threshold, shown count) into context on every auto-context turn, including empty ones — a feeling-of-knowing signal so the agent can tell 'nothing stored' from 'retrieval just missed' and choose to search deliberately. Shape only; never the near-miss content. Off by default.",
+			"advanced": true
+		},
 		"debug": {
 			"label": "Debug Logging",
 			"help": "Enable verbose debug logs for API calls and responses",
@@ -344,6 +349,9 @@
 				}
 			},
 			"coverageLog": {
+				"type": "boolean"
+			},
+			"recallSignal": {
 				"type": "boolean"
 			},
 			"debug": {


### PR DESCRIPTION
Adds a retrieval-shape signal to every successful auto-context turn, including empty turns. Corrects the coverage calibration bug by separating the raw server score from the client composite actually compared with the threshold. Coverage JSONL moves to schema v2 and records injected hits, selection descriptors, author classification, and context size, while distinguishing empty, below-threshold, filtered, and injected outcomes. Backend failures remain silent rather than being reported as absence.\n\nValidation: focused coverage and auto-context tests pass (34/34); TypeScript build and type-check pass; diff check passes. The full suite's two filesystem watcher tests remain blocked locally by the pre-existing EMFILE host limit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperspell/codesmith/hyperspell-openclaw/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790372708&installation_model_id=8852&pr_number=133&repository=hyperspell%2Fhyperspell-openclaw&return_to=https%3A%2F%2Fgithub.com%2Fhyperspell%2Fhyperspell-openclaw%2Fpull%2F133&signature=3d075e0a1a97600059e3a36fac5027fee4679b1a6ad77453267b2148e09ae809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

**Update 2026-08-27 (b716884):** the recall line is now opt-in behind `recallSignal` (default **off**, declared in the plugin config schema) — shipping changes no existing install's context; coverage telemetry remains controlled by `coverageLog` alone. Both EntelligenceAI findings fixed (telemetry counts only rendered sections; coverage writes moved to a serialized async queue with `flushCoverageLog()`), plus a raw-score fallback for the unranked multi-user lane gated-top. Design record: `docs/proposals/19-metamemory-recall-signal.md`.